### PR TITLE
Introduce OpenCode runtime path utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Copilot works automatically if OpenCode has Copilot configured and logged in.
 **Optional:** For more reliable quota reporting, provide a fine-grained PAT:
 
 1. Create a fine-grained PAT at GitHub with **Account permissions > Plan > Read**
-2. Create `~/.config/opencode/copilot-quota-token.json`:
+2. Create `copilot-quota-token.json` under OpenCode's runtime config directory (see `opencode debug paths`):
 
 ```json
 {
@@ -159,7 +159,9 @@ Requires the `opencode-antigravity-auth` plugin for multi-account support:
 }
 ```
 
-Account credentials are stored in `~/.config/opencode/antigravity-accounts.json`.
+Account credentials are stored under OpenCode's runtime config directory (see `opencode debug paths`).
+
+If you are troubleshooting, `/quota_status` prints the candidate paths checked for `antigravity-accounts.json`.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "zod": "4.1.8"
   },
   "dependencies": {
-    "opencode-antigravity-auth": "^1.2.8"
+    "opencode-antigravity-auth": "^1.2.8",
+    "xdg-basedir": "^5.1.0"
   },
   "overrides": {
     "zod": "4.1.8"

--- a/src/lib/api-key-resolver.ts
+++ b/src/lib/api-key-resolver.ts
@@ -7,8 +7,9 @@
 
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
-import { homedir } from "os";
 import { join } from "path";
+
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
 import { parseJsonOrJsonc } from "./jsonc.js";
 
 /** A candidate config file path with its format */
@@ -25,13 +26,18 @@ export interface ConfigCandidate {
  */
 export function getOpencodeConfigCandidatePaths(): ConfigCandidate[] {
   const cwd = process.cwd();
-  const configBaseDir = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  const { configDirs } = getOpencodeRuntimeDirCandidates();
+
+  const global: ConfigCandidate[] = [];
+  for (const dir of configDirs) {
+    global.push({ path: join(dir, "opencode.jsonc"), isJsonc: true });
+    global.push({ path: join(dir, "opencode.json"), isJsonc: false });
+  }
 
   return [
     { path: join(cwd, "opencode.jsonc"), isJsonc: true },
     { path: join(cwd, "opencode.json"), isJsonc: false },
-    { path: join(configBaseDir, "opencode", "opencode.jsonc"), isJsonc: true },
-    { path: join(configBaseDir, "opencode", "opencode.json"), isJsonc: false },
+    ...global,
   ];
 }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -11,8 +11,9 @@ import { parseJsonOrJsonc } from "./jsonc.js";
 
 import { existsSync } from "fs";
 import { readFile } from "fs/promises";
-import { homedir } from "os";
 import { join } from "path";
+
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
 
 export interface LoadConfigMeta {
   source: "sdk" | "files" | "defaults";
@@ -177,12 +178,12 @@ export async function loadConfig(
 
   async function loadFromFiles(): Promise<QuotaToastConfig> {
     const cwd = process.cwd();
-    const configBaseDir = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+    const { configDirs } = getOpencodeRuntimeDirCandidates();
 
     // Order: global first, then local overrides.
     // Within each location, load .json first, then .jsonc so that
     // .jsonc takes precedence on key collisions (matching the documented intent).
-    const locations = [join(configBaseDir, "opencode"), cwd];
+    const locations = [...configDirs, cwd];
 
     const quota: Partial<QuotaToastConfig> = {};
     const usedPaths: string[] = [];

--- a/src/lib/google-token-cache.ts
+++ b/src/lib/google-token-cache.ts
@@ -8,8 +8,9 @@
  */
 
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { homedir } from "os";
 import { dirname, join } from "path";
+
+import { getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
 import { createHash } from "crypto";
 
 export interface GoogleAccessTokenCacheEntry {
@@ -31,11 +32,9 @@ let memCache: GoogleAccessTokenCacheFile | null = null;
 let loadPromise: Promise<GoogleAccessTokenCacheFile> | null = null;
 
 function getCacheBaseDir(): string {
-  const home = homedir();
-  if (process.platform === "win32") {
-    return process.env.LOCALAPPDATA || join(home, "AppData", "Local");
-  }
-  return process.env.XDG_CACHE_HOME || join(home, ".cache");
+  // Match OpenCode runtime cache semantics (xdg-basedir).
+  // This avoids mismatches on Windows where OpenCode cache is not under LOCALAPPDATA.
+  return getOpencodeRuntimeDirs().cacheDir;
 }
 
 export function getGoogleTokenCachePath(): string {

--- a/src/lib/opencode-runtime-paths.ts
+++ b/src/lib/opencode-runtime-paths.ts
@@ -1,0 +1,124 @@
+import { homedir } from "os";
+import { join } from "path";
+import {
+  xdgCache,
+  xdgConfig,
+  xdgData,
+  xdgState,
+} from "xdg-basedir";
+
+export interface OpencodeRuntimeDirs {
+  dataDir: string;
+  configDir: string;
+  cacheDir: string;
+  stateDir: string;
+}
+
+export interface OpencodeRuntimeDirCandidates {
+  dataDirs: string[];
+  configDirs: string[];
+  cacheDirs: string[];
+  stateDirs: string[];
+}
+
+function dedupe(list: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of list) {
+    if (!item) continue;
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
+}
+
+export function getOpencodeRuntimeDirs(params?: {
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+}): OpencodeRuntimeDirs {
+  const env = params?.env ?? process.env;
+  const home = params?.homeDir ?? homedir();
+
+  // Match OpenCode behavior: Global.Path.<dir> = join(xdg<Dir>, "opencode")
+  // xdg-basedir may return undefined if env is missing; provide deterministic fallbacks.
+  const dataBase = env.XDG_DATA_HOME?.trim() || xdgData || join(home, ".local", "share");
+  const configBase = env.XDG_CONFIG_HOME?.trim() || xdgConfig || join(home, ".config");
+  const cacheBase = env.XDG_CACHE_HOME?.trim() || xdgCache || join(home, ".cache");
+  const stateBase = env.XDG_STATE_HOME?.trim() || xdgState || join(home, ".local", "state");
+
+  return {
+    dataDir: join(dataBase, "opencode"),
+    configDir: join(configBase, "opencode"),
+    cacheDir: join(cacheBase, "opencode"),
+    stateDir: join(stateBase, "opencode"),
+  };
+}
+
+export function getOpencodeRuntimeDirCandidates(params?: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  homeDir?: string;
+  primary?: OpencodeRuntimeDirs;
+}): OpencodeRuntimeDirCandidates {
+  const platform = params?.platform ?? process.platform;
+  const env = params?.env ?? process.env;
+  const home = params?.homeDir ?? homedir();
+
+  const primary = params?.primary ?? getOpencodeRuntimeDirs({ env, homeDir: home });
+
+  const winAppData = env.APPDATA?.trim();
+  const winLocalAppData = env.LOCALAPPDATA?.trim();
+
+  const windowsRoamingFallback = join(home, "AppData", "Roaming");
+  const windowsLocalFallback = join(home, "AppData", "Local");
+
+  const dataDirs: string[] = [primary.dataDir];
+  const configDirs: string[] = [primary.configDir];
+  const cacheDirs: string[] = [primary.cacheDir];
+  const stateDirs: string[] = [primary.stateDir];
+
+  if (platform === "win32") {
+    // OpenCode uses xdg-basedir; on some Windows setups that can resolve to
+    // non-AppData locations (e.g. C:\\Users\\name.local\\share). However, many
+    // users and older installs place OpenCode data/config under APPDATA/LOCALAPPDATA.
+    const appDataBase = winAppData || windowsRoamingFallback;
+    const localAppDataBase = winLocalAppData || windowsLocalFallback;
+
+    // Data and config: include both roaming and local as alternates.
+    dataDirs.push(join(appDataBase, "opencode"));
+    dataDirs.push(join(localAppDataBase, "opencode"));
+
+    configDirs.push(join(appDataBase, "opencode"));
+    configDirs.push(join(localAppDataBase, "opencode"));
+
+    // Cache/state: local is more likely.
+    cacheDirs.push(join(localAppDataBase, "opencode"));
+    stateDirs.push(join(localAppDataBase, "opencode"));
+  } else if (platform === "darwin") {
+    // Preserve compatibility with legacy Linux-style installs on macOS.
+    dataDirs.push(join(home, ".local", "share", "opencode"));
+    configDirs.push(join(home, ".config", "opencode"));
+    cacheDirs.push(join(home, ".cache", "opencode"));
+    stateDirs.push(join(home, ".local", "state", "opencode"));
+
+    // macOS canonical dirs (OpenCode xdg-basedir should already map here,
+    // but keep explicit candidates to aid diagnostics and migrations).
+    dataDirs.push(join(home, "Library", "Application Support", "opencode"));
+    configDirs.push(join(home, "Library", "Application Support", "opencode"));
+    cacheDirs.push(join(home, "Library", "Caches", "opencode"));
+  } else {
+    // Linux / other: add common legacy fallbacks.
+    dataDirs.push(join(home, ".local", "share", "opencode"));
+    configDirs.push(join(home, ".config", "opencode"));
+    cacheDirs.push(join(home, ".cache", "opencode"));
+    stateDirs.push(join(home, ".local", "state", "opencode"));
+  }
+
+  return {
+    dataDirs: dedupe(dataDirs),
+    configDirs: dedupe(configDirs),
+    cacheDirs: dedupe(cacheDirs),
+    stateDirs: dedupe(stateDirs),
+  };
+}

--- a/src/lib/path-pick.ts
+++ b/src/lib/path-pick.ts
@@ -1,0 +1,14 @@
+import { existsSync } from "fs";
+
+export function pickFirstExistingPath(candidates: string[]): string {
+  for (const p of candidates) {
+    try {
+      if (existsSync(p)) return p;
+    } catch {
+      // ignore
+    }
+  }
+
+  // Deterministic fallback for diagnostics.
+  return candidates[0] ?? "";
+}

--- a/tests/lib.copilot.test.ts
+++ b/tests/lib.copilot.test.ts
@@ -9,6 +9,21 @@ vi.mock("fs", async (importOriginal) => {
   };
 });
 
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({
+    dataDirs: ["/home/test/.local/share/opencode"],
+    configDirs: ["/home/test/.config/opencode"],
+    cacheDirs: ["/home/test/.cache/opencode"],
+    stateDirs: ["/home/test/.local/state/opencode"],
+  }),
+  getOpencodeRuntimeDirs: () => ({
+    dataDir: "/home/test/.local/share/opencode",
+    configDir: "/home/test/.config/opencode",
+    cacheDir: "/home/test/.cache/opencode",
+    stateDir: "/home/test/.local/state/opencode",
+  }),
+}));
+
 vi.mock("../src/lib/opencode-auth.js", () => ({
   readAuthFile: vi.fn(),
 }));

--- a/tests/lib.firmware-config.test.ts
+++ b/tests/lib.firmware-config.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { join } from "path";
 import { homedir } from "os";
 
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({
+    dataDirs: [join(homedir(), ".local", "share", "opencode")],
+    configDirs: [join(homedir(), ".config", "opencode")],
+    cacheDirs: [join(homedir(), ".cache", "opencode")],
+    stateDirs: [join(homedir(), ".local", "state", "opencode")],
+  }),
+  getOpencodeRuntimeDirs: () => ({
+    dataDir: join(homedir(), ".local", "share", "opencode"),
+    configDir: join(homedir(), ".config", "opencode"),
+    cacheDir: join(homedir(), ".cache", "opencode"),
+    stateDir: join(homedir(), ".local", "state", "opencode"),
+  }),
+}));
+
 // Mock fs and fs/promises before importing the module
 vi.mock("fs", () => ({
   existsSync: vi.fn(),
@@ -27,6 +42,9 @@ describe("firmware-config", () => {
     delete process.env.FIRMWARE_AI_API_KEY;
     delete process.env.FIRMWARE_API_KEY;
     delete process.env.XDG_CONFIG_HOME;
+    delete process.env.XDG_DATA_HOME;
+    delete process.env.XDG_CACHE_HOME;
+    delete process.env.XDG_STATE_HOME;
   });
 
   afterEach(() => {
@@ -289,8 +307,7 @@ describe("firmware-config", () => {
       const { existsSync } = await import("fs");
       const { readAuthFile } = await import("../src/lib/opencode-auth.js");
 
-      const configDir = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
-      const expectedPath = join(configDir, "opencode", "opencode.json");
+      const expectedPath = join(homedir(), ".config", "opencode", "opencode.json");
 
       (existsSync as any).mockImplementation((path: string) => {
         return path === expectedPath;
@@ -320,9 +337,9 @@ describe("firmware-config", () => {
       expect(paths[1].isJsonc).toBe(false);
 
       // Global paths
-      expect(paths[2].path).toContain(".config");
+      expect(paths[2].path).toContain("opencode");
       expect(paths[2].isJsonc).toBe(true);
-      expect(paths[3].path).toContain(".config");
+      expect(paths[3].path).toContain("opencode");
       expect(paths[3].isJsonc).toBe(false);
     });
   });

--- a/tests/lib.google.approach-c.test.ts
+++ b/tests/lib.google.approach-c.test.ts
@@ -16,7 +16,22 @@ vi.mock("../src/lib/google-token-cache.js", () => ({
   setCachedAccessToken: vi.fn(async () => undefined),
 }));
 
-describe("queryGoogleQuota (approach C)", () => {
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({
+    dataDirs: ["/home/test/.local/share/opencode"],
+    configDirs: ["/home/test/.config/opencode"],
+    cacheDirs: ["/home/test/.cache/opencode"],
+    stateDirs: ["/home/test/.local/state/opencode"],
+  }),
+  getOpencodeRuntimeDirs: () => ({
+    dataDir: "/home/test/.local/share/opencode",
+    configDir: "/home/test/.config/opencode",
+    cacheDir: "/home/test/.cache/opencode",
+    stateDir: "/home/test/.local/state/opencode",
+  }),
+}));
+
+describe("google approach C", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));

--- a/tests/lib.openai.test.ts
+++ b/tests/lib.openai.test.ts
@@ -3,6 +3,21 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { queryOpenAIQuota } from "../src/lib/openai.js";
 
 // Mock auth reader
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({
+    dataDirs: ["/home/test/.local/share/opencode"],
+    configDirs: ["/home/test/.config/opencode"],
+    cacheDirs: ["/home/test/.cache/opencode"],
+    stateDirs: ["/home/test/.local/state/opencode"],
+  }),
+  getOpencodeRuntimeDirs: () => ({
+    dataDir: "/home/test/.local/share/opencode",
+    configDir: "/home/test/.config/opencode",
+    cacheDir: "/home/test/.cache/opencode",
+    stateDir: "/home/test/.local/state/opencode",
+  }),
+}));
+
 vi.mock("../src/lib/opencode-auth.js", () => ({
   readAuthFile: vi.fn(),
 }));

--- a/tests/lib.opencode-runtime-paths.test.ts
+++ b/tests/lib.opencode-runtime-paths.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getOpencodeRuntimeDirCandidates, getOpencodeRuntimeDirs } from "../src/lib/opencode-runtime-paths.js";
+
+describe("opencode-runtime-paths", () => {
+  it("builds deterministic dirs from XDG env fallbacks", () => {
+    const env: NodeJS.ProcessEnv = {
+      XDG_DATA_HOME: "/x/data",
+      XDG_CONFIG_HOME: "/x/config",
+      XDG_CACHE_HOME: "/x/cache",
+      XDG_STATE_HOME: "/x/state",
+    };
+
+    const dirs = getOpencodeRuntimeDirs({ env, homeDir: "/home/test" });
+    expect(dirs).toEqual({
+      dataDir: "/x/data/opencode",
+      configDir: "/x/config/opencode",
+      cacheDir: "/x/cache/opencode",
+      stateDir: "/x/state/opencode",
+    });
+  });
+
+  it("includes Windows APPDATA/LOCALAPPDATA fallbacks after primary", () => {
+    const env: NodeJS.ProcessEnv = {
+      XDG_DATA_HOME: "C:/Users/u.local/share",
+      XDG_CONFIG_HOME: "C:/Users/u.local/config",
+      XDG_CACHE_HOME: "C:/Users/u.local/cache",
+      XDG_STATE_HOME: "C:/Users/u.local/state",
+      APPDATA: "C:/Users/u/AppData/Roaming",
+      LOCALAPPDATA: "C:/Users/u/AppData/Local",
+    };
+
+    const primary = getOpencodeRuntimeDirs({ env, homeDir: "C:/Users/u" });
+    const c = getOpencodeRuntimeDirCandidates({ platform: "win32", env, homeDir: "C:/Users/u", primary });
+
+    expect(c.dataDirs[0]).toBe(primary.dataDir);
+    expect(c.configDirs[0]).toBe(primary.configDir);
+    expect(c.cacheDirs[0]).toBe(primary.cacheDir);
+    expect(c.stateDirs[0]).toBe(primary.stateDir);
+
+    expect(c.dataDirs).toContain("C:/Users/u/AppData/Roaming/opencode");
+    expect(c.dataDirs).toContain("C:/Users/u/AppData/Local/opencode");
+
+    expect(c.configDirs).toContain("C:/Users/u/AppData/Roaming/opencode");
+    expect(c.configDirs).toContain("C:/Users/u/AppData/Local/opencode");
+  });
+});


### PR DESCRIPTION
**Added centralized OpenCode runtime path helpers and switch modules to use them.**

The changes standardize where OpenCode files are looked up (config/data/cache/state), include legacy fallbacks for Windows/macOS, and make path selection and diagnostics deterministic for testing and troubleshooting.

- New opencode-runtime-paths.ts: provides getOpencodeRuntimeDirs and getOpencodeRuntimeDirCandidates (uses xdg-basedir with deterministic fallbacks and Windows/macOS legacy candidates).
- New path-pick.ts: pickFirstExistingPath helper for selecting the first existing candidate or a deterministic fallback.
- Replace ad-hoc homedir/platform heuristics across modules (api-key-resolver, config, google-token-cache, google, opencode-auth, opencode-storage, quota-status) to consume the new runtime dirs/candidates. This unifies path resolution, improves cross-platform compatibility, and adds clearer diagnostics.
- quota-status: now prints selected runtime dirs and storage/config candidates/present paths for easier troubleshooting.
- Tests: add opencode-runtime-paths tests and update many tests to mock the new runtime-paths module and adjust expectations.
- package.json: add dependency on xdg-basedir.


