### PR TITLE
feat: add Kimi for Coding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # OpenCode Quota
+
 [![npm version](https://img.shields.io/npm/v/%40slkiser%2Fopencode-quota)](https://www.npmjs.com/package/@slkiser/opencode-quota)
 [![npm downloads](https://img.shields.io/npm/dm/%40slkiser%2Fopencode-quota)](https://www.npmjs.com/package/@slkiser/opencode-quota)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 [![CI](https://img.shields.io/github/actions/workflow/status/slkiser/opencode-quota/ci.yml?branch=main&label=CI)](https://github.com/slkiser/opencode-quota/actions/workflows/ci.yml)
 [![Node >=18](https://img.shields.io/badge/node-%3E%3D18-339933)](./package.json)
 
-
 `opencode-quota` adds usage quota and token visibility to OpenCode with zero context-window pollution.
 
 What you get:
 
-- TUI sidebar panel with quota 
+- TUI sidebar panel with quota
 - popup quota toasts after assistant responses
 - manual `/quota`, `/quota_status`, and `/tokens_*` commands
 
@@ -45,15 +45,17 @@ What you get:
   </tr>
 </table>
 
-OpenCode `>= 1.4.3` is required. 
+OpenCode `>= 1.4.3` is required.
 
 If you are coming back later:
+
 - see [Provider Setup At A Glance](#provider-setup-at-a-glance) for provider-specific setup needs
 - see [Commands](#commands) for the slash commands
 - see [Configuration Reference](#configuration-reference) when you want to customize behavior
 - see [Troubleshooting](#troubleshooting) if something does not appear or auto-detect correctly
 
 ## Installation
+
 ### Automatic setup (recommended)
 
 ```sh
@@ -62,23 +64,22 @@ npx @slkiser/opencode-quota init
 
 The installer (append-only, preserves existing values) asks for:
 
-- **Scope**: `Project` or `Global` 
+- **Scope**: `Project` or `Global`
 - **Quota UI**: `Toast`, `Sidebar`, `Toast + Sidebar`, or `None (manual /quota and /tokens_* only)`
-- **Provider mode**: `Auto-detect` or `Manual select` 
-- **Layout style**: `classic` or `grouped` 
-- **Show session input/output tokens**: `Yes` or `No` 
+- **Provider mode**: `Auto-detect` or `Manual select`
+- **Layout style**: `classic` or `grouped`
+- **Show session input/output tokens**: `Yes` or `No`
 
 All quota settings live in `opencode.json` or `opencode.jsonc`. `tui.json` or `tui.jsonc` is only for loading the sidebar plugin.
 
-
-### After install 
+### After install
 
 1. Restart OpenCode.
 2. Run `/quota_status`.
 3. Run `/quota`.
 4. If you chose `Sidebar` or `Toast + Sidebar`, open the session sidebar and confirm the `Quota` panel appears.
 
-### Manual setup 
+### Manual setup
 
 You can install manually, but the installer is easier and safer.
 
@@ -87,7 +88,7 @@ You can install manually, but the installer is easier and safer.
 ```jsonc
 {
   "$schema": "https://opencode.ai/config.json",
-  "plugin": ["@slkiser/opencode-quota"]
+  "plugin": ["@slkiser/opencode-quota"],
 }
 ```
 
@@ -96,7 +97,7 @@ You can install manually, but the installer is easier and safer.
 ```jsonc
 {
   "$schema": "https://opencode.ai/tui.json",
-  "plugin": ["@slkiser/opencode-quota"]
+  "plugin": ["@slkiser/opencode-quota"],
 }
 ```
 
@@ -115,9 +116,9 @@ Keep the `tui.json` or `tui.jsonc` entry above and disable toasts in `opencode.j
   "plugin": ["@slkiser/opencode-quota"],
   "experimental": {
     "quotaToast": {
-      "enableToast": false
-    }
-  }
+      "enableToast": false,
+    },
+  },
 }
 ```
 
@@ -130,9 +131,9 @@ Keep the `tui.json` or `tui.jsonc` entry above and disable toasts in `opencode.j
 {
   "experimental": {
     "quotaToast": {
-      "enabledProviders": ["copilot", "openai", "google-antigravity"]
-    }
-  }
+      "enabledProviders": ["copilot", "openai", "google-antigravity"],
+    },
+  },
 }
 ```
 
@@ -145,9 +146,9 @@ Keep the `tui.json` or `tui.jsonc` entry above and disable toasts in `opencode.j
 {
   "experimental": {
     "quotaToast": {
-      "formatStyle": "grouped"
-    }
-  }
+      "formatStyle": "grouped",
+    },
+  },
 }
 ```
 
@@ -172,7 +173,6 @@ Keep the `tui.json` or `tui.jsonc` entry above and disable toasts in `opencode.j
 | **Kimi Code**           | Yes                                                  | OpenCode auth/global config/env | Remote API               |
 | **OpenCode Go**         | Needs [quick setup](#opencode-go-quick-setup)        | Env/config auth                 | Dashboard scraping       |
 
-
 <a id="anthropic-quick-setup"></a>
 
 <details>
@@ -196,6 +196,7 @@ For behavior details and troubleshooting, see [Anthropic notes](#anthropic-notes
 </details>
 
 <a id="cursor-quick-setup"></a>
+
 <details>
 <summary><strong>Quick setup: Cursor</strong></summary>
 
@@ -207,15 +208,15 @@ Cursor quota support requires the `@playwo/opencode-cursor-oauth` [plugin](https
   "plugin": ["@playwo/opencode-cursor-oauth", "@slkiser/opencode-quota"],
   "provider": {
     "cursor": {
-      "name": "Cursor"
-    }
+      "name": "Cursor",
+    },
   },
   "experimental": {
     "quotaToast": {
       "cursorPlan": "pro",
-      "cursorBillingCycleStartDay": 7
-    }
-  }
+      "cursorBillingCycleStartDay": 7,
+    },
+  },
 }
 ```
 
@@ -230,6 +231,7 @@ For behavior details and troubleshooting, see [Cursor notes](#cursor-notes).
 </details>
 
 <a id="google-antigravity-quick-setup"></a>
+
 <details>
 <summary><strong>Quick setup: Google Antigravity</strong></summary>
 
@@ -237,7 +239,7 @@ Google quota support requires the `opencode-antigravity-auth` [plugin](https://g
 
 ```jsonc
 {
-  "plugin": ["opencode-antigravity-auth", "@slkiser/opencode-quota"]
+  "plugin": ["opencode-antigravity-auth", "@slkiser/opencode-quota"],
 }
 ```
 
@@ -246,6 +248,7 @@ For behavior details and troubleshooting, see [Google Antigravity notes](#google
 </details>
 
 <a id="qwen-code-quick-setup"></a>
+
 <details>
 <summary><strong>Quick setup: Qwen Code</strong></summary>
 
@@ -253,7 +256,7 @@ Qwen quota support requires the `opencode-qwencode-auth` [plugin](https://github
 
 ```jsonc
 {
-  "plugin": ["opencode-qwencode-auth", "@slkiser/opencode-quota"]
+  "plugin": ["opencode-qwencode-auth", "@slkiser/opencode-quota"],
 }
 ```
 
@@ -262,6 +265,7 @@ For behavior details and troubleshooting, see [Qwen Code notes](#qwen-code-notes
 </details>
 
 <a id="opencode-go-quick-setup"></a>
+
 <details>
 <summary><strong>Quick setup: OpenCode Go</strong></summary>
 
@@ -294,24 +298,24 @@ Environment variables take precedence over the config file. Run `/quota_status` 
 
 ## Commands
 
-| Command | What it shows |
-| --- | --- |
-| `/quota` | Manual grouped quota report with a local call timestamp |
-| `/quota_status` | Concise diagnostics for config, TUI setup, provider availability, account detection, and pricing snapshot health |
-| `/pricing_refresh` | Pull the local runtime pricing snapshot from `models.dev` on demand |
-| `/tokens_today` | Tokens used today (calendar day) |
-| `/tokens_daily` | Tokens used in the last 24 hours |
-| `/tokens_weekly` | Tokens used in the last 7 days |
-| `/tokens_monthly` | Tokens used in the last 30 days, including pricing sections |
-| `/tokens_all` | Tokens used across all local history |
-| `/tokens_session` | Tokens used in the current session only |
-| `/tokens_session_all` | Tokens used in the current session plus all descendant child/subagent sessions |
-| `/tokens_between` | Tokens used between two dates: `YYYY-MM-DD YYYY-MM-DD` |
-
+| Command               | What it shows                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `/quota`              | Manual grouped quota report with a local call timestamp                                                          |
+| `/quota_status`       | Concise diagnostics for config, TUI setup, provider availability, account detection, and pricing snapshot health |
+| `/pricing_refresh`    | Pull the local runtime pricing snapshot from `models.dev` on demand                                              |
+| `/tokens_today`       | Tokens used today (calendar day)                                                                                 |
+| `/tokens_daily`       | Tokens used in the last 24 hours                                                                                 |
+| `/tokens_weekly`      | Tokens used in the last 7 days                                                                                   |
+| `/tokens_monthly`     | Tokens used in the last 30 days, including pricing sections                                                      |
+| `/tokens_all`         | Tokens used across all local history                                                                             |
+| `/tokens_session`     | Tokens used in the current session only                                                                          |
+| `/tokens_session_all` | Tokens used in the current session plus all descendant child/subagent sessions                                   |
+| `/tokens_between`     | Tokens used between two dates: `YYYY-MM-DD YYYY-MM-DD`                                                           |
 
 ## Provider-Specific Notes
 
 <a id="anthropic-notes"></a>
+
 <details>
 <summary><strong>Anthropic (Claude)</strong></summary>
 
@@ -321,17 +325,18 @@ If the Claude CLI exposes 5-hour and 7-day quota windows in local structured out
 
 **Troubleshooting:**
 
-| Problem | Solution |
-| --- | --- |
-| `claude` not found | Install Claude Code and make sure `claude` is on your `PATH` |
-| Claude installed at a custom path | Set `experimental.quotaToast.anthropicBinaryPath` to the Claude executable path |
-| Not authenticated | Run `claude auth login`, then confirm `claude auth status` works |
-| Authenticated but no quota rows | Your local Claude CLI version did not expose quota windows; run `/quota_status` for the exact probe result |
-| Plugin not detected | Confirm OpenCode is configured with the `anthropic` provider |
+| Problem                           | Solution                                                                                                   |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `claude` not found                | Install Claude Code and make sure `claude` is on your `PATH`                                               |
+| Claude installed at a custom path | Set `experimental.quotaToast.anthropicBinaryPath` to the Claude executable path                            |
+| Not authenticated                 | Run `claude auth login`, then confirm `claude auth status` works                                           |
+| Authenticated but no quota rows   | Your local Claude CLI version did not expose quota windows; run `/quota_status` for the exact probe result |
+| Plugin not detected               | Confirm OpenCode is configured with the `anthropic` provider                                               |
 
 </details>
 
 <a id="github-copilot-notes"></a>
+
 <details>
 <summary><strong>GitHub Copilot</strong></summary>
 
@@ -366,6 +371,7 @@ Example `copilot-quota-token.json`:
 </details>
 
 <a id="cursor-notes"></a>
+
 <details>
 <summary><strong>Cursor</strong></summary>
 
@@ -384,15 +390,16 @@ Example override:
   "experimental": {
     "quotaToast": {
       "cursorPlan": "none",
-      "cursorIncludedApiUsd": 120
-    }
-  }
+      "cursorIncludedApiUsd": 120,
+    },
+  },
 }
 ```
 
 </details>
 
 <a id="openai-notes"></a>
+
 <details>
 <summary><strong>OpenAI</strong></summary>
 
@@ -405,6 +412,7 @@ OpenAI uses native OpenCode OAuth from `auth.json`. The canonical auth family is
 </details>
 
 <a id="qwen-code-notes"></a>
+
 <details>
 <summary><strong>Qwen Code</strong></summary>
 
@@ -419,6 +427,7 @@ See [Qwen Code quick setup](#qwen-code-quick-setup) for auth. Usage is local-onl
 </details>
 
 <a id="alibaba-coding-plan-notes"></a>
+
 <details>
 <summary><strong>Alibaba Coding Plan</strong></summary>
 
@@ -440,16 +449,16 @@ Example fallback tier:
 {
   "experimental": {
     "quotaToast": {
-      "alibabaCodingPlanTier": "lite"
-    }
-  }
+      "alibabaCodingPlanTier": "lite",
+    },
+  },
 }
 ```
 
 </details>
 
-
 <a id="minimax-coding-plan-notes"></a>
+
 <details>
 <summary><strong>MiniMax Coding Plan</strong></summary>
 
@@ -474,7 +483,7 @@ Kimi Code uses trusted env vars or trusted user/global OpenCode config first, th
 - API key sources are `KIMI_API_KEY`, `KIMI_CODE_API_KEY`, trusted user/global `provider["kimi-for-coding"].options.apiKey` or `provider["kimi-code"].options.apiKey`, then `auth.json`.
 - Repo-local `opencode.json` / `opencode.jsonc` is ignored for Kimi secrets.
 - Allowed env templates are limited to `{env:KIMI_API_KEY}` and `{env:KIMI_CODE_API_KEY}`.
-- The plugin calls `https://api.kimi.com/coding/v1/usages` (Kimi Code) and falls back to `https://api.moonshot.ai/v1/usages` (Moonshot) when needed.
+- The plugin calls `https://api.kimi.com/coding/v1/usages`.
 - `/quota_status` shows auth detection, API-key diagnostics, live quota state, and endpoint errors.
 
 </details>
@@ -495,6 +504,7 @@ Z.ai uses trusted env vars or trusted user/global OpenCode config first, then na
 </details>
 
 <a id="firmware-ai-notes"></a>
+
 <details>
 <summary><strong>Firmware AI</strong></summary>
 
@@ -511,16 +521,17 @@ Example user/global config (`~/.config/opencode/opencode.jsonc` on Linux/macOS):
   "provider": {
     "firmware": {
       "options": {
-        "apiKey": "{env:FIRMWARE_API_KEY}"
-      }
-    }
-  }
+        "apiKey": "{env:FIRMWARE_API_KEY}",
+      },
+    },
+  },
 }
 ```
 
 </details>
 
 <a id="chutes-ai-notes"></a>
+
 <details>
 <summary><strong>Chutes AI</strong></summary>
 
@@ -537,16 +548,17 @@ Example user/global config (`~/.config/opencode/opencode.jsonc` on Linux/macOS):
   "provider": {
     "chutes": {
       "options": {
-        "apiKey": "{env:CHUTES_API_KEY}"
-      }
-    }
-  }
+        "apiKey": "{env:CHUTES_API_KEY}",
+      },
+    },
+  },
 }
 ```
 
 </details>
 
 <a id="google-antigravity-notes"></a>
