### PR TITLE
Auto-detect providers & improve model/auth handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Add to your `opencode.json`:
 }
 ```
 
-Then enable the providers you use:
+That's it. Providers are auto-detected based on your OpenCode configuration. Toasts appear automatically after assistant responses.
+
+**Optional:** To restrict which providers are queried, set `enabledProviders` explicitly:
 
 ```jsonc
 {
@@ -33,8 +35,6 @@ Then enable the providers you use:
   },
 }
 ```
-
-That's it. Toasts appear automatically after assistant responses.
 
 > **LLM Agents:** Ask your agent to install `https://github.com/slkiser/opencode-quota` with the providers you have enabled. See [LLM Agent Installation Instructions](#llm-agent-installation-instructions) for details.
 
@@ -171,7 +171,7 @@ All options go under `experimental.quotaToast` in `opencode.json`:
 | ------------------- | ------------ | ----------------------------------------------- |
 | `enabled`           | `true`       | Enable/disable plugin                           |
 | `enableToast`       | `true`       | Show popup toasts                               |
-| `enabledProviders`  | `[]`         | Provider IDs to query (see table above)         |
+| `enabledProviders`  | `"auto"`     | Provider IDs to query, or `"auto"` to detect    |
 | `minIntervalMs`     | `300000`     | Minimum ms between API fetches (default: 5 min) |
 | `toastDurationMs`   | `9000`       | How long toasts display (ms)                    |
 | `onlyCurrentModel`  | `false`      | Only show quota for the current model           |
@@ -212,9 +212,9 @@ Add the plugin to the user's `opencode.json`:
 
 If the user already has plugins, append to the existing array.
 
-#### Step 3: Configure Providers
+#### Step 3: Configure Providers (Optional)
 
-Based on the user's connected providers, add the appropriate `enabledProviders`:
+By default, providers are auto-detected. If the user wants to restrict which providers are queried, add explicit `enabledProviders`:
 
 ```jsonc
 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1352,9 +1352,9 @@
       "license": "ISC"
     },
     "node_modules/hono": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-      "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -77,10 +77,18 @@ function buildLegacyTokenHeaders(token: string): Record<string, string> {
 
 /**
  * Read Copilot auth data from auth.json
+ *
+ * Tries multiple key names to handle different OpenCode versions/configs.
  */
 async function readCopilotAuth(): Promise<CopilotAuthData | null> {
   const authData = await readAuthFile();
-  const copilotAuth = authData?.["github-copilot"];
+  if (!authData) return null;
+
+  // Try known key names in priority order
+  const copilotAuth =
+    authData["github-copilot"] ??
+    (authData as Record<string, CopilotAuthData | undefined>)["copilot"] ??
+    (authData as Record<string, CopilotAuthData | undefined>)["copilot-chat"];
 
   if (!copilotAuth || copilotAuth.type !== "oauth" || !copilotAuth.refresh) {
     return null;

--- a/src/lib/opencode-auth.ts
+++ b/src/lib/opencode-auth.ts
@@ -17,7 +17,9 @@ export function getAuthPath(): string {
   const dataDir =
     process.platform === "win32"
       ? process.env.LOCALAPPDATA || join(home, "AppData", "Local")
-      : join(home, ".local", "share");
+      : process.platform === "darwin"
+        ? join(home, "Library", "Application Support")
+        : join(home, ".local", "share");
   return join(dataDir, "opencode", "auth.json");
 }
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -43,9 +43,11 @@ function tokensTotal(t: {
 export async function buildQuotaStatusReport(params: {
   configSource: string;
   configPaths: string[];
-  enabledProviders: string[];
+  enabledProviders: string[] | "auto";
   onlyCurrentModel: boolean;
   currentModel?: string;
+  /** Whether a session was available for model lookup */
+  sessionModelLookup?: "ok" | "not_found" | "no_session";
   providerAvailability: Array<{
     id: string;
     enabled: boolean;
@@ -71,10 +73,17 @@ export async function buildQuotaStatusReport(params: {
     `- configSource: ${params.configSource}${params.configPaths.length ? ` (${params.configPaths.join(" | ")})` : ""}`,
   );
   lines.push(
-    `- enabledProviders: ${params.enabledProviders.length ? params.enabledProviders.join(",") : "(none)"}`,
+    `- enabledProviders: ${params.enabledProviders === "auto" ? "(auto)" : params.enabledProviders.length ? params.enabledProviders.join(",") : "(none)"}`,
   );
   lines.push(`- onlyCurrentModel: ${params.onlyCurrentModel ? "true" : "false"}`);
-  lines.push(`- currentModel: ${params.currentModel ?? "(unknown)"}`);
+  const modelDisplay = params.currentModel
+    ? params.currentModel
+    : params.sessionModelLookup === "not_found"
+      ? "(error: session.get returned no modelID)"
+      : params.sessionModelLookup === "no_session"
+        ? "(no session available)"
+        : "(unknown)";
+  lines.push(`- currentModel: ${modelDisplay}`);
   lines.push("- providers:");
   for (const p of params.providerAvailability) {
     const bits: string[] = [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,8 +34,11 @@ export interface QuotaToastConfig {
    *
    * Keep this list short and user-friendly; each provider advertises a stable id.
    * Example: ["copilot", "google-antigravity"].
+   *
+   * When set to "auto" (or left unconfigured), the plugin will auto-enable
+   * all providers whose `isAvailable()` returns true at runtime.
    */
-  enabledProviders: string[];
+  enabledProviders: string[] | "auto";
 
   googleModels: GoogleModelId[];
   showOnIdle: boolean;
@@ -72,8 +75,8 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
 
   debug: false,
 
-  // Providers are OFF by default; users opt-in via config.
-  enabledProviders: [],
+  // Providers are auto-detected by default; set to explicit list to opt-in manually.
+  enabledProviders: "auto" as const,
 
   // If Google Antigravity is enabled, default to Claude only.
   googleModels: ["CLAUDE"],

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -14,16 +14,22 @@ export const copilotProvider: QuotaProvider = {
     try {
       const resp = await ctx.client.config.providers();
       const ids = new Set((resp.data?.providers ?? []).map((p) => p.id));
-      return ids.has("github-copilot");
+      return ids.has("github-copilot") || ids.has("copilot") || ids.has("copilot-chat");
     } catch {
       return false;
     }
   },
 
   matchesCurrentModel(model: string): boolean {
-    const provider = model.split("/")[0]?.toLowerCase();
-    if (!provider) return false;
-    return provider.includes("copilot") || provider.includes("github");
+    const lower = model.toLowerCase();
+    // Check provider prefix (part before "/")
+    const provider = lower.split("/")[0];
+    if (provider && (provider.includes("copilot") || provider.includes("github"))) {
+      return true;
+    }
+    // Also match if the full model string contains "copilot" or "github-copilot"
+    // to handle models like "github-copilot/claude-sonnet-4.5"
+    return lower.includes("copilot") || lower.includes("github-copilot");
   },
 
   async fetch(_ctx: QuotaProviderContext): Promise<QuotaProviderResult> {


### PR DESCRIPTION
Enable automatic provider detection (enabledProviders = "auto") and normalize provider IDs (dedupe, canonicalize copilot). Add session-based current-model lookup and sessionModelLookup diagnostics. Improve model normalization (strip provider prefixes, hyphenate Claude versions) and add Anthropic pricing fallback candidates. Make Copilot provider detection and auth-reading more robust (accept multiple key names). Fix auth path on macOS. Improve unavailable-quota diagnostics/messages and preserve explicit empty provider lists behavior. Update types/defaults and adjust debug output to reflect auto mode.