### PR TITLE
Add Qwen Code provider and local quota tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ That's it. Providers are auto-detected based on your OpenCode configuration. Toa
 {
   "experimental": {
     "quotaToast": {
-      "enabledProviders": ["copilot", "openai", "google-antigravity"]
+      "enabledProviders": ["copilot", "openai", "qwen-code", "google-antigravity"]
     }
   }
 }
@@ -65,6 +65,7 @@ That's it. Providers are auto-detected based on your OpenCode configuration. Toa
 | ------------------ | -------------------- | --------------------------------------------- |
 | GitHub Copilot     | `copilot`            | OpenCode auth (automatic)                     |
 | OpenAI (Plus/Pro)  | `openai`             | OpenCode auth (automatic)                     |
+| Qwen Code (OAuth)  | `qwen-code`          | OpenCode auth via `opencode-qwencode-auth`    |
 | Firmware AI        | `firmware`           | OpenCode auth or API key                      |
 | Chutes AI          | `chutes`             | OpenCode auth or API key                      |
 | Google Antigravity | `google-antigravity` | Multi-account via `opencode-antigravity-auth` |
@@ -100,6 +101,28 @@ Tier options: `free`, `pro`, `pro+`, `business`, `enterprise`
 <summary><strong>OpenAI</strong> (no setup needed)</summary>
 
 OpenAI works automatically if OpenCode has OpenAI/ChatGPT configured.
+
+</details>
+
+<details>
+<summary><strong>Qwen Code (OAuth)</strong></summary>
+
+Requires OAuth credentials from the `opencode-qwencode-auth` plugin.
+
+Quota output for Qwen is **local-only estimation**:
+
+- 1000 requests per UTC day (resets at UTC midnight)
+- 60 requests per rolling minute
+- Counter increments on successful question-tool completions while plugin is enabled and current model is `qwen-code/*`
+
+No remote quota endpoint is called for Qwen and Alibaba API is not used.
+
+Local state file path:
+
+- `.../opencode/opencode-quota/qwen-local-quota.json` (under OpenCode state dir)
+
+Use `/quota_status` to verify auth detection and local Qwen counter status.
+If the local Qwen state file is missing, `/quota_status` reports usage from a default empty state.
 
 </details>
 