+
 <details>
 <summary><strong>Google Antigravity</strong></summary>
 
@@ -559,6 +571,7 @@ See [Google Antigravity quick setup](#google-antigravity-quick-setup). This comp
 </details>
 
 <a id="nanogpt-notes"></a>
+
 <details>
 <summary><strong>NanoGPT</strong></summary>
 
@@ -578,16 +591,17 @@ Example user/global config (`~/.config/opencode/opencode.jsonc` on Linux/macOS):
   "provider": {
     "nanogpt": {
       "options": {
-        "apiKey": "{env:NANOGPT_API_KEY}"
-      }
-    }
-  }
+        "apiKey": "{env:NANOGPT_API_KEY}",
+      },
+    },
+  },
 }
 ```
 
 </details>
 
 <a id="opencode-go-notes"></a>
+
 <details>
 <summary><strong>OpenCode Go</strong></summary>
 
@@ -603,12 +617,12 @@ OpenCode Go quota scrapes the OpenCode Go dashboard at `https://opencode.ai/work
 
 **Troubleshooting:**
 
-| Problem | Solution |
-| --- | --- |
-| Config not detected | Confirm `OPENCODE_GO_WORKSPACE_ID` and `OPENCODE_GO_AUTH_COOKIE` are set, then use `/quota_status` to inspect the exact config paths checked on your machine |
-| Incomplete config | Both `workspaceId` and `authCookie` are required; check `/quota_status` for which field is missing |
-| Scrape returns no data | The auth cookie may have expired; get a fresh one from your browser |
-| Dashboard format changed | The SolidJS SSR pattern may have changed; file an issue or wait for the official API |
+| Problem                  | Solution                                                                                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Config not detected      | Confirm `OPENCODE_GO_WORKSPACE_ID` and `OPENCODE_GO_AUTH_COOKIE` are set, then use `/quota_status` to inspect the exact config paths checked on your machine |
+| Incomplete config        | Both `workspaceId` and `authCookie` are required; check `/quota_status` for which field is missing                                                           |
+| Scrape returns no data   | The auth cookie may have expired; get a fresh one from your browser                                                                                          |
+| Dashboard format changed | The SolidJS SSR pattern may have changed; file an issue or wait for the official API                                                                         |
 
 </details>
 
@@ -620,32 +634,31 @@ When both are present, user/global config provides defaults. Project/workspace c
 
 ### Core/shared settings
 
-| Option | Default | Meaning |
-| --- | --- | --- |
-| `enabled` | `true` | Master switch for quota collection and handled slash commands. When `false`, `/quota`, `/quota_status`, `/pricing_refresh`, and `/tokens_*` are handled as no-ops. |
-| `enabledProviders` | `"auto"` | Auto-detect providers, or set an explicit provider list. |
-| `minIntervalMs` | `300000` | Minimum fetch interval between provider updates. |
-| `formatStyle` | `classic` | Shared quota-row style for popup toasts and the TUI sidebar: `classic` or `grouped`. Legacy `toastStyle` is still accepted on read for backward compatibility, but `formatStyle` is the canonical key. |
-| `onlyCurrentModel` | `false` | Filter quota rows to the current model/provider when that session selection can be resolved. |
-| `showSessionTokens` | `true` | Show the `Session input/output tokens` section in quota displays when session token data is available. Toasts and `/quota` show per-model input/output rows; the TUI sidebar shows a one-line total summary. |
-| `pricingSnapshot.source` | `"auto"` | Token pricing snapshot selection for `/tokens_*`: `auto`, `bundled`, or `runtime`. |
-| `pricingSnapshot.autoRefresh` | `7` | Refresh stale local pricing data after this many days. |
-
+| Option                        | Default   | Meaning                                                                                                                                                                                                      |
+| ----------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `enabled`                     | `true`    | Master switch for quota collection and handled slash commands. When `false`, `/quota`, `/quota_status`, `/pricing_refresh`, and `/tokens_*` are handled as no-ops.                                           |
+| `enabledProviders`            | `"auto"`  | Auto-detect providers, or set an explicit provider list.                                                                                                                                                     |
+| `minIntervalMs`               | `300000`  | Minimum fetch interval between provider updates.                                                                                                                                                             |
+| `formatStyle`                 | `classic` | Shared quota-row style for popup toasts and the TUI sidebar: `classic` or `grouped`. Legacy `toastStyle` is still accepted on read for backward compatibility, but `formatStyle` is the canonical key.       |
+| `onlyCurrentModel`            | `false`   | Filter quota rows to the current model/provider when that session selection can be resolved.                                                                                                                 |
+| `showSessionTokens`           | `true`    | Show the `Session input/output tokens` section in quota displays when session token data is available. Toasts and `/quota` show per-model input/output rows; the TUI sidebar shows a one-line total summary. |
+| `pricingSnapshot.source`      | `"auto"`  | Token pricing snapshot selection for `/tokens_*`: `auto`, `bundled`, or `runtime`.                                                                                                                           |
+| `pricingSnapshot.autoRefresh` | `7`       | Refresh stale local pricing data after this many days.                                                                                                                                                       |
 
 ### Toast settings
 
