### PR TITLE
fix: prevent slash commands from triggering LLM response

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1009,7 +1009,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       }
     },
 
-    "command.execute.before": async (input: CommandExecuteInput) => {
+    "command.execute.before": async (input: CommandExecuteInput, output?: { parts: Array<{ type: string; text?: string }> }) => {
       try {
         const cmd = input.command;
         const sessionID = input.sessionID;
@@ -1182,7 +1182,14 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
           handled();
         }
       } catch (err) {
-        if (isCommandHandledError(err)) return;
+        if (isCommandHandledError(err)) {
+          // Clear output parts so the original command text is not sent to the LLM
+          if (output?.parts) {
+            output.parts.length = 0;
+          }
+          // Re-throw to signal OpenCode to stop the command pipeline
+          throw err;
+        }
         throw err;
       }
     },

--- a/tests/plugin.command-handled-boundary.test.ts
+++ b/tests/plugin.command-handled-boundary.test.ts
@@ -66,18 +66,21 @@ describe("plugin command handled boundary", () => {
     mocks.getProviders.mockReturnValue([]);
   });
 
-  it("swallows command-handled sentinel errors", async () => {
+  it("re-throws command-handled sentinel and clears output parts", async () => {
     const { QuotaToastPlugin } = await import("../src/plugin.js");
     const client = createClient();
     const hooks = await QuotaToastPlugin({ client } as any);
+    const output = { parts: [{ type: "text", text: "/quota" }] };
 
     await expect(
       hooks["command.execute.before"]?.({
         command: "quota",
         sessionID: "session-1",
-      } as any),
-    ).resolves.toBeUndefined();
+      } as any, output as any),
+    ).rejects.toThrow("__QUOTA_COMMAND_HANDLED__");
 
+    // Output parts should be cleared to prevent LLM invocation
+    expect(output.parts).toHaveLength(0);
     expect(client.session.prompt).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Summary

- Fix slash commands (`/quota`, `/tokens_*`, `/quota_status`) triggering a full LLM model response before showing output
- Clear `output.parts` in-place so the original command text is never sent to the LLM
- Re-throw the sentinel error to signal OpenCode to stop the command pipeline

## Root Cause

The `command.execute.before` hook's catch block was swallowing the `__QUOTA_COMMAND_HANDLED__` sentinel error and returning normally:

```typescript
} catch (err) {
  if (isCommandHandledError(err)) return; // ← returns normally, OpenCode proceeds to call LLM
  throw err;
}
```

This caused OpenCode to treat the hook as successfully completed and proceed with sending the command text (e.g. `/quota`) to the LLM as a regular user prompt, resulting in an unwanted model response before the quota data appeared.

## Fix

Two-pronged approach for maximum compatibility:

1. **Clear `output.parts`** — empties the array in-place so even if OpenCode catches the error, the command text cannot reach the LLM
2. **Re-throw sentinel** — signals OpenCode to abort the command pipeline entirely

The `output` parameter is typed as optional (`output?:`) for backward compatibility with older OpenCode versions that may not pass it.

```typescript
} catch (err) {
  if (isCommandHandledError(err)) {
    if (output?.parts) {
      output.parts.length = 0;
    }
    throw err;
  }
  throw err;
}
```

## Testing

- Updated `plugin.command-handled-boundary.test.ts` to verify the sentinel is re-thrown and output parts are cleared
- All related tests pass (`npm test` — 79/82 pass; 3 pre-existing failures in `lib.opencode-runtime-paths.test.ts` due to Windows path separator differences, unrelated to this change)

## Related

- Fixes #11
- Related upstream issue: anomalyco/opencode#9306 (proposes adding `noReply` to hook output)