@@ -182,7 +205,7 @@ All options go under `experimental.quotaToast` in `opencode.json` or `opencode.j
 | `enableToast`       | `true`       | Show popup toasts                                                            |
 | `toastStyle`        | `classic`    | Toast layout style: `classic` or `grouped`                                   |
 | `enabledProviders`  | `"auto"`     | Provider IDs to query, or `"auto"` to detect                                 |
-| `minIntervalMs`     | `300000`     | Minimum ms between API fetches (default: 5 min)                              |
+| `minIntervalMs`     | `300000`     | Minimum ms between provider fetches (default: 5 min); Qwen local RPM stays live on question triggers |
 | `toastDurationMs`   | `9000`       | How long toasts display (ms)                                                 |
 | `showOnIdle`        | `true`       | Show toast on idle trigger                                                   |
 | `showOnQuestion`    | `true`       | Show toast after a question/assistant response                               |
@@ -243,6 +266,7 @@ By default, providers are auto-detected. If the user wants to restrict which pro
         // Add only the providers the user has configured:
         // "copilot"            - if using GitHub Copilot
         // "openai"             - if using OpenAI/ChatGPT
+        // "qwen-code"          - if using Qwen Code OAuth (requires opencode-qwencode-auth)
         // "firmware"           - if using Firmware AI
         // "chutes"             - if using Chutes AI
         // "google-antigravity" - if using Google Antigravity (requires opencode-antigravity-auth)
@@ -258,10 +282,12 @@ By default, providers are auto-detected. If the user wants to restrict which pro
 | ------------------------------------------- | ----------------------- |
 | `github-copilot` provider or Copilot models | `"copilot"`             |
 | `openai` / `chatgpt` provider               | `"openai"`              |
+| `qwen-code` provider                        | `"qwen-code"`           |
 | `firmware` / `firmware-ai` provider         | `"firmware"`            |
 | `chutes` provider                           | `"chutes"`              |
 | `google` provider with antigravity models   | `"google-antigravity"`  |
 | `opencode-antigravity-auth` in plugins      | `"google-antigravity"`  |
+| `opencode-qwencode-auth` in plugins         | `"qwen-code"`           |
 
 #### Example: Full Configuration
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -43,6 +43,8 @@ function normalizeProviderId(id: string): string {
     case "copilot-chat":
     case "github-copilot-chat":
       return "copilot";
+    case "qwen":
+      return "qwen-code";
     default:
       return s;
   }

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -85,6 +85,8 @@ export interface QuotaProviderContext {
   config: {
     googleModels: string[];
     toastStyle?: "classic" | "grouped";
+    onlyCurrentModel?: boolean;
+    currentModel?: string;
   };
 }
 

--- a/src/lib/qwen-local-quota.ts
+++ b/src/lib/qwen-local-quota.ts
@@ -1,0 +1,216 @@
+import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import { clampPercent } from "./format-utils.js";
+import { getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
+
+const QWEN_LOCAL_QUOTA_STATE_VERSION = 1 as const;
+const QWEN_DAILY_LIMIT = 1000;
+const QWEN_RPM_LIMIT = 60;
+const RPM_WINDOW_MS = 60_000;
+const MAX_RECENT_TIMESTAMPS = 300;
+
+export interface QwenLocalQuotaStateFileV1 {
+  version: 1;
+  utcDay: string;
+  dayCount: number;
+  recent: number[];
+  updatedAt: number;
+}
+
+export interface QwenComputedQuota {
+  day: {
+    used: number;
+    limit: number;
+    percentRemaining: number;
+    resetTimeIso: string;
+  };
+  rpm: {
+    used: number;
+    limit: number;
+    percentRemaining: number;
+    resetTimeIso?: string;
+  };
+}
+
+function utcDayKey(tsMs: number): string {
+  return new Date(tsMs).toISOString().slice(0, 10);
+}
+
+function nextUtcMidnightIso(tsMs: number): string {
+  const now = new Date(tsMs);
+  const nextMidnight = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0);
+  return new Date(nextMidnight).toISOString();
+}
+
+function defaultState(nowMs: number): QwenLocalQuotaStateFileV1 {
+  return {
+    version: QWEN_LOCAL_QUOTA_STATE_VERSION,
+    utcDay: utcDayKey(nowMs),
+    dayCount: 0,
+    recent: [],
+    updatedAt: nowMs,
+  };
+}
+
+function normalizeState(raw: unknown, nowMs: number): QwenLocalQuotaStateFileV1 {
+  if (!raw || typeof raw !== "object") {
+    return defaultState(nowMs);
+  }
+
+  const obj = raw as Partial<QwenLocalQuotaStateFileV1>;
+  const recentRaw = Array.isArray(obj.recent) ? obj.recent : [];
+  const recent = recentRaw
+    .filter((x): x is number => typeof x === "number" && Number.isFinite(x) && x > 0)
+    .map((x) => Math.trunc(x));
+
+  return {
+    version: QWEN_LOCAL_QUOTA_STATE_VERSION,
+    utcDay: typeof obj.utcDay === "string" && obj.utcDay.length === 10 ? obj.utcDay : utcDayKey(nowMs),
+    dayCount:
+      typeof obj.dayCount === "number" && Number.isFinite(obj.dayCount) && obj.dayCount >= 0
+        ? Math.trunc(obj.dayCount)
+        : 0,
+    recent,
+    updatedAt:
+      typeof obj.updatedAt === "number" && Number.isFinite(obj.updatedAt) && obj.updatedAt > 0
+        ? Math.trunc(obj.updatedAt)
+        : nowMs,
+  };
+}
+
+function applyUtcResetAndPrune(state: QwenLocalQuotaStateFileV1, nowMs: number): QwenLocalQuotaStateFileV1 {
+  const today = utcDayKey(nowMs);
+  const recentFloor = nowMs - RPM_WINDOW_MS;
+  const recent = state.recent
+    .filter((ts) => ts >= recentFloor && ts <= nowMs)
+    .slice(-MAX_RECENT_TIMESTAMPS);
+
+  if (state.utcDay !== today) {
+    return {
+      version: QWEN_LOCAL_QUOTA_STATE_VERSION,
+      utcDay: today,
+      dayCount: 0,
+      recent,
+      updatedAt: nowMs,
+    };
+  }
+
+  return {
+    version: QWEN_LOCAL_QUOTA_STATE_VERSION,
+    utcDay: today,
+    dayCount: state.dayCount,
+    recent,
+    updatedAt: nowMs,
+  };
+}
+
+function toPercentRemaining(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  const remaining = ((limit - used) / limit) * 100;
+  return clampPercent(remaining);
+}
+
+async function readStateFromDisk(path: string, nowMs: number): Promise<QwenLocalQuotaStateFileV1> {
+  try {
+    const raw = await readFile(path, "utf-8");
+    return normalizeState(JSON.parse(raw), nowMs);
+  } catch {
+    return defaultState(nowMs);
+  }
+}
+
+async function writeStateToDisk(path: string, state: QwenLocalQuotaStateFileV1): Promise<void> {
+  const dir = dirname(path);
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  await mkdir(dir, { recursive: true });
+  await writeFile(tmp, JSON.stringify(state, null, 2), "utf-8");
+
+  const safeRm = async (target: string): Promise<void> => {
+    try {
+      await rm(target, { force: true });
+    } catch {
+      // best effort cleanup
+    }
+  };
+
+  try {
+    await rename(tmp, path);
+  } catch (err) {
+    const code =
+      err && typeof err === "object" && "code" in err
+        ? String((err as { code?: unknown }).code)
+        : "";
+    const shouldRetryAsReplace =
+      code === "EPERM" || code === "EEXIST" || code === "EACCES" || code === "ENOTEMPTY";
+
+    if (!shouldRetryAsReplace) {
+      await safeRm(tmp);
+      throw err;
+    }
+
+    await safeRm(path);
+    await rename(tmp, path);
+  }
+}
+
+export function getQwenLocalQuotaPath(): string {
+  const { stateDir } = getOpencodeRuntimeDirs();
+  return join(stateDir, "opencode-quota", "qwen-local-quota.json");
+}
+
+export async function readQwenLocalQuotaState(params?: { nowMs?: number }): Promise<QwenLocalQuotaStateFileV1> {
+  const nowMs = params?.nowMs ?? Date.now();
+  const path = getQwenLocalQuotaPath();
+  const state = await readStateFromDisk(path, nowMs);
+  return applyUtcResetAndPrune(state, nowMs);
+}
+
+export async function recordQwenCompletion(params?: { atMs?: number }): Promise<QwenLocalQuotaStateFileV1> {
+  const nowMs = params?.atMs ?? Date.now();
+  const path = getQwenLocalQuotaPath();
+  const loaded = await readStateFromDisk(path, nowMs);
+  const state = applyUtcResetAndPrune(loaded, nowMs);
+
+  const next: QwenLocalQuotaStateFileV1 = {
+    ...state,
+    dayCount: state.dayCount + 1,
+    recent: [...state.recent, nowMs].slice(-MAX_RECENT_TIMESTAMPS),
+    updatedAt: nowMs,
+  };
+
+  await writeStateToDisk(path, next);
+  return next;
+}
+
+export function computeQwenQuota(params: {
+  state: QwenLocalQuotaStateFileV1;
+  nowMs?: number;
+  dayLimit?: number;
+  rpmLimit?: number;
+}): QwenComputedQuota {
+  const nowMs = params.nowMs ?? Date.now();
+  const dayLimit = params.dayLimit ?? QWEN_DAILY_LIMIT;
+  const rpmLimit = params.rpmLimit ?? QWEN_RPM_LIMIT;
+  const state = applyUtcResetAndPrune(params.state, nowMs);
+
+  const dayUsed = Math.max(0, Math.trunc(state.dayCount));
+  const rpmUsed = state.recent.length;
+  const oldestRecent = state.recent.length > 0 ? Math.min(...state.recent) : undefined;
+
+  return {
+    day: {
+      used: dayUsed,
+      limit: dayLimit,
+      percentRemaining: toPercentRemaining(dayUsed, dayLimit),
+      resetTimeIso: nextUtcMidnightIso(nowMs),
+    },
+    rpm: {
+      used: rpmUsed,
+      limit: rpmLimit,
+      percentRemaining: toPercentRemaining(rpmUsed, rpmLimit),
+      resetTimeIso:
+        typeof oldestRecent === "number" ? new Date(oldestRecent + RPM_WINDOW_MS).toISOString() : undefined,
+    },
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -177,6 +177,12 @@ export interface AuthData {
     type: string;
     key?: string;
   };
+  "opencode-qwencode-auth"?: {
+    type: string;
+    access?: string;
+    refresh?: string;
+    expires?: number;
+  };
 }
 
 // =============================================================================

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,14 +14,22 @@ import { getOrFetchWithCacheControl } from "./lib/cache.js";
 import { formatQuotaRows } from "./lib/format.js";
 import { formatQuotaCommand } from "./lib/quota-command-format.js";
 import { getProviders } from "./providers/registry.js";
-import type { QuotaToastEntry, QuotaToastError } from "./lib/entries.js";
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+  QuotaToastError,
+  SessionTokensData,
+} from "./lib/entries.js";
 import { tool } from "@opencode-ai/plugin";
 import { aggregateUsage } from "./lib/quota-stats.js";
-import type { SessionTokensData } from "./lib/entries.js";
 import { fetchSessionTokensForDisplay } from "./lib/session-tokens.js";
 import { formatQuotaStatsReport } from "./lib/quota-stats-format.js";
 import { buildQuotaStatusReport, type SessionTokenError } from "./lib/quota-status.js";
 import { refreshGoogleTokensForAllAccounts } from "./lib/google.js";
+import { readAuthFileCached } from "./lib/opencode-auth.js";
+import { recordQwenCompletion } from "./lib/qwen-local-quota.js";
 import {
   parseOptionalJsonArgs,
   parseQuotaBetweenArgs,
@@ -99,9 +107,17 @@ interface PluginEvent {
 }
 
 /** Tool execute hook input */
-interface ToolExecuteInput {
+interface ToolExecuteAfterInput {
   tool: string;
   sessionID: string;
+  callID: string;
+}
+
+/** Tool execute hook output */
+interface ToolExecuteAfterOutput {
+  title: string;
+  output: string;
+  metadata: unknown;
 }
 
 /** Slash-command execute hook input (e.g. /quota_daily) */
@@ -243,6 +259,9 @@ function isTokenReportCommand(cmd: string): cmd is TokenReportCommandId {
  */
 export const QuotaToastPlugin: Plugin = async ({ client }) => {
   const typedClient = client as unknown as OpencodeClient;
+  const QWEN_AUTH_CACHE_MAX_AGE_MS = 5_000;
+  const TOOL_FAILURE_STATUSES = new Set(["error", "failed", "failure", "cancelled", "canceled"]);
+  const TOOL_SUCCESS_STATUSES = new Set(["success", "ok", "completed", "complete"]);
 
   function getProviderDisplayLabel(id: string): string {
     switch (id) {
@@ -256,6 +275,8 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
         return "Firmware";
       case "chutes":
         return "Chutes";
+      case "qwen-code":
+        return "Qwen";
       default:
         return id;
     }
@@ -298,6 +319,141 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
 
   // Track last session token error for /quota_status diagnostics
   let lastSessionTokenError: SessionTokenError | undefined;
+
+  type ProviderFetchCacheEntry = {
+    timestamp: number;
+    result?: QuotaProviderResult;
+    inFlight?: Promise<QuotaProviderResult>;
+  };
+
+  const providerFetchCache = new Map<string, ProviderFetchCacheEntry>();
+
+  function isQwenModel(model?: string): boolean {
+    return typeof model === "string" && model.toLowerCase().startsWith("qwen-code/");
+  }
+
+  async function hasQwenOAuthAuth(): Promise<boolean> {
+    const auth = await readAuthFileCached({ maxAgeMs: QWEN_AUTH_CACHE_MAX_AGE_MS });
+    const qwen = auth?.["opencode-qwencode-auth"];
+    return (
+      !!qwen &&
+      qwen.type === "oauth" &&
+      typeof qwen.access === "string" &&
+      qwen.access.trim().length > 0
+    );
+  }
+
+  function asRecord(value: unknown): Record<string, unknown> | null {
+    return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+  }
+
+  function evaluateToolOutcome(candidate: Record<string, unknown>): boolean | null {
+    if (typeof candidate.ok === "boolean") return candidate.ok;
+    if (typeof candidate.success === "boolean") return candidate.success;
+
+    const statusRaw = candidate.status;
+    if (typeof statusRaw === "string") {
+      const status = statusRaw.toLowerCase();
+      if (TOOL_FAILURE_STATUSES.has(status)) return false;
+      if (TOOL_SUCCESS_STATUSES.has(status)) return true;
+    }
+
+    if (candidate.error !== undefined && candidate.error !== null) return false;
+
+    const exitCode = candidate.exitCode;
+    if (typeof exitCode === "number" && Number.isFinite(exitCode)) {
+      return exitCode === 0;
+    }
+
+    return null;
+  }
+
+  function isSuccessfulQuestionExecution(output: ToolExecuteAfterOutput): boolean {
+    const metadata = asRecord(output.metadata);
+    const metadataOutcome = metadata ? evaluateToolOutcome(metadata) : null;
+    if (metadataOutcome !== null) return metadataOutcome;
+
+    const result = metadata ? asRecord(metadata.result) : null;
+    const resultOutcome = result ? evaluateToolOutcome(result) : null;
+    if (resultOutcome !== null) return resultOutcome;
+
+    // Fallback: keep behavior permissive if runtime omits explicit success state.
+    const title = output.title.trim().toLowerCase();
+    if (title.startsWith("error") || title.includes("failed")) return false;
+
+    return true;
+  }
+
+  function makeProviderFetchCacheKey(providerId: string, ctx: QuotaProviderContext): string {
+    const style = ctx.config.toastStyle ?? "classic";
+    const googleModels = ctx.config.googleModels.join(",");
+    const onlyCurrentModel = ctx.config.onlyCurrentModel ? "yes" : "no";
+    const currentModel = ctx.config.currentModel ?? "";
+    return `${providerId}|style=${style}|googleModels=${googleModels}|onlyCurrentModel=${onlyCurrentModel}|currentModel=${currentModel}`;
+  }
+
+  async function fetchProviderWithCache(params: {
+    provider: QuotaProvider;
+    ctx: QuotaProviderContext;
+    ttlMs: number;
+  }): Promise<QuotaProviderResult> {
+    const { provider, ctx, ttlMs } = params;
+
+    // Qwen is local-only and should update per completion for accurate RPM.
+    if (provider.id === "qwen-code") {
+      return await provider.fetch(ctx);
+    }
+
+    const cacheKey = makeProviderFetchCacheKey(provider.id, ctx);
+    const now = Date.now();
+    const existing = providerFetchCache.get(cacheKey);
+
+    if (
+      existing?.result &&
+      existing.timestamp > 0 &&
+      ttlMs > 0 &&
+      now - existing.timestamp < ttlMs
+    ) {
+      return existing.result;
+    }
+
+    if (existing?.inFlight) {
+      return existing.inFlight;
+    }
+
+    const promise = (async () => {
+      try {
+        const result = await provider.fetch(ctx);
+        if (result.attempted) {
+          providerFetchCache.set(cacheKey, { timestamp: Date.now(), result });
+        } else {
+          providerFetchCache.delete(cacheKey);
+        }
+        return result;
+      } catch (err) {
+        providerFetchCache.delete(cacheKey);
+        throw err;
+      }
+    })();
+
+    providerFetchCache.set(cacheKey, {
+      timestamp: existing?.timestamp ?? 0,
+      result: existing?.result,
+      inFlight: promise,
+    });
+
+    return promise;
+  }
+
+  async function shouldBypassToastCacheForQwen(trigger: string, sessionID: string): Promise<boolean> {
+    if (trigger !== "question") return false;
+    if (config.enabledProviders !== "auto" && !config.enabledProviders.includes("qwen-code")) return false;
+
+    const currentModel = await getCurrentModel(sessionID);
+    if (!isQwenModel(currentModel)) return false;
+
+    return await hasQwenOAuthAuth();
+  }
 
   async function refreshConfig(): Promise<void> {
     if (configInFlight) return configInFlight;
@@ -465,11 +621,13 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       currentModel = await getCurrentModel(sessionID);
     }
 
-    const ctx = {
+    const ctx: QuotaProviderContext = {
       client: typedClient,
       config: {
         googleModels: config.googleModels,
         toastStyle: config.toastStyle,
+        onlyCurrentModel: config.onlyCurrentModel,
+        currentModel,
       },
     };
 
@@ -498,7 +656,15 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
         : null;
     }
 
-    const results = await Promise.all(active.map((p) => p.fetch(ctx)));
+    const results = await Promise.all(
+      active.map((p) =>
+        fetchProviderWithCache({
+          provider: p,
+          ctx,
+          ttlMs: config.minIntervalMs,
+        }),
+      ),
+    );
 
     const entries: QuotaToastEntry[] = results.flatMap((r) => r.entries);
     const errors: QuotaToastError[] = results.flatMap((r) => r.errors);
@@ -618,6 +784,10 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
    * Show quota toast for a session
    */
   async function showQuotaToast(sessionID: string, trigger: string): Promise<void> {
+    if (!configLoaded) {
+      await refreshConfig();
+    }
+
     // Check if subagent session
     if (await isSubagentSession(sessionID)) {
       await log("Skipping toast for subagent session", { sessionID, trigger });
@@ -633,7 +803,11 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       return lines.some((l) => /\b\d{1,3}%\b/.test(l) && !/:\s/.test(l));
     }
 
-    const message = config.debug
+    const bypassMessageCache = config.debug
+      ? true
+      : await shouldBypassToastCacheForQwen(trigger, sessionID);
+
+    const message = bypassMessageCache
       ? await fetchQuotaMessage(trigger, sessionID)
       : await getOrFetchWithCacheControl(async () => {
           const msg = await fetchQuotaMessage(trigger, sessionID);
@@ -682,22 +856,35 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       : allProviders.filter((p) => config.enabledProviders.includes(p.id));
     if (!isAutoMode && providers.length === 0) return null;
 
-    const ctx = {
+    let currentModel: string | undefined;
+    if (config.onlyCurrentModel && sessionID) {
+      currentModel = await getCurrentModel(sessionID);
+    }
+
+    const ctx: QuotaProviderContext = {
       client: typedClient,
       config: {
         googleModels: config.googleModels,
         // Always format /quota in grouped mode for a more dashboard-like look.
         toastStyle: "grouped" as const,
+        onlyCurrentModel: config.onlyCurrentModel,
+        currentModel,
       },
     };
 
-    const avail = await Promise.all(
-      providers.map(async (p) => ({ p, ok: await p.isAvailable(ctx as any) })),
-    );
+    const avail = await Promise.all(providers.map(async (p) => ({ p, ok: await p.isAvailable(ctx) })));
     const active = avail.filter((x) => x.ok).map((x) => x.p);
     if (active.length === 0) return null;
 
-    const results = await Promise.all(active.map((p) => p.fetch(ctx as any)));
+    const results = await Promise.all(
+      active.map((p) =>
+        fetchProviderWithCache({
+          provider: p,
+          ctx,
+          ttlMs: config.minIntervalMs,
+        }),
+      ),
+    );
     const entries = results.flatMap((r) => r.entries) as any[];
     const errors = results.flatMap((r) => r.errors);
 
@@ -1058,8 +1245,29 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
     },
 
     // Tool execute hook for question tool
-    "tool.execute.after": async (input: ToolExecuteInput) => {
-      if (input.tool === "question" && config.showOnQuestion) {
+    "tool.execute.after": async (input: ToolExecuteAfterInput, output: ToolExecuteAfterOutput) => {
+      if (input.tool !== "question") return;
+
+      if (!configLoaded) {
+        await refreshConfig();
+      }
+
+      if (!config.enabled) return;
+
+      if (isSuccessfulQuestionExecution(output)) {
+        const model = await getCurrentModel(input.sessionID);
+        if (isQwenModel(model) && (await hasQwenOAuthAuth())) {
+          try {
+            await recordQwenCompletion();
+          } catch (err) {
+            await log("Failed to record Qwen local quota completion", {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+      }
+
+      if (config.showOnQuestion) {
         await showQuotaToast(input.sessionID, "question");
       }
     },

--- a/src/providers/qwen-code.ts
+++ b/src/providers/qwen-code.ts
@@ -1,0 +1,87 @@
+import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import { computeQwenQuota, readQwenLocalQuotaState } from "../lib/qwen-local-quota.js";
+import { readAuthFileCached } from "../lib/opencode-auth.js";
+
+const QWEN_AUTH_CACHE_MAX_AGE_MS = 5_000;
+
+type GroupedToastEntry = {
+  name: string;
+  percentRemaining: number;
+  resetTimeIso?: string;
+  group?: string;
+  label?: string;
+  right?: string;
+};
+
+function hasQwenOAuthAuth(auth: Awaited<ReturnType<typeof readAuthFileCached>>): boolean {
+  const qwen = auth?.["opencode-qwencode-auth"];
+  return (
+    !!qwen &&
+    qwen.type === "oauth" &&
+    typeof qwen.access === "string" &&
+    qwen.access.trim().length > 0
+  );
+}
+
+export const qwenCodeProvider: QuotaProvider = {
+  id: "qwen-code",
+
+  async isAvailable(_ctx: QuotaProviderContext): Promise<boolean> {
+    const auth = await readAuthFileCached({ maxAgeMs: QWEN_AUTH_CACHE_MAX_AGE_MS });
+    return hasQwenOAuthAuth(auth);
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    return model.toLowerCase().startsWith("qwen-code/");
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const auth = await readAuthFileCached({ maxAgeMs: QWEN_AUTH_CACHE_MAX_AGE_MS });
+    if (!hasQwenOAuthAuth(auth)) {
+      return { attempted: false, entries: [], errors: [] };
+    }
+
+    const quota = computeQwenQuota({ state: await readQwenLocalQuotaState() });
+    const style = ctx.config.toastStyle ?? "classic";
+
+    if (style === "grouped") {
+      const entries: GroupedToastEntry[] = [
+        {
+          name: "Qwen Daily",
+          group: "Qwen (OAuth)",
+          label: "Daily:",
+          right: `${quota.day.used}/${quota.day.limit}`,
+          percentRemaining: quota.day.percentRemaining,
+          resetTimeIso: quota.day.resetTimeIso,
+        },
+        {
+          name: "Qwen RPM",
+          group: "Qwen (OAuth)",
+          label: "RPM:",
+          right: `${quota.rpm.used}/${quota.rpm.limit}`,
+          percentRemaining: quota.rpm.percentRemaining,
+          resetTimeIso: quota.rpm.resetTimeIso,
+        },
+      ];
+
+      return { attempted: true, entries, errors: [] };
+    }
+
+    return {
+      attempted: true,
+      entries: [
+        {
+          name: "Qwen Daily",
+          percentRemaining: quota.day.percentRemaining,
+          resetTimeIso: quota.day.resetTimeIso,
+        },
+        {
+          name: "Qwen RPM",
+          percentRemaining: quota.rpm.percentRemaining,
+          resetTimeIso: quota.rpm.resetTimeIso,
+        },
+      ],
+      errors: [],
+    };
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -10,12 +10,14 @@ import { openaiProvider } from "./openai.js";
 import { googleAntigravityProvider } from "./google-antigravity.js";
 import { firmwareProvider } from "./firmware.js";
 import { chutesProvider } from "./chutes.js";
+import { qwenCodeProvider } from "./qwen-code.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
   return [
     copilotProvider,
     openaiProvider,
+    qwenCodeProvider,
     firmwareProvider,
     chutesProvider,
     googleAntigravityProvider,

--- a/tests/lib.qwen-local-quota.test.ts
+++ b/tests/lib.qwen-local-quota.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirs: () => ({
+    dataDir: "/home/test/.local/share/opencode",
+    configDir: "/home/test/.config/opencode",
+    cacheDir: "/home/test/.cache/opencode",
+    stateDir: "/home/test/.local/state/opencode",
+  }),
+}));
+
+vi.mock("fs/promises", () => ({
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  rename: vi.fn(),
+  rm: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+describe("qwen-local-quota", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns a default state when file is missing", async () => {
+    vi.setSystemTime(new Date("2026-02-24T12:00:00.000Z"));
+    const fs = await import("fs/promises");
+    (fs.readFile as any).mockRejectedValueOnce(new Error("missing"));
+
+    const { computeQwenQuota, readQwenLocalQuotaState } = await import("../src/lib/qwen-local-quota.js");
+    const state = await readQwenLocalQuotaState();
+    const quota = computeQwenQuota({ state });
+
+    expect(state.utcDay).toBe("2026-02-24");
+    expect(state.dayCount).toBe(0);
+    expect(state.recent).toEqual([]);
+    expect(quota.day.used).toBe(0);
+    expect(quota.day.percentRemaining).toBe(100);
+    expect(quota.rpm.used).toBe(0);
+    expect(quota.rpm.percentRemaining).toBe(100);
+    expect(quota.day.resetTimeIso).toBe("2026-02-25T00:00:00.000Z");
+  });
+
+  it("resets day counter at UTC midnight when recording a completion", async () => {
+    vi.setSystemTime(new Date("2026-02-24T00:00:10.000Z"));
+    const fs = await import("fs/promises");
+
+    (fs.readFile as any).mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        utcDay: "2026-02-23",
+        dayCount: 42,
+        recent: [Date.now() - 10_000],
+        updatedAt: Date.now() - 60_000,
+      }),
+    );
+
+    const { recordQwenCompletion } = await import("../src/lib/qwen-local-quota.js");
+    const next = await recordQwenCompletion();
+
+    expect(next.utcDay).toBe("2026-02-24");
+    expect(next.dayCount).toBe(1);
+    expect(next.recent.length).toBe(2);
+
+    expect(fs.writeFile).toHaveBeenCalledTimes(1);
+    const [, payload] = (fs.writeFile as any).mock.calls[0];
+    const persisted = JSON.parse(payload as string);
+    expect(persisted.dayCount).toBe(1);
+    expect(persisted.utcDay).toBe("2026-02-24");
+    expect(fs.rename).toHaveBeenCalledTimes(1);
+  });
+
+  it("computes RPM from timestamps in the last 60 seconds", async () => {
+    vi.setSystemTime(new Date("2026-02-24T12:00:00.000Z"));
+
+    const now = Date.now();
+    const { computeQwenQuota } = await import("../src/lib/qwen-local-quota.js");
+    const quota = computeQwenQuota({
+      nowMs: now,
+      state: {
+        version: 1,
+        utcDay: "2026-02-24",
+        dayCount: 50,
+        recent: [now - 61_000, now - 30_000, now - 1_000],
+        updatedAt: now,
+      },
+    });
+
+    expect(quota.rpm.used).toBe(2);
+    expect(quota.rpm.limit).toBe(60);
+    expect(quota.rpm.percentRemaining).toBe(97);
+    expect(quota.rpm.resetTimeIso).toBe(new Date(now - 30_000 + 60_000).toISOString());
+  });
+
+  it("replaces destination when rename fails on existing file", async () => {
+    vi.setSystemTime(new Date("2026-02-24T12:00:00.000Z"));
+    const fs = await import("fs/promises");
+    const now = Date.now();
+
+    (fs.readFile as any).mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        utcDay: "2026-02-24",
+        dayCount: 3,
+        recent: [now - 20_000],
+        updatedAt: now - 20_000,
+      }),
+    );
+
+    const renameError = Object.assign(new Error("destination exists"), { code: "EPERM" });
+    (fs.rename as any).mockRejectedValueOnce(renameError).mockResolvedValueOnce(undefined);
+
+    const { recordQwenCompletion } = await import("../src/lib/qwen-local-quota.js");
+    const next = await recordQwenCompletion();
+
+    expect(next.dayCount).toBe(4);
+    expect(fs.rm).toHaveBeenCalledTimes(1);
+    expect(fs.rename).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/plugin.qwen-hook.test.ts
+++ b/tests/plugin.qwen-hook.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_CONFIG } from "../src/lib/types.js";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  readAuthFileCached: vi.fn(),
+  recordQwenCompletion: vi.fn(),
+}));
+
+vi.mock("@opencode-ai/plugin", () => {
+  const makeChain = () => {
+    const chain: any = {};
+    chain.optional = () => chain;
+    chain.describe = () => chain;
+    chain.int = () => chain;
+    chain.min = () => chain;
+    return chain;
+  };
+
+  const toolFn = ((definition: unknown) => definition) as any;
+  toolFn.schema = {
+    boolean: () => makeChain(),
+    number: () => makeChain(),
+  };
+
+  return { tool: toolFn };
+});
+
+vi.mock("../src/lib/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+  createLoadConfigMeta: () => ({ source: "test", paths: [] }),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: mocks.readAuthFileCached,
+  readAuthFile: vi.fn(),
+  getAuthPath: vi.fn(() => "/tmp/auth.json"),
+  getAuthPaths: vi.fn(() => ["/tmp/auth.json"]),
+  clearReadAuthFileCacheForTests: vi.fn(),
+}));
+
+vi.mock("../src/lib/qwen-local-quota.js", () => ({
+  recordQwenCompletion: mocks.recordQwenCompletion,
+  readQwenLocalQuotaState: vi.fn(),
+  computeQwenQuota: vi.fn(),
+  getQwenLocalQuotaPath: vi.fn(() => "/tmp/qwen-local-quota.json"),
+}));
+
+function createClient(modelID: string) {
+  return {
+    config: {
+      get: vi.fn().mockResolvedValue({ data: {} }),
+      providers: vi.fn().mockResolvedValue({ data: { providers: [] } }),
+    },
+    session: {
+      get: vi.fn().mockResolvedValue({ data: { modelID } }),
+      prompt: vi.fn().mockResolvedValue({}),
+    },
+    tui: {
+      showToast: vi.fn().mockResolvedValue({}),
+    },
+    app: {
+      log: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+describe("plugin qwen question hook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.loadConfig.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      showOnQuestion: false,
+    });
+    mocks.readAuthFileCached.mockResolvedValue({
+      "opencode-qwencode-auth": { type: "oauth", access: "token" },
+    });
+    mocks.recordQwenCompletion.mockResolvedValue({
+      version: 1,
+      utcDay: "2026-02-24",
+      dayCount: 1,
+      recent: [],
+      updatedAt: 1,
+    });
+  });
+
+  it("records completion on successful qwen question execution", async () => {
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = await QuotaToastPlugin({ client: createClient("qwen-code/qwen3-coder-plus") } as any);
+
+    await hooks["tool.execute.after"]?.(
+      { tool: "question", sessionID: "session-1", callID: "call-1" },
+      { title: "Question", output: "ok", metadata: { status: "success" } },
+    );
+
+    expect(mocks.recordQwenCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not record completion when plugin is disabled", async () => {
+    mocks.loadConfig.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      enabled: false,
+      showOnQuestion: false,
+    });
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = await QuotaToastPlugin({ client: createClient("qwen-code/qwen3-coder-plus") } as any);
+
+    await hooks["tool.execute.after"]?.(
+      { tool: "question", sessionID: "session-1", callID: "call-2" },
+      { title: "Question", output: "ok", metadata: { status: "success" } },
+    );
+
+    expect(mocks.recordQwenCompletion).not.toHaveBeenCalled();
+  });
+
+  it("does not record completion when tool output indicates failure", async () => {
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = await QuotaToastPlugin({ client: createClient("qwen-code/qwen3-coder-plus") } as any);
+
+    await hooks["tool.execute.after"]?.(
+      { tool: "question", sessionID: "session-1", callID: "call-3" },
+      { title: "Error", output: "failed", metadata: { status: "error", error: "boom" } },
+    );
+
+    expect(mocks.recordQwenCompletion).not.toHaveBeenCalled();
+  });
+});

--- a/tests/providers.qwen-code.test.ts
+++ b/tests/providers.qwen-code.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { qwenCodeProvider } from "../src/providers/qwen-code.js";
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/qwen-local-quota.js", () => ({
+  readQwenLocalQuotaState: vi.fn(),
+  computeQwenQuota: vi.fn(),
+}));
+
+describe("qwen-code provider", () => {
+  it("returns attempted:false when oauth auth is not configured", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({});
+
+    const out = await qwenCodeProvider.fetch({ config: {} } as any);
+    expect(out.attempted).toBe(false);
+    expect(out.entries).toEqual([]);
+  });
+
+  it("maps local quota into grouped entries", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    const { computeQwenQuota, readQwenLocalQuotaState } = await import("../src/lib/qwen-local-quota.js");
+
+    (readAuthFileCached as any).mockResolvedValue({
+      "opencode-qwencode-auth": { type: "oauth", access: "token" },
+    });
+    (readQwenLocalQuotaState as any).mockResolvedValue({});
+    (computeQwenQuota as any).mockReturnValue({
+      day: {
+        used: 42,
+        limit: 1000,
+        percentRemaining: 96,
+        resetTimeIso: "2026-02-25T00:00:00.000Z",
+      },
+      rpm: {
+        used: 5,
+        limit: 60,
+        percentRemaining: 92,
+        resetTimeIso: "2026-02-24T12:00:30.000Z",
+      },
+    });
+
+    const out = await qwenCodeProvider.fetch({ config: { toastStyle: "grouped" } } as any);
+
+    expect(out.attempted).toBe(true);
+    expect(out.errors).toEqual([]);
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0]).toMatchObject({
+      name: "Qwen Daily",
+      group: "Qwen (OAuth)",
+      label: "Daily:",
+      right: "42/1000",
+      percentRemaining: 96,
+    });
+    expect(out.entries[1]).toMatchObject({
+      name: "Qwen RPM",
+      group: "Qwen (OAuth)",
+      label: "RPM:",
+      right: "5/60",
+      percentRemaining: 92,
+    });
+  });
+
+  it("matches qwen-code model ids", () => {
+    expect(qwenCodeProvider.matchesCurrentModel?.("qwen-code/qwen3-coder-plus")).toBe(true);
+    expect(qwenCodeProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+});


### PR DESCRIPTION
Introduce support for Qwen Code (OAuth) with a local-only quota estimator and integrate it into the plugin. Adds a new qwen-local-quota module to track daily and RPM counts, compute quota, persist state, and record completions; a qwen-code provider to surface grouped/classic toast entries; and provider registry/config updates to recognize "qwen-code". Add readAuthFileCached (with test helper) to reduce auth file IO and use it in availability/fetch checks. Update plugin logic to record Qwen completions on successful question executions, bypass toast cache for Qwen when needed, and add provider fetch caching. Update types, normalize provider ids, README docs, and add unit tests for local quota, provider, and plugin hook behavior.