-| Option | Default | Meaning |
-| --- | --- | --- |
-| `enableToast` | `true` | Show popup toasts. Disabling this does not disable `/quota` or the TUI sidebar. |
-| `toastDurationMs` | `9000` | Toast duration in milliseconds. |
-| `showOnIdle` | `true` | Show a toast on the idle trigger. |
-| `showOnQuestion` | `true` | Show a toast after a question/assistant response. |
-| `showOnCompact` | `true` | Show a toast after session compaction. |
-| `showOnBothFail` | `true` | Show a fallback toast when providers attempted quota reads and all failed. |
-| `layout.maxWidth` | `50` | Toast formatting width target. Ignored by the TUI sidebar. |
-| `layout.narrowAt` | `42` | Toast compact-layout breakpoint. Ignored by the TUI sidebar. |
-| `layout.tinyAt` | `32` | Toast tiny-layout breakpoint. Ignored by the TUI sidebar. |
-| `debug` | `false` | Append toast debug context when troubleshooting. |
+| Option            | Default | Meaning                                                                         |
+| ----------------- | ------- | ------------------------------------------------------------------------------- |
+| `enableToast`     | `true`  | Show popup toasts. Disabling this does not disable `/quota` or the TUI sidebar. |
+| `toastDurationMs` | `9000`  | Toast duration in milliseconds.                                                 |
+| `showOnIdle`      | `true`  | Show a toast on the idle trigger.                                               |
+| `showOnQuestion`  | `true`  | Show a toast after a question/assistant response.                               |
+| `showOnCompact`   | `true`  | Show a toast after session compaction.                                          |
+| `showOnBothFail`  | `true`  | Show a fallback toast when providers attempted quota reads and all failed.      |
+| `layout.maxWidth` | `50`    | Toast formatting width target. Ignored by the TUI sidebar.                      |
+| `layout.narrowAt` | `42`    | Toast compact-layout breakpoint. Ignored by the TUI sidebar.                    |
+| `layout.tinyAt`   | `32`    | Toast tiny-layout breakpoint. Ignored by the TUI sidebar.                       |
+| `debug`           | `false` | Append toast debug context when troubleshooting.                                |
 
 ### TUI sidebar setup
 
@@ -656,31 +669,31 @@ If you want the `Quota` sidebar panel, you need **two files**:
 
 **Important:** `experimental.quotaToast.*` settings do **not** go in `tui.json`. `tui.json` is only for loading the TUI plugin.
 
-| File | What goes there | Needed for sidebar? |
-| --- | --- | --- |
-| `tui.json` / `tui.jsonc` | `plugin: ["@slkiser/opencode-quota"]` | Yes |
-| `opencode.json` / `opencode.jsonc` | All `experimental.quotaToast.*` settings | Yes |
+| File                               | What goes there                          | Needed for sidebar? |
+| ---------------------------------- | ---------------------------------------- | ------------------- |
+| `tui.json` / `tui.jsonc`           | `plugin: ["@slkiser/opencode-quota"]`    | Yes                 |
+| `opencode.json` / `opencode.jsonc` | All `experimental.quotaToast.*` settings | Yes                 |
 
 ### Provider-specific settings
 
-| Option | Default | Meaning |
-| --- | --- | --- |
-| `anthropicBinaryPath` | `"claude"` | Command/path used for local Claude CLI probing; override this for custom installs or shim locations. |
-| `googleModels` | `["CLAUDE"]` | Google model keys to query: `CLAUDE`, `G3PRO`, `G3FLASH`, `G3IMAGE`. |
-| `alibabaCodingPlanTier` | `"lite"` | Fallback Alibaba Coding Plan tier when auth does not include `tier`. |
-| `cursorPlan` | `"none"` | Cursor included API budget preset: `none`, `pro`, `pro-plus`, `ultra`. |
-| `cursorIncludedApiUsd` | unset | Override Cursor monthly included API budget in USD. |
-| `cursorBillingCycleStartDay` | unset | Local billing-cycle anchor day `1..28`; when unset, Cursor usage resets on the local calendar month. |
+| Option                       | Default      | Meaning                                                                                              |
+| ---------------------------- | ------------ | ---------------------------------------------------------------------------------------------------- |
+| `anthropicBinaryPath`        | `"claude"`   | Command/path used for local Claude CLI probing; override this for custom installs or shim locations. |
+| `googleModels`               | `["CLAUDE"]` | Google model keys to query: `CLAUDE`, `G3PRO`, `G3FLASH`, `G3IMAGE`.                                 |
+| `alibabaCodingPlanTier`      | `"lite"`     | Fallback Alibaba Coding Plan tier when auth does not include `tier`.                                 |
+| `cursorPlan`                 | `"none"`     | Cursor included API budget preset: `none`, `pro`, `pro-plus`, `ultra`.                               |
+| `cursorIncludedApiUsd`       | unset        | Override Cursor monthly included API budget in USD.                                                  |
+| `cursorBillingCycleStartDay` | unset        | Local billing-cycle anchor day `1..28`; when unset, Cursor usage resets on the local calendar month. |
 
 ## Token Pricing Snapshot
 
 `/tokens_*` uses a local `models.dev` pricing snapshot. A bundled snapshot ships for offline use, and Cursor `auto` and `composer*` pricing stays bundled because those ids are not on `models.dev`.
 
-| `pricingSnapshot.source` | Active pricing behavior |
-| --- | --- |
-| `auto` | Newer runtime snapshot wins; otherwise bundled pricing stays active. |
-| `bundled` | Packaged bundled snapshot stays active. |
-| `runtime` | Runtime snapshot stays active when present; bundled pricing is fallback until one exists. |
+| `pricingSnapshot.source` | Active pricing behavior                                                                   |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `auto`                   | Newer runtime snapshot wins; otherwise bundled pricing stays active.                      |
+| `bundled`                | Packaged bundled snapshot stays active.                                                   |
+| `runtime`                | Runtime snapshot stays active when present; bundled pricing is fallback until one exists. |
 
 - See [Configuration Reference](#configuration-reference) for option defaults.
 - `pricingSnapshot.autoRefresh` controls how many days a runtime snapshot can age before background refresh.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ What you get:
 - popup quota toasts after assistant responses
 - manual `/quota`, `/quota_status`, and `/tokens_*` commands
 
-**Quota providers**: Anthropic (Claude), GitHub Copilot, OpenAI (Plus/Pro), Cursor, Qwen Code, Alibaba Coding Plan, MiniMax Coding Plan, Chutes AI, Firmware AI, Google Antigravity, Z.ai Coding Plan, NanoGPT, and OpenCode Go.
+**Quota providers**: Anthropic (Claude), GitHub Copilot, OpenAI (Plus/Pro), Cursor, Qwen Code, Alibaba Coding Plan, MiniMax Coding Plan, Kimi Code, Chutes AI, Firmware AI, Google Antigravity, Z.ai Coding Plan, NanoGPT, and OpenCode Go.
 
 **Token reports**: All models and providers in [models.dev](https://models.dev), plus deterministic local pricing for Cursor Auto/Composer and Cursor model aliases that are not on models.dev.
 
@@ -155,24 +155,26 @@ Keep the `tui.json` or `tui.jsonc` entry above and disable toasts in `opencode.j
 
 ## Provider Setup At A Glance
 
-| Provider | Auto setup | Authentication | Quota |
-| --- | --- | --- | --- |
-| **Anthropic (Claude)** | Needs [quick setup](#anthropic-quick-setup) | Local CLI auth | Local CLI report |
-| **GitHub Copilot** | Usually | OpenCode auth or PAT | Remote API |
-| **OpenAI** | Yes | OpenCode auth | Remote API |
-| **Cursor** | Needs [quick setup](#cursor-quick-setup) | Companion auth | Local runtime accounting |
-| **Qwen Code** | Needs [quick setup](#qwen-code-quick-setup) | Companion auth | Local estimation |
-| **Alibaba Coding Plan** | Yes | OpenCode auth/global config/env | Local estimation |
-| **Firmware AI** | Usually | OpenCode auth/global config/env | Remote API |
-| **Chutes AI** | Usually | OpenCode auth/global config/env | Remote API |
-| **Google Antigravity** | Needs [quick setup](#google-antigravity-quick-setup) | Companion auth | Remote API |
-| **Z.ai** | Yes | OpenCode auth/global config/env | Remote API |
-| **NanoGPT** | Usually | OpenCode auth/global config/env | Remote API |
-| **MiniMax Coding Plan** | Yes | OpenCode auth/global config/env | Remote API |
-| **OpenCode Go** | Needs [quick setup](#opencode-go-quick-setup) | Env/config auth | Dashboard scraping |
+| Provider                | Auto setup                                           | Authentication                  | Quota                    |
+| ----------------------- | ---------------------------------------------------- | ------------------------------- | ------------------------ |
+| **Anthropic (Claude)**  | Needs [quick setup](#anthropic-quick-setup)          | Local CLI auth                  | Local CLI report         |
+| **GitHub Copilot**      | Usually                                              | OpenCode auth or PAT            | Remote API               |
+| **OpenAI**              | Yes                                                  | OpenCode auth                   | Remote API               |
+| **Cursor**              | Needs [quick setup](#cursor-quick-setup)             | Companion auth                  | Local runtime accounting |
+| **Qwen Code**           | Needs [quick setup](#qwen-code-quick-setup)          | Companion auth                  | Local estimation         |
+| **Alibaba Coding Plan** | Yes                                                  | OpenCode auth/global config/env | Local estimation         |
+| **Firmware AI**         | Usually                                              | OpenCode auth/global config/env | Remote API               |
+| **Chutes AI**           | Usually                                              | OpenCode auth/global config/env | Remote API               |
+| **Google Antigravity**  | Needs [quick setup](#google-antigravity-quick-setup) | Companion auth                  | Remote API               |
+| **Z.ai**                | Yes                                                  | OpenCode auth/global config/env | Remote API               |
+| **NanoGPT**             | Usually                                              | OpenCode auth/global config/env | Remote API               |
+| **MiniMax Coding Plan** | Yes                                                  | OpenCode auth/global config/env | Remote API               |
+| **Kimi Code**           | Yes                                                  | OpenCode auth/global config/env | Remote API               |
+| **OpenCode Go**         | Needs [quick setup](#opencode-go-quick-setup)        | Env/config auth                 | Dashboard scraping       |
 
 
 <a id="anthropic-quick-setup"></a>
+
 <details>
 <summary><strong>Quick setup: Anthropic (Claude)</strong></summary>
 
@@ -462,7 +464,23 @@ MiniMax Coding Plan uses trusted env vars or trusted user/global OpenCode config
 
 </details>
 
+<a id="kimi-code-notes"></a>
+
+<details>
+<summary><strong>Kimi Code</strong></summary>
+
+Kimi Code uses trusted env vars or trusted user/global OpenCode config first, then native OpenCode auth from `auth.json["kimi-for-coding"]` or `auth.json["kimi-code"]`. No additional plugin is required.
+
+- API key sources are `KIMI_API_KEY`, `KIMI_CODE_API_KEY`, trusted user/global `provider["kimi-for-coding"].options.apiKey` or `provider["kimi-code"].options.apiKey`, then `auth.json`.
+- Repo-local `opencode.json` / `opencode.jsonc` is ignored for Kimi secrets.
+- Allowed env templates are limited to `{env:KIMI_API_KEY}` and `{env:KIMI_CODE_API_KEY}`.
+- The plugin calls `https://api.kimi.com/coding/v1/usages` (Kimi Code) and falls back to `https://api.moonshot.ai/v1/usages` (Moonshot) when needed.
+- `/quota_status` shows auth detection, API-key diagnostics, live quota state, and endpoint errors.
+
+</details>
+
 <a id="zai-notes"></a>
+
 <details>
 <summary><strong>Z.ai</strong></summary>
 

--- a/src/lib/kimi-auth.ts
+++ b/src/lib/kimi-auth.ts
@@ -1,0 +1,171 @@
+import {
+  extractProviderOptionsApiKey,
+  getApiKeyCheckedPaths,
+  getFirstAuthEntryValue,
+  getGlobalOpencodeConfigCandidatePaths,
+  resolveApiKeyFromEnvAndConfig,
+} from "./api-key-resolver.js";
+import { sanitizeDisplayText } from "./display-sanitize.js";
+import { getAuthPaths, readAuthFileCached } from "./opencode-auth.js";
+
+import type { AuthData, KimiAuthData } from "./types.js";
+
+export const DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS = 5_000;
+const KIMI_AUTH_KEYS = ["kimi-for-coding", "kimi-code", "kimi"] as const;
+const KIMI_PROVIDER_KEYS = ["kimi-for-coding", "kimi-code", "kimi"] as const;
+const ALLOWED_KIMI_ENV_VARS = ["KIMI_API_KEY", "KIMI_CODE_API_KEY"] as const;
+
+export type KimiKeySource =
+  | "env:KIMI_API_KEY"
+  | "env:KIMI_CODE_API_KEY"
+  | "opencode.json"
+  | "opencode.jsonc"
+  | "auth.json";
+
+export type ResolvedKimiAuth =
+  | { state: "none" }
+  | { state: "configured"; apiKey: string }
+  | { state: "invalid"; error: string };
+
+export type KimiAuthDiagnostics =
+  | {
+      state: "none";
+      source: null;
+      checkedPaths: string[];
+      authPaths: string[];
+    }
+  | {
+      state: "configured";
+      source: KimiKeySource;
+      checkedPaths: string[];
+      authPaths: string[];
+    }
+  | {
+      state: "invalid";
+      source: "auth.json";
+      checkedPaths: string[];
+      authPaths: string[];
+      error: string;
+    };
+
+export { getGlobalOpencodeConfigCandidatePaths as getOpencodeConfigCandidatePaths } from "./api-key-resolver.js";
+
+function getKimiAuthEntry(auth: AuthData | null | undefined): unknown {
+  return getFirstAuthEntryValue(auth, KIMI_AUTH_KEYS);
+}
+
+function isKimiAuthData(value: unknown): value is KimiAuthData {
+  return value !== null && typeof value === "object";
+}
+
+function sanitizeKimiAuthValue(value: string): string {
+  const sanitized = sanitizeDisplayText(value).replace(/\s+/g, " ").trim();
+  return (sanitized || "unknown").slice(0, 120);
+}
+
+export function resolveKimiAuth(auth: AuthData | null | undefined): ResolvedKimiAuth {
+  const kimi = getKimiAuthEntry(auth);
+  if (kimi === null || kimi === undefined) {
+    return { state: "none" };
+  }
+
+  if (!isKimiAuthData(kimi)) {
+    return { state: "invalid", error: "Kimi auth entry has invalid shape" };
+  }
+
+  if (typeof kimi.type !== "string") {
+    return { state: "invalid", error: "Kimi auth entry present but type is missing or invalid" };
+  }
+
+  if (kimi.type !== "api") {
+    return {
+      state: "invalid",
+      error: `Unsupported Kimi auth type: "${sanitizeKimiAuthValue(kimi.type)}"`,
+    };
+  }
+
+  const key = typeof kimi.key === "string" ? kimi.key.trim() : "";
+  if (!key) {
+    return { state: "invalid", error: "Kimi auth entry present but key is empty" };
+  }
+
+  return { state: "configured", apiKey: key };
+}
+
+async function resolveKimiAuthWithSource(params?: {
+  maxAgeMs?: number;
+}): Promise<{ auth: ResolvedKimiAuth; source: KimiKeySource | null }> {
+  const resolvedFromEnvOrConfig = await resolveApiKeyFromEnvAndConfig<KimiKeySource>({
+    envVars: [
+      { name: "KIMI_API_KEY", source: "env:KIMI_API_KEY" },
+      { name: "KIMI_CODE_API_KEY", source: "env:KIMI_CODE_API_KEY" },
+    ],
+    extractFromConfig: (config) =>
+      extractProviderOptionsApiKey(config, {
+        providerKeys: KIMI_PROVIDER_KEYS,
+        allowedEnvVars: ALLOWED_KIMI_ENV_VARS,
+      }),
+    configJsonSource: "opencode.json",
+    configJsoncSource: "opencode.jsonc",
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+  });
+
+  if (resolvedFromEnvOrConfig) {
+    return {
+      auth: { state: "configured", apiKey: resolvedFromEnvOrConfig.key },
+      source: resolvedFromEnvOrConfig.source,
+    };
+  }
+
+  const maxAgeMs = Math.max(0, params?.maxAgeMs ?? DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS);
+  const authData = await readAuthFileCached({ maxAgeMs });
+  const auth = resolveKimiAuth(authData);
+
+  return {
+    auth,
+    source: auth.state === "none" ? null : "auth.json",
+  };
+}
+
+export async function resolveKimiAuthCached(params?: {
+  maxAgeMs?: number;
+}): Promise<ResolvedKimiAuth> {
+  return (await resolveKimiAuthWithSource(params)).auth;
+}
+
+export async function getKimiAuthDiagnostics(params?: {
+  maxAgeMs?: number;
+}): Promise<KimiAuthDiagnostics> {
+  const { auth, source } = await resolveKimiAuthWithSource(params);
+  const checkedPaths = getApiKeyCheckedPaths({
+    envVarNames: [...ALLOWED_KIMI_ENV_VARS],
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+  });
+  const authPaths = getAuthPaths();
+
+  if (auth.state === "none") {
+    return {
+      state: "none",
+      source: null,
+      checkedPaths,
+      authPaths,
+    };
+  }
+
+  if (auth.state === "invalid") {
+    return {
+      state: "invalid",
+      source: "auth.json",
+      checkedPaths,
+      authPaths,
+      error: auth.error,
+    };
+  }
+
+  return {
+    state: "configured",
+    source: source ?? "auth.json",
+    checkedPaths,
+    authPaths,
+  };
+}

--- a/src/lib/kimi.ts
+++ b/src/lib/kimi.ts
@@ -5,8 +5,7 @@ import { fetchWithTimeout } from "./http.js";
 import { resolveKimiAuthCached, DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS } from "./kimi-auth.js";
 
 const KIMI_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
-const MOONSHOT_USAGE_URL = "https://api.moonshot.ai/v1/usages";
-const USER_AGENT = "KimiCLI/1.35";
+const USER_AGENT = "OpenCode-Quota-Toast/1.0";
 
 function getFiniteNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) {
@@ -244,39 +243,22 @@ export async function queryKimiQuota(): Promise<KimiResult> {
     return { success: false, error: auth.error };
   }
 
-  const kimiResult = await fetchKimiQuotaFromUrl(KIMI_USAGE_URL, auth.apiKey);
-  if (kimiResult.ok && kimiResult.windows.length > 0) {
+  const result = await fetchKimiQuotaFromUrl(KIMI_USAGE_URL, auth.apiKey);
+  if (result.ok && result.windows.length > 0) {
     return {
       success: true,
       label: "Kimi Code",
-      windows: kimiResult.windows,
+      windows: result.windows,
     };
   }
 
-  const moonshotResult = await fetchKimiQuotaFromUrl(MOONSHOT_USAGE_URL, auth.apiKey);
-  if (moonshotResult.ok && moonshotResult.windows.length > 0) {
-    return {
-      success: true,
-      label: "Kimi Code",
-      windows: moonshotResult.windows,
-    };
+  if (!result.ok) {
+    return { success: false, error: result.error };
   }
 
-  // Prefer the first endpoint's error if both failed or returned no windows.
-  const firstError = !kimiResult.ok ? kimiResult.error : null;
-  const secondError = !moonshotResult.ok ? moonshotResult.error : null;
-
-  if (firstError) {
-    return { success: false, error: firstError };
-  }
-  if (secondError) {
-    return { success: false, error: secondError };
-  }
-
-  // Both succeeded structurally but had no usable windows.
-  const topLevelKeys = (kimiResult as Extract<FetchResult, { ok: true }>).topLevelKeys;
+  // Succeeded structurally but had no usable windows.
   return {
     success: false,
-    error: describeUnexpectedPayload(topLevelKeys),
+    error: describeUnexpectedPayload(result.topLevelKeys),
   };
 }

--- a/src/lib/kimi.ts
+++ b/src/lib/kimi.ts
@@ -1,0 +1,282 @@
+import type { KimiResult, KimiQuotaWindow, QuotaError } from "./types.js";
+import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
+import { clampPercent } from "./format-utils.js";
+import { fetchWithTimeout } from "./http.js";
+import { resolveKimiAuthCached, DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS } from "./kimi-auth.js";
+
+const KIMI_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
+const MOONSHOT_USAGE_URL = "https://api.moonshot.ai/v1/usages";
+const USER_AGENT = "KimiCLI/1.35";
+
+function getFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return undefined;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseResetTimeIso(data: Record<string, unknown>): string | undefined {
+  for (const key of ["reset_at", "resetAt", "reset_time", "resetTime"]) {
+    const val = data[key];
+    if (typeof val === "string" && val.trim().length > 0) {
+      const ms = Date.parse(val);
+      if (Number.isFinite(ms)) {
+        return new Date(ms).toISOString();
+      }
+    }
+  }
+
+  for (const key of ["reset_in", "resetIn", "ttl"]) {
+    const seconds = getFiniteNumber(data[key]);
+    if (seconds !== undefined && seconds > 0) {
+      return new Date(Date.now() + Math.round(seconds * 1000)).toISOString();
+    }
+  }
+
+  const window = data.window;
+  if (window !== null && typeof window === "object") {
+    const w = window as Record<string, unknown>;
+    const windowSeconds = getFiniteNumber(w.duration);
+    if (windowSeconds !== undefined && windowSeconds > 0) {
+      return new Date(Date.now() + Math.round(windowSeconds * 1000)).toISOString();
+    }
+  }
+
+  return undefined;
+}
+
+function buildLimitLabel(
+  item: Record<string, unknown>,
+  detail: Record<string, unknown>,
+  window: Record<string, unknown>,
+  index: number,
+): string {
+  for (const key of ["name", "title", "scope"]) {
+    const val = getNonEmptyString(item[key] ?? detail[key]);
+    if (val) return val;
+  }
+
+  const duration = getFiniteNumber(window.duration ?? item.duration ?? detail.duration);
+  const timeUnit = String(window.timeUnit ?? item.timeUnit ?? detail.timeUnit ?? "");
+
+  if (duration !== undefined && duration > 0) {
+    if (timeUnit.includes("MINUTE")) {
+      if (duration >= 60 && duration % 60 === 0) {
+        return `${duration / 60}h limit`;
+      }
+      return `${duration}m limit`;
+    }
+    if (timeUnit.includes("HOUR")) {
+      return `${duration}h limit`;
+    }
+    if (timeUnit.includes("DAY")) {
+      return `${duration}d limit`;
+    }
+    return `${duration}s limit`;
+  }
+
+  return `Limit #${index + 1}`;
+}
+
+function toUsageRow(
+  data: Record<string, unknown>,
+  defaultLabel: string,
+): {
+  label: string;
+  used: number;
+  limit: number;
+  percentRemaining: number;
+  resetTimeIso?: string;
+} | null {
+  const limit = getFiniteNumber(data.limit);
+  let used = getFiniteNumber(data.used);
+
+  if (used === undefined) {
+    const remaining = getFiniteNumber(data.remaining);
+    if (remaining !== undefined && limit !== undefined) {
+      used = limit - remaining;
+    }
+  }
+
+  if (used === undefined && limit === undefined) {
+    return null;
+  }
+
+  const safeUsed = used ?? 0;
+  const safeLimit = limit ?? 0;
+  const percentRemaining =
+    safeLimit > 0 ? clampPercent(((safeLimit - safeUsed) / safeLimit) * 100) : 0;
+
+  return {
+    label: getNonEmptyString(data.name ?? data.title) ?? defaultLabel,
+    used: safeUsed,
+    limit: safeLimit,
+    percentRemaining,
+    resetTimeIso: parseResetTimeIso(data),
+  };
+}
+
+function extractPayloadData(payload: Record<string, unknown>): {
+  usage: unknown;
+  limits: unknown;
+  topLevelKeys: string[];
+} {
+  const topLevelKeys = Object.keys(payload);
+
+  if (payload.data !== null && typeof payload.data === "object") {
+    const data = payload.data as Record<string, unknown>;
+    return {
+      usage: data.usage ?? payload.usage,
+      limits: data.limits ?? payload.limits,
+      topLevelKeys,
+    };
+  }
+
+  return { usage: payload.usage, limits: payload.limits, topLevelKeys };
+}
+
+function describeUnexpectedPayload(topLevelKeys: string[]): string {
+  const keys = topLevelKeys.length ? topLevelKeys.join(", ") : "(empty)";
+  return `Unexpected response structure (keys: ${keys})`;
+}
+
+function parseKimiUsagePayload(payload: Record<string, unknown>): {
+  windows: KimiQuotaWindow[];
+  topLevelKeys: string[];
+} {
+  const { usage, limits, topLevelKeys } = extractPayloadData(payload);
+  const windows: KimiQuotaWindow[] = [];
+
+  if (usage !== null && typeof usage === "object") {
+    const row = toUsageRow(usage as Record<string, unknown>, "Weekly limit");
+    if (row) {
+      windows.push({
+        label: row.label,
+        used: row.used,
+        limit: row.limit,
+        percentRemaining: row.percentRemaining,
+        resetTimeIso: row.resetTimeIso,
+      });
+    }
+  }
+
+  if (Array.isArray(limits)) {
+    for (let i = 0; i < limits.length; i++) {
+      const item = limits[i];
+      if (item === null || typeof item !== "object") continue;
+      const itemMap = item as Record<string, unknown>;
+
+      const detailRaw = itemMap.detail;
+      const detail =
+        detailRaw !== null && typeof detailRaw === "object"
+          ? (detailRaw as Record<string, unknown>)
+          : itemMap;
+
+      const windowRaw = itemMap.window;
+      const window =
+        windowRaw !== null && typeof windowRaw === "object"
+          ? (windowRaw as Record<string, unknown>)
+          : {};
+
+      const label = buildLimitLabel(itemMap, detail, window, i);
+      const row = toUsageRow(detail, label);
+      if (row) {
+        windows.push({
+          label: row.label,
+          used: row.used,
+          limit: row.limit,
+          percentRemaining: row.percentRemaining,
+          resetTimeIso: row.resetTimeIso,
+        });
+      }
+    }
+  }
+
+  return { windows, topLevelKeys };
+}
+
+type FetchResult =
+  | { ok: true; windows: KimiQuotaWindow[]; topLevelKeys: string[] }
+  | { ok: false; error: string };
+
+async function fetchKimiQuotaFromUrl(url: string, apiKey: string): Promise<FetchResult> {
+  try {
+    const resp = await fetchWithTimeout(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "User-Agent": USER_AGENT,
+      },
+    });
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        ok: false,
+        error: `Kimi API error ${resp.status}: ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    const payload = (await resp.json()) as Record<string, unknown>;
+    const { windows, topLevelKeys } = parseKimiUsagePayload(payload);
+    return { ok: true, windows, topLevelKeys };
+  } catch (err) {
+    return {
+      ok: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+export async function queryKimiQuota(): Promise<KimiResult> {
+  const auth = await resolveKimiAuthCached({ maxAgeMs: DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS });
+  if (auth.state === "none") return null;
+  if (auth.state === "invalid") {
+    return { success: false, error: auth.error };
+  }
+
+  const kimiResult = await fetchKimiQuotaFromUrl(KIMI_USAGE_URL, auth.apiKey);
+  if (kimiResult.ok && kimiResult.windows.length > 0) {
+    return {
+      success: true,
+      label: "Kimi Code",
+      windows: kimiResult.windows,
+    };
+  }
+
+  const moonshotResult = await fetchKimiQuotaFromUrl(MOONSHOT_USAGE_URL, auth.apiKey);
+  if (moonshotResult.ok && moonshotResult.windows.length > 0) {
+    return {
+      success: true,
+      label: "Kimi Code",
+      windows: moonshotResult.windows,
+    };
+  }
+
+  // Prefer the first endpoint's error if both failed or returned no windows.
+  const firstError = !kimiResult.ok ? kimiResult.error : null;
+  const secondError = !moonshotResult.ok ? moonshotResult.error : null;
+
+  if (firstError) {
+    return { success: false, error: firstError };
+  }
+  if (secondError) {
+    return { success: false, error: secondError };
+  }
+
+  // Both succeeded structurally but had no usable windows.
+  const topLevelKeys = (kimiResult as Extract<FetchResult, { ok: true }>).topLevelKeys;
+  return {
+    success: false,
+    error: describeUnexpectedPayload(topLevelKeys),
+  };
+}

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -11,6 +11,7 @@ export type CanonicalQuotaProviderId =
   | "zai"
   | "nanogpt"
   | "minimax-coding-plan"
+  | "kimi-for-coding"
   | "opencode-go";
 
 export type QuotaProviderAutoSetup = "yes" | "usually" | "needs_quick_setup";
@@ -56,6 +57,8 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   zai: "Z.ai",
   nanogpt: "NanoGPT",
   "minimax-coding-plan": "MiniMax Coding Plan",
+  "kimi-for-coding": "Kimi Code",
+  "kimi-code": "Kimi Code",
   "opencode-go": "OpenCode Go",
 };
 
@@ -72,6 +75,9 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   alibaba: "alibaba-coding-plan",
   "nano-gpt": "nanogpt",
   minimax: "minimax-coding-plan",
+  kimi: "kimi-for-coding",
+  "kimi-for-code": "kimi-for-coding",
+  "kimi-code": "kimi-for-coding",
   "opencode-go-subscription": "opencode-go",
 };
 
@@ -88,6 +94,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   zai: ["zai", "glm", "zai-coding-plan"],
   nanogpt: ["nanogpt", "nano-gpt"],
   "minimax-coding-plan": ["minimax-coding-plan", "minimax"],
+  "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
   "opencode-go": ["opencode-go"],
 };
 
@@ -171,6 +178,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
   },
   {
     id: "minimax-coding-plan",
+    autoSetup: "yes",
+    authentication: "opencode_auth_api_key",
+    authFallbacks: ["env_api_key", "global_opencode_config"],
+    quota: "remote_api",
+  },
+  {
+    id: "kimi-for-coding",
     autoSetup: "yes",
     authentication: "opencode_auth_api_key",
     authFallbacks: ["env_api_key", "global_opencode_config"],

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -60,10 +60,17 @@ async function getProviderAvailability(params: {
   provider: QuotaProvider;
   ctx: QuotaProviderContext;
 }): Promise<QuotaAvailability> {
-  return {
-    provider: params.provider,
-    ok: await params.provider.isAvailable(params.ctx),
-  };
+  try {
+    return {
+      provider: params.provider,
+      ok: await params.provider.isAvailable(params.ctx),
+    };
+  } catch {
+    return {
+      provider: params.provider,
+      ok: false,
+    };
+  }
 }
 
 export type CollectQuotaRenderDataResult = {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -60,17 +60,10 @@ async function getProviderAvailability(params: {
   provider: QuotaProvider;
   ctx: QuotaProviderContext;
 }): Promise<QuotaAvailability> {
-  try {
-    return {
-      provider: params.provider,
-      ok: await params.provider.isAvailable(params.ctx),
-    };
-  } catch {
-    return {
-      provider: params.provider,
-      ok: false,
-    };
-  }
+  return {
+    provider: params.provider,
+    ok: await params.provider.isAvailable(params.ctx),
+  };
 }
 
 export type CollectQuotaRenderDataResult = {
@@ -205,12 +198,7 @@ async function fetchProviderWithCache(params: {
   const now = Date.now();
   const existing = providerFetchCache.get(cacheKey);
 
-  if (
-    existing?.result &&
-    existing.timestamp > 0 &&
-    ttlMs > 0 &&
-    now - existing.timestamp < ttlMs
-  ) {
+  if (existing?.result && existing.timestamp > 0 && ttlMs > 0 && now - existing.timestamp < ttlMs) {
     return existing.result;
   }
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -32,6 +32,12 @@ import {
 } from "./minimax-auth.js";
 import { DEFAULT_ZAI_AUTH_CACHE_MAX_AGE_MS, getZaiAuthDiagnostics } from "./zai-auth.js";
 import {
+  DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS,
+  getKimiAuthDiagnostics,
+  resolveKimiAuthCached,
+} from "./kimi-auth.js";
+import { queryKimiQuota } from "./kimi.js";
+import {
   getPricingSnapshotHealth,
   getPricingRefreshPolicy,
   getPricingSnapshotMeta,
@@ -308,6 +314,14 @@ function supportedProviderPricingRow(params: {
     };
   }
 
+  if (id === "kimi-code") {
+    return {
+      id,
+      pricing: "no",
+      notes: "request quota via Kimi Code API (not token-priced)",
+    };
+  }
+
   // Providers that correspond directly to models.dev providers.
   if (params.snapshotProviders.includes(id)) {
     return { id, pricing: "yes", notes: "models.dev snapshot provider" };
@@ -431,7 +445,9 @@ export async function buildQuotaStatusReport(params: {
     lines.push(`- inferred_selected_config_path: ${params.tuiDiagnostics.inferredSelectedPath ?? "(none)"}`);
     lines.push(`- present_config_paths: ${joinOrNone(params.tuiDiagnostics.presentPaths)}`);
     lines.push(`- candidate_config_paths: ${joinOrNone(params.tuiDiagnostics.candidatePaths)}`);
-    lines.push(`- quota_plugin_configured: ${params.tuiDiagnostics.quotaPluginConfigured ? "true" : "false"}`);
+    lines.push(
+      `- quota_plugin_configured: ${params.tuiDiagnostics.quotaPluginConfigured ? "true" : "false"}`,
+    );
     lines.push(`- quota_plugin_paths: ${joinOrNone(params.tuiDiagnostics.quotaPluginConfigPaths)}`);
   }
   lines.push("- providers:");
@@ -491,9 +507,7 @@ export async function buildQuotaStatusReport(params: {
     `- alibaba auth configured: ${alibabaAuthDiagnostics.state === "none" ? "false" : "true"}`,
   );
   lines.push(`- alibaba_api_key_source: ${alibabaAuthDiagnostics.source ?? "(none)"}`);
-  lines.push(
-    `- alibaba_api_key_checked_paths: ${joinOrNone(alibabaAuthDiagnostics.checkedPaths)}`,
-  );
+  lines.push(`- alibaba_api_key_checked_paths: ${joinOrNone(alibabaAuthDiagnostics.checkedPaths)}`);
   lines.push(`- alibaba_api_key_auth_paths: ${joinOrNone(alibabaAuthDiagnostics.authPaths)}`);
   lines.push(`- alibaba coding plan fallback tier: ${params.alibabaCodingPlanTier}`);
   lines.push(
@@ -691,6 +705,37 @@ export async function buildQuotaStatusReport(params: {
         if (!fiveHourEntry && !weeklyEntry) {
           lines.push("- live_state: no reportable MiniMax Coding Plan quota");
         }
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push("kimi:");
+  const kimiAuth = await getKimiAuthDiagnostics({
+    maxAgeMs: DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS,
+  });
+  lines.push(`- auth_state: ${kimiAuth.state}`);
+  lines.push(`- api_key_configured: ${kimiAuth.state === "configured" ? "true" : "false"}`);
+  lines.push(`- api_key_source: ${kimiAuth.source ?? "(none)"}`);
+  lines.push(`- api_key_checked_paths: ${joinOrNone(kimiAuth.checkedPaths)}`);
+  lines.push(`- api_key_auth_paths: ${joinOrNone(kimiAuth.authPaths)}`);
+  if (kimiAuth.state === "invalid") {
+    lines.push(`- auth_error: ${sanitizeDisplayText(kimiAuth.error)}`);
+  }
+  if (kimiAuth.state === "configured") {
+    const kimiQuota = await queryKimiQuota();
+    if (!kimiQuota) {
+      lines.push("- live_fetch_error: Kimi API key became unavailable before fetch");
+    } else if (!kimiQuota.success) {
+      lines.push(`- live_fetch_error: ${kimiQuota.error}`);
+    } else {
+      for (const window of kimiQuota.windows) {
+        lines.push(
+          `- ${window.label.toLowerCase().replace(/\s+/g, "_")}: used=${window.used}/${window.limit} percent_remaining=${window.percentRemaining} reset_at=${window.resetTimeIso ?? "(none)"}`,
+        );
+      }
+      if (kimiQuota.windows.length === 0) {
+        lines.push("- live_state: no reportable Kimi quota");
       }
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -266,6 +266,8 @@ export interface AuthData {
     key: string;
   };
   "minimax-coding-plan"?: MiniMaxAuthData;
+  "kimi-code"?: KimiAuthData;
+  kimi?: KimiAuthData;
 }
 
 // =============================================================================
@@ -312,6 +314,34 @@ export interface GoogleQuotaResponse {
     }
   >;
 }
+
+// =============================================================================
+// Kimi Types
+// =============================================================================
+
+/** Kimi auth entry in auth.json */
+export interface KimiAuthData {
+  type: "api";
+  key: string;
+}
+
+/** Kimi quota window */
+export interface KimiQuotaWindow {
+  label: string;
+  used: number;
+  limit: number;
+  percentRemaining: number;
+  resetTimeIso?: string;
+}
+
+/** Result from fetching Kimi quota */
+export interface KimiQuotaResult {
+  success: true;
+  label: string;
+  windows: KimiQuotaWindow[];
+}
+
+export type KimiResult = KimiQuotaResult | QuotaError | null;
 
 // =============================================================================
 // Z.ai Types

--- a/src/providers/kimi-code.ts
+++ b/src/providers/kimi-code.ts
@@ -61,7 +61,7 @@ export const kimiCodeProvider: QuotaProvider = {
       return attemptedErrorResult("Kimi Code", result.error);
     }
 
-    const style = ctx.config.toastStyle ?? "classic";
+    const style = ctx.config.formatStyle ?? "classic";
 
     if (style === "classic") {
       const worst = [...result.windows].sort((a, b) => a.percentRemaining - b.percentRemaining)[0];

--- a/src/providers/kimi-code.ts
+++ b/src/providers/kimi-code.ts
@@ -1,0 +1,91 @@
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import { queryKimiQuota } from "../lib/kimi.js";
+import { DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS, resolveKimiAuthCached } from "../lib/kimi-auth.js";
+import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
+import { normalizeQuotaProviderId } from "../lib/provider-metadata.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+function formatUsageRight(window: { used: number; limit: number }): string {
+  return `${window.used}/${window.limit}`;
+}
+
+export const kimiCodeProvider: QuotaProvider = {
+  id: "kimi-for-coding",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const providerAvailable = await isCanonicalProviderAvailable({
+      ctx,
+      providerId: "kimi-for-coding",
+      fallbackOnError: false,
+    });
+    if (!providerAvailable) {
+      return false;
+    }
+
+    const auth = await resolveKimiAuthCached({
+      maxAgeMs: DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS,
+    });
+    return auth.state === "configured" || auth.state === "invalid";
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    const [provider] = model.toLowerCase().split("/", 2);
+    return normalizeQuotaProviderId(provider) === "kimi-for-coding";
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const auth = await resolveKimiAuthCached({
+      maxAgeMs: DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS,
+    });
+
+    if (auth.state === "none") {
+      return notAttemptedResult();
+    }
+
+    if (auth.state === "invalid") {
+      return attemptedErrorResult("Kimi Code", auth.error);
+    }
+
+    const result = await queryKimiQuota();
+
+    if (!result) {
+      return notAttemptedResult();
+    }
+
+    if (!result.success) {
+      return attemptedErrorResult("Kimi Code", result.error);
+    }
+
+    const style = ctx.config.toastStyle ?? "classic";
+
+    if (style === "classic") {
+      const worst = [...result.windows].sort((a, b) => a.percentRemaining - b.percentRemaining)[0];
+      if (!worst) {
+        return attemptedResult([]);
+      }
+      return attemptedResult([
+        {
+          name: result.label,
+          percentRemaining: worst.percentRemaining,
+          resetTimeIso: worst.resetTimeIso,
+        },
+      ]);
+    }
+
+    const entries: QuotaToastEntry[] = result.windows.map((window) => ({
+      name: `${result.label} ${window.label}`,
+      group: result.label,
+      label: `${window.label}:`,
+      right: formatUsageRight(window),
+      percentRemaining: window.percentRemaining,
+      resetTimeIso: window.resetTimeIso,
+    }));
+
+    return attemptedResult(entries);
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -18,6 +18,7 @@ import { zaiProvider } from "./zai.js";
 import { nanoGptProvider } from "./nanogpt.js";
 import { minimaxCodingPlanProvider } from "./minimax-coding-plan.js";
 import { opencodeGoProvider } from "./opencode-go.js";
+import { kimiCodeProvider } from "./kimi-code.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
@@ -34,6 +35,7 @@ export function getProviders(): QuotaProvider[] {
     zaiProvider,
     nanoGptProvider,
     minimaxCodingPlanProvider,
+    kimiCodeProvider,
     opencodeGoProvider,
   ];
 }

--- a/tests/lib.kimi.test.ts
+++ b/tests/lib.kimi.test.ts
@@ -132,34 +132,8 @@ describe("queryKimiQuota", () => {
     });
   });
 
-  it("falls back to Moonshot endpoint when Kimi endpoint returns non-200", async () => {
+  it("returns error when endpoint fails", async () => {
     mockKimiAuthConfigured();
-    mockKimiHttpFailure(404, "not found");
-    mockKimiHttpSuccess({
-      usage: {
-        limit: 50,
-        used: 10,
-      },
-    });
-
-    const result = await queryKimiQuota();
-
-    expect(result).toMatchObject({
-      success: true,
-      windows: [
-        {
-          label: "Weekly limit",
-          used: 10,
-          limit: 50,
-          percentRemaining: 80,
-        },
-      ],
-    });
-  });
-
-  it("returns error when both endpoints fail", async () => {
-    mockKimiAuthConfigured();
-    mockKimiHttpFailure(401, "Unauthorized");
     mockKimiHttpFailure(401, "Unauthorized");
 
     const result = await queryKimiQuota();
@@ -170,10 +144,9 @@ describe("queryKimiQuota", () => {
     });
   });
 
-  it("returns error with unexpected response keys when both endpoints have no usable data", async () => {
+  it("returns error with unexpected response keys when endpoint has no usable data", async () => {
     mockKimiAuthConfigured();
     mockKimiHttpSuccess({ message: "hello", code: 0 });
-    mockKimiHttpSuccess({ foo: "bar" });
 
     const result = await queryKimiQuota();
 
@@ -185,7 +158,6 @@ describe("queryKimiQuota", () => {
 
   it("returns API error on non-200 with sanitized text", async () => {
     mockKimiAuthConfigured();
-    mockKimiHttpFailure(403, "Forbidden access");
     mockKimiHttpFailure(403, "Forbidden access");
 
     const result = await queryKimiQuota();

--- a/tests/lib.kimi.test.ts
+++ b/tests/lib.kimi.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authMocks = vi.hoisted(() => ({
+  resolveKimiAuthCached: vi.fn(),
+}));
+
+const fetchMocks = vi.hoisted(() => ({
+  fetchWithTimeout: vi.fn(),
+}));
+
+vi.mock("../src/lib/kimi-auth.js", () => ({
+  resolveKimiAuthCached: authMocks.resolveKimiAuthCached,
+  DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS: 5_000,
+}));
+
+vi.mock("../src/lib/http.js", () => ({
+  fetchWithTimeout: fetchMocks.fetchWithTimeout,
+}));
+
+import { queryKimiQuota } from "../src/lib/kimi.js";
+
+function mockKimiAuthConfigured(apiKey = "test-key") {
+  authMocks.resolveKimiAuthCached.mockResolvedValueOnce({ state: "configured", apiKey });
+}
+
+function mockKimiHttpSuccess(payload: unknown) {
+  fetchMocks.fetchWithTimeout.mockResolvedValueOnce({
+    ok: true,
+    json: async () => payload,
+  });
+}
+
+function mockKimiHttpFailure(status: number, text: string) {
+  fetchMocks.fetchWithTimeout.mockResolvedValueOnce({
+    ok: false,
+    status,
+    text: async () => text,
+  });
+}
+
+describe("queryKimiQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.resolveKimiAuthCached.mockResolvedValue({ state: "configured", apiKey: "test-key" });
+  });
+
+  it("returns null when auth is none", async () => {
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({ state: "none" });
+    const result = await queryKimiQuota();
+    expect(result).toBeNull();
+  });
+
+  it("returns error when auth is invalid", async () => {
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({ state: "invalid", error: "bad auth" });
+    const result = await queryKimiQuota();
+    expect(result).toEqual({ success: false, error: "bad auth" });
+  });
+
+  it("parses string numbers from real API shape", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpSuccess({
+      usage: {
+        limit: "100",
+        used: "45",
+        remaining: "55",
+        resetTime: "2026-04-16T15:36:21.718434Z",
+      },
+      limits: [
+        {
+          window: {
+            duration: 300,
+            timeUnit: "TIME_UNIT_MINUTE",
+          },
+          detail: {
+            limit: "100",
+            used: "22",
+            remaining: "78",
+            resetTime: "2026-04-16T16:36:21.718434Z",
+          },
+        },
+      ],
+      parallel: {
+        limit: "20",
+      },
+    });
+
+    const result = await queryKimiQuota();
+
+    expect(result).toMatchObject({
+      success: true,
+      label: "Kimi Code",
+      windows: [
+        {
+          label: "Weekly limit",
+          used: 45,
+          limit: 100,
+          percentRemaining: 55,
+          resetTimeIso: "2026-04-16T15:36:21.718Z",
+        },
+        {
+          label: "5h limit",
+          used: 22,
+          limit: 100,
+          percentRemaining: 78,
+          resetTimeIso: "2026-04-16T16:36:21.718Z",
+        },
+      ],
+    });
+  });
+
+  it("computes used from remaining when used is absent", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpSuccess({
+      usage: {
+        limit: "100",
+        remaining: "30",
+      },
+    });
+
+    const result = await queryKimiQuota();
+
+    expect(result).toMatchObject({
+      success: true,
+      windows: [
+        {
+          label: "Weekly limit",
+          used: 70,
+          limit: 100,
+          percentRemaining: 30,
+        },
+      ],
+    });
+  });
+
+  it("falls back to Moonshot endpoint when Kimi endpoint returns non-200", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpFailure(404, "not found");
+    mockKimiHttpSuccess({
+      usage: {
+        limit: 50,
+        used: 10,
+      },
+    });
+
+    const result = await queryKimiQuota();
+
+    expect(result).toMatchObject({
+      success: true,
+      windows: [
+        {
+          label: "Weekly limit",
+          used: 10,
+          limit: 50,
+          percentRemaining: 80,
+        },
+      ],
+    });
+  });
+
+  it("returns error when both endpoints fail", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpFailure(401, "Unauthorized");
+    mockKimiHttpFailure(401, "Unauthorized");
+
+    const result = await queryKimiQuota();
+
+    expect(result).toEqual({
+      success: false,
+      error: "Kimi API error 401: Unauthorized",
+    });
+  });
+
+  it("returns error with unexpected response keys when both endpoints have no usable data", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpSuccess({ message: "hello", code: 0 });
+    mockKimiHttpSuccess({ foo: "bar" });
+
+    const result = await queryKimiQuota();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Unexpected response structure (keys: message, code)",
+    });
+  });
+
+  it("returns API error on non-200 with sanitized text", async () => {
+    mockKimiAuthConfigured();
+    mockKimiHttpFailure(403, "Forbidden access");
+    mockKimiHttpFailure(403, "Forbidden access");
+
+    const result = await queryKimiQuota();
+
+    expect(result).toMatchObject({
+      success: false,
+      error: "Kimi API error 403: Forbidden access",
+    });
+  });
+
+  it("sanitizes thrown errors", async () => {
+    mockKimiAuthConfigured();
+    fetchMocks.fetchWithTimeout.mockRejectedValue(new Error("network error"));
+
+    const result = await queryKimiQuota();
+
+    expect(result).toEqual({
+      success: false,
+      error: "network error",
+    });
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -98,6 +98,13 @@ describe("provider-metadata", () => {
         quota: "remote_api",
       },
       {
+        id: "kimi-for-coding",
+        autoSetup: "yes",
+        authentication: "opencode_auth_api_key",
+        authFallbacks: ["env_api_key", "global_opencode_config"],
+        quota: "remote_api",
+      },
+      {
         id: "opencode-go",
         autoSetup: "needs_quick_setup",
         authentication: "state_only",
@@ -144,6 +151,11 @@ describe("provider-metadata", () => {
       "minimax-coding-plan",
       "minimax",
     ]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS["kimi-for-coding"]).toEqual([
+      "kimi-for-coding",
+      "kimi",
+      "kimi-code",
+    ]);
   });
 
   it("keeps runtime ids distinct from broad normalization aliases", () => {
@@ -163,6 +175,7 @@ describe("provider-metadata", () => {
     ]);
     expect(getQuotaProviderRuntimeIds("zai")).toEqual(["zai", "glm", "zai-coding-plan"]);
     expect(getQuotaProviderRuntimeIds("minimax")).toEqual(["minimax-coding-plan", "minimax"]);
+    expect(getQuotaProviderRuntimeIds("kimi")).toEqual(["kimi-for-coding", "kimi", "kimi-code"]);
     expect(getQuotaProviderRuntimeIds("not-a-provider")).toEqual([]);
   });
 
@@ -199,6 +212,8 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("nanogpt")).toBe("NanoGPT");
     expect(getQuotaProviderDisplayLabel("nano-gpt")).toBe("NanoGPT");
     expect(getQuotaProviderDisplayLabel("minimax")).toBe("MiniMax Coding Plan");
+    expect(getQuotaProviderDisplayLabel("kimi-code")).toBe("Kimi Code");
+    expect(getQuotaProviderDisplayLabel("kimi")).toBe("Kimi Code");
     expect(getQuotaProviderDisplayLabel("something-else")).toBe("something-else");
   });
 });

--- a/tests/providers.kimi-code.test.ts
+++ b/tests/providers.kimi-code.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+
+const authMocks = vi.hoisted(() => ({
+  resolveKimiAuthCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/kimi-auth.js", () => ({
+  resolveKimiAuthCached: authMocks.resolveKimiAuthCached,
+  DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS: 5_000,
+}));
+
+vi.mock("../src/lib/kimi.js", () => ({
+  queryKimiQuota: vi.fn(),
+}));
+
+vi.mock("../src/lib/provider-availability.js", () => ({
+  isCanonicalProviderAvailable: vi.fn(),
+}));
+
+import { kimiCodeProvider } from "../src/providers/kimi-code.js";
+
+describe("kimi-code provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.resolveKimiAuthCached.mockResolvedValue({
+      state: "configured",
+      apiKey: "test-key",
+    });
+  });
+
+  it("returns attempted:false when no kimi auth is configured", async () => {
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({ state: "none" });
+
+    const out = await kimiCodeProvider.fetch({ config: {} } as any);
+    expectNotAttempted(out);
+  });
+
+  it("returns error when kimi auth is invalid", async () => {
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({
+      state: "invalid",
+      error: "Invalid API key",
+    });
+
+    const out = await kimiCodeProvider.fetch({ config: {} } as any);
+    expectAttemptedWithErrorLabel(out, "Kimi Code");
+    expect(out.errors[0]?.message).toBe("Invalid API key");
+  });
+
+  it("maps success into grouped entries for all windows", async () => {
+    const { queryKimiQuota } = await import("../src/lib/kimi.js");
+    (queryKimiQuota as any).mockResolvedValueOnce({
+      success: true,
+      label: "Kimi Code",
+      windows: [
+        {
+          label: "Weekly limit",
+          used: 250,
+          limit: 1000,
+          percentRemaining: 75,
+          resetTimeIso: "2026-01-08T00:00:00.000Z",
+        },
+        {
+          label: "5h limit",
+          used: 100,
+          limit: 500,
+          percentRemaining: 80,
+          resetTimeIso: "2026-01-01T05:00:00.000Z",
+        },
+      ],
+    });
+
+    const out = await kimiCodeProvider.fetch({ config: { toastStyle: "grouped" } } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "Kimi Code Weekly limit",
+        group: "Kimi Code",
+        label: "Weekly limit:",
+        right: "250/1000",
+        percentRemaining: 75,
+        resetTimeIso: "2026-01-08T00:00:00.000Z",
+      },
+      {
+        name: "Kimi Code 5h limit",
+        group: "Kimi Code",
+        label: "5h limit:",
+        right: "100/500",
+        percentRemaining: 80,
+        resetTimeIso: "2026-01-01T05:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("maps success into a single toast entry (classic) using worst window", async () => {
+    const { queryKimiQuota } = await import("../src/lib/kimi.js");
+    (queryKimiQuota as any).mockResolvedValueOnce({
+      success: true,
+      label: "Kimi Code",
+      windows: [
+        {
+          label: "Weekly limit",
+          used: 250,
+          limit: 1000,
+          percentRemaining: 75,
+          resetTimeIso: "2026-01-08T00:00:00.000Z",
+        },
+        {
+          label: "5h limit",
+          used: 100,
+          limit: 500,
+          percentRemaining: 80,
+          resetTimeIso: "2026-01-01T05:00:00.000Z",
+        },
+      ],
+    });
+
+    const out = await kimiCodeProvider.fetch({ config: { toastStyle: "classic" } } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "Kimi Code",
+        percentRemaining: 75,
+        resetTimeIso: "2026-01-08T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("maps errors into toast errors", async () => {
+    const { queryKimiQuota } = await import("../src/lib/kimi.js");
+    (queryKimiQuota as any).mockResolvedValueOnce({
+      success: false,
+      error: "Unauthorized",
+    });
+
+    const out = await kimiCodeProvider.fetch({} as any);
+    expectAttemptedWithErrorLabel(out, "Kimi Code");
+  });
+
+  it("matches kimi model ids", () => {
+    expect(kimiCodeProvider.matchesCurrentModel?.("kimi-code/kimi-k2")).toBe(true);
+    expect(kimiCodeProvider.matchesCurrentModel?.("kimi/kimi-k2")).toBe(true);
+    expect(kimiCodeProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+
+  it("is available when provider ids include kimi and auth is configured", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValue(true);
+
+    const available = await kimiCodeProvider.isAvailable({} as any);
+    expect(available).toBe(true);
+  });
+
+  it("is available when auth is invalid so the provider can surface the error", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValue(true);
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({
+      state: "invalid",
+      error: 'Unsupported Kimi auth type: "oauth"',
+    });
+
+    const available = await kimiCodeProvider.isAvailable({} as any);
+    expect(available).toBe(true);
+  });
+
+  it("is not available when provider ids exist but auth is missing", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValue(true);
+    authMocks.resolveKimiAuthCached.mockResolvedValueOnce({ state: "none" });
+
+    const available = await kimiCodeProvider.isAvailable({} as any);
+    expect(available).toBe(false);
+  });
+
+  it("is not available when provider lookup throws", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    (isCanonicalProviderAvailable as any).mockRestore();
+
+    const ctx = {
+      client: {
+        config: {
+          providers: vi.fn().mockRejectedValue(new Error("boom")),
+          get: vi.fn(),
+        },
+      },
+      config: { googleModels: [] },
+    } as any;
+
+    const available = await kimiCodeProvider.isAvailable(ctx);
+    expect(available).toBe(false);
+    expect(authMocks.resolveKimiAuthCached).not.toHaveBeenCalled();
+  });
+});

--- a/tests/providers.kimi-code.test.ts
+++ b/tests/providers.kimi-code.test.ts
@@ -75,7 +75,7 @@ describe("kimi-code provider", () => {
       ],
     });
 
-    const out = await kimiCodeProvider.fetch({ config: { toastStyle: "grouped" } } as any);
+    const out = await kimiCodeProvider.fetch({ config: { formatStyle: "grouped" } } as any);
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toEqual([
       {
@@ -120,7 +120,7 @@ describe("kimi-code provider", () => {
       ],
     });
 
-    const out = await kimiCodeProvider.fetch({ config: { toastStyle: "classic" } } as any);
+    const out = await kimiCodeProvider.fetch({ config: { formatStyle: "classic" } } as any);
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toEqual([
       {


### PR DESCRIPTION
## Summary

Introduce the Kimi Code provider, enabling authentication through environment variables and configuration files. Implement a quota fetcher with string-number parsing and a fallback mechanism. Add tests for the new provider and ensure alignment of package dependencies. This enhancement expands the functionality of the application by integrating Kimi's services.

<img width="812" height="191" alt="image" src="https://github.com/user-attachments/assets/3ac20c4b-e095-4322-bae9-5e7996f95d4e" />


## Linked Issue

https://github.com/slkiser/opencode-quota/issues/45

## OpenCode Validation

- Current production released OpenCode version tested: 1.4.6
- Why this version is relevant to the fix:

## Quality Checklist

- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
