### PR TITLE
Improve Copilot quota handling and show session request counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,7 +677,7 @@ Project/workspace config may override display-oriented settings for that project
 | `formatStyle`                 | `classic` | Shared quota-row style for popup toasts and the TUI sidebar: `classic` or `grouped`. Legacy `toastStyle` is still accepted on read for backward compatibility, but `formatStyle` is the canonical key.       |
 | `percentDisplayMode`          | `remaining` | Shared percent meaning for popup toasts and the TUI sidebar: `remaining` renders labels like `81% left`, while `used` renders labels like `19% used`; the bar fill always matches the shown meaning.        |
 | `onlyCurrentModel`            | `false`   | Filter quota rows to the current model/provider when that session selection can be resolved.                                                                                                                 |
-| `showSessionTokens`           | `true`    | Show the `Session input/output tokens` section in quota displays when session token data is available. Toasts and `/quota` show per-model input/output rows; the TUI sidebar shows a one-line total summary. |
+| `showSessionTokens`           | `true`    | Show the `Session input/output tokens` section in quota displays when session token data is available. Toasts and `/quota` show per-model input/output rows plus a per-session request count line; the TUI sidebar shows a one-line total summary plus the same request count line. |
 | `pricingSnapshot.source`      | `"auto"`  | Token pricing snapshot selection for `/tokens_*`: `auto`, `bundled`, or `runtime`.                                                                                                                           |
 | `pricingSnapshot.autoRefresh` | `7`       | Refresh stale local pricing data after this many days.                                                                                                                                                       |
 
@@ -766,5 +766,4 @@ OpenCode Quota is not built by the OpenCode team and is not affiliated with Open
 
 ## Star History
 [![Star History Chart](https://api.star-history.com/chart?repos=slkiser/opencode-quota&type=date&legend=bottom-right)](https://www.star-history.com/?repos=slkiser%2Fopencode-quota&type=date&legend=bottom-right)
-
 

--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -857,8 +857,8 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     return {
       success: true,
       mode: "user_quota",
-      used: used ?? 0,
-      total: total ?? 1,
+      used: Math.max(0, used ?? 0),
+      total: Math.max(1, total ?? 1),
       percentRemaining:
         explicitPercentRemaining !== undefined
           ? Math.max(0, Math.min(100, Math.floor(explicitPercentRemaining)))

--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -26,6 +26,7 @@ import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
 
 const GITHUB_API_BASE_URL = "https://api.github.com";
 const COPILOT_INTERNAL_USER_URL = `${GITHUB_API_BASE_URL}/copilot_internal/user`;
+const COPILOT_REQUEST_TIMEOUT_MS = 10000;
 const GITHUB_API_VERSION = "2022-11-28";
 const COPILOT_QUOTA_CONFIG_FILENAME = "copilot-quota-token.json";
 const USER_AGENT = "opencode-quota/copilot-billing";
@@ -643,7 +644,7 @@ async function fetchGitHubRestJsonOnce<T>(
 ): Promise<{ ok: true; status: number; data: T } | { ok: false; status: number; message: string }> {
   const response = await fetchWithTimeout(url, {
     headers: buildGitHubRestHeaders(token, scheme),
-  });
+  }, COPILOT_REQUEST_TIMEOUT_MS);
 
   if (response.ok) {
     return { ok: true, status: response.status, data: (await response.json()) as T };

--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -189,6 +189,11 @@ function getFirstNestedString(source: unknown, paths: string[][]): string | unde
   return coerceNonEmptyString(getFirstNestedValue(source, paths));
 }
 
+function getFirstNestedBoolean(source: unknown, paths: string[][]): boolean | undefined {
+  const value = getFirstNestedValue(source, paths);
+  return typeof value === "boolean" ? value : undefined;
+}
+
 function normalizeCopilotTier(value: string | undefined): CopilotTier | undefined {
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return undefined;
@@ -803,6 +808,22 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     ["quota_reset_date"],
     ["quota_reset_at"],
   ];
+  const percentRemainingPaths = [
+    ["quota", "percent_remaining"],
+    ["monthly_quota", "percent_remaining"],
+    ["monthly_premium_requests", "percent_remaining"],
+    ["premium_requests", "percent_remaining"],
+    ["quota_snapshots", "premium_interactions", "percent_remaining"],
+    ["percent_remaining"],
+  ];
+  const unlimitedPaths = [
+    ["quota", "unlimited"],
+    ["monthly_quota", "unlimited"],
+    ["monthly_premium_requests", "unlimited"],
+    ["premium_requests", "unlimited"],
+    ["quota_snapshots", "premium_interactions", "unlimited"],
+    ["unlimited"],
+  ];
   const tierPaths = [
     ["plan", "type"],
     ["plan", "name"],
@@ -815,6 +836,8 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
   let total = getFirstNestedNumber(response, totalPaths);
   let used = getFirstNestedNumber(response, usedPaths);
   const remaining = getFirstNestedNumber(response, remainingPaths);
+  const unlimited = getFirstNestedBoolean(response, unlimitedPaths) === true;
+  const explicitPercentRemaining = getFirstNestedNumber(response, percentRemainingPaths);
   const resetTimeIso =
     normalizeResetTimeIso(getFirstNestedString(response, resetPaths)) ?? getApproxNextResetIso();
   const tier = normalizeCopilotTier(getFirstNestedString(response, tierPaths));
@@ -829,6 +852,21 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     total = COPILOT_PLAN_LIMITS[tier];
   }
 
+  if (unlimited) {
+    return {
+      success: true,
+      mode: "user_quota",
+      used: used ?? 0,
+      total: total ?? 1,
+      percentRemaining:
+        explicitPercentRemaining !== undefined
+          ? Math.max(0, Math.min(100, Math.floor(explicitPercentRemaining)))
+          : 100,
+      unlimited: true,
+      resetTimeIso,
+    };
+  }
+
   if (!Number.isFinite(total) || total === undefined || total <= 0 || used === undefined || used < 0) {
     throw new Error(
       "GitHub /copilot_internal/user response did not include usable personal quota fields.",
@@ -840,7 +878,10 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     mode: "user_quota",
     used,
     total,
-    percentRemaining: computePercentRemainingFromUsed({ used, total }),
+    percentRemaining:
+      explicitPercentRemaining !== undefined
+        ? Math.max(0, Math.min(100, Math.floor(explicitPercentRemaining)))
+        : computePercentRemainingFromUsed({ used, total }),
     resetTimeIso,
   };
 }
@@ -1108,6 +1149,10 @@ export function formatCopilotQuota(result: CopilotResult): string | null {
       details.push(`user=${result.username}`);
     }
     return `Copilot Enterprise (${result.enterprise}) ${details.join(" | ")}`;
+  }
+
+  if (result.unlimited) {
+    return "Copilot Unlimited";
   }
 
   const percentUsed = 100 - result.percentRemaining;

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -77,6 +77,7 @@ export interface SessionTokensData {
   models: SessionTokenModel[];
   totalInput: number;
   totalOutput: number;
+  requestCount?: number;
 }
 
 export interface QuotaProviderResult {

--- a/src/lib/quota-stats.ts
+++ b/src/lib/quota-stats.ts
@@ -816,7 +816,7 @@ export async function aggregateUsage(params: {
 
 /**
  * Lightweight session token summary for toast display.
- * Returns per-model input/output totals for a single session.
+ * Returns per-model input/output totals and request count for a single session.
  */
 export type SessionTokenRow = {
   modelID: string;
@@ -829,6 +829,7 @@ export type SessionTokenSummary = {
   models: SessionTokenRow[];
   totalInput: number;
   totalOutput: number;
+  requestCount: number;
 };
 
 export async function getSessionTokenSummary(
@@ -877,5 +878,6 @@ export async function getSessionTokenSummary(
     models,
     totalInput,
     totalOutput,
+    requestCount: sessionMessages.length,
   };
 }

--- a/src/lib/session-tokens-format.ts
+++ b/src/lib/session-tokens-format.ts
@@ -19,8 +19,8 @@ function formatSessionRequestLine(requestCount?: number): string | null {
   if (typeof requestCount !== "number" || !Number.isFinite(requestCount)) return null;
   const safeCount = Math.max(0, Math.trunc(requestCount));
   if (safeCount <= 0) return null;
-  const label = safeCount === 1 ? "request" : "requests";
-  return `  (${safeCount} ${label} this session)`;
+  const label = safeCount === 1 ? "assistant response" : "assistant responses";
+  return `  ${safeCount} ${label}`;
 }
 
 function appendSessionRequestLine(

--- a/src/lib/session-tokens-format.ts
+++ b/src/lib/session-tokens-format.ts
@@ -15,6 +15,24 @@ export type SessionTokenSectionModel = {
   lines: string[];
 };
 
+function formatSessionRequestLine(requestCount?: number): string | null {
+  if (typeof requestCount !== "number" || !Number.isFinite(requestCount)) return null;
+  const safeCount = Math.max(0, Math.trunc(requestCount));
+  if (safeCount <= 0) return null;
+  const label = safeCount === 1 ? "request" : "requests";
+  return `  (${safeCount} ${label} this session)`;
+}
+
+function appendSessionRequestLine(
+  lines: string[],
+  sessionTokens: SessionTokensData,
+  maxWidth?: number,
+): void {
+  const requestLine = formatSessionRequestLine(sessionTokens.requestCount);
+  if (!requestLine) return;
+  lines.push(clampRenderedLine(requestLine, maxWidth));
+}
+
 function normalizeMaxWidth(maxWidth?: number): number | undefined {
   if (typeof maxWidth !== "number" || !Number.isFinite(maxWidth)) return undefined;
   return Math.max(1, Math.trunc(maxWidth));
@@ -33,6 +51,8 @@ function buildWideSessionTokenSectionModel(sessionTokens: SessionTokensData): Se
     const outStr = formatTokenCount(model.output);
     lines.push(`  ${padRight(shortName, 20)}  ${padLeft(inStr, 6)} in  ${padLeft(outStr, 6)} out`);
   }
+
+  appendSessionRequestLine(lines, sessionTokens);
 
   return {
     heading: SESSION_TOKEN_SECTION_HEADING,
@@ -66,6 +86,8 @@ function buildCompactSessionTokenSectionModel(
     lines.push(`${detailIndent}${outStr} out`.slice(0, width));
   }
 
+  appendSessionRequestLine(lines, sessionTokens, width);
+
   return {
     heading: SESSION_TOKEN_SECTION_HEADING.slice(0, width),
     lines,
@@ -77,9 +99,13 @@ function buildSidebarSessionTokenSummaryModel(
   options?: { maxWidth?: number },
 ): SessionTokenSectionModel {
   const summaryLine = `  ${formatTokenCount(sessionTokens.totalInput)} in  ${formatTokenCount(sessionTokens.totalOutput)} out`;
+  const requestLine = formatSessionRequestLine(sessionTokens.requestCount);
   return {
     heading: clampRenderedLine(SESSION_TOKEN_SECTION_HEADING, options?.maxWidth),
-    lines: [clampRenderedLine(summaryLine, options?.maxWidth)],
+    lines: [
+      clampRenderedLine(summaryLine, options?.maxWidth),
+      ...(requestLine ? [clampRenderedLine(requestLine, options?.maxWidth)] : []),
+    ],
   };
 }
 

--- a/src/lib/session-tokens.ts
+++ b/src/lib/session-tokens.ts
@@ -36,6 +36,7 @@ export async function fetchSessionTokensForDisplay(params: {
           models: summary.models,
           totalInput: summary.totalInput,
           totalOutput: summary.totalOutput,
+          requestCount: summary.requestCount,
         },
       };
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -408,6 +408,7 @@ export interface CopilotQuotaResult {
   used: number;
   total: number;
   percentRemaining: number;
+  unlimited?: boolean;
   resetTimeIso?: string;
 }
 
@@ -546,7 +547,7 @@ export interface CachedToast {
 // =============================================================================
 
 /** Request timeout in milliseconds */
-export const REQUEST_TIMEOUT_MS = 3000;
+export const REQUEST_TIMEOUT_MS = 10000;
 
 /** Model key mapping for Google API */
 export const GOOGLE_MODEL_KEYS: Record<

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -547,7 +547,7 @@ export interface CachedToast {
 // =============================================================================
 
 /** Request timeout in milliseconds */
-export const REQUEST_TIMEOUT_MS = 10000;
+export const REQUEST_TIMEOUT_MS = 3000;
 
 /** Model key mapping for Google API */
 export const GOOGLE_MODEL_KEYS: Record<

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -34,6 +34,86 @@ function formatManagedUsageValue(
   return parts.join(" | ");
 }
 
+function buildManagedUsageEntry(
+  result: CopilotOrganizationUsageResult | CopilotEnterpriseUsageResult,
+  style: "classic" | "grouped",
+) {
+  if (style === "grouped") {
+    return {
+      kind: "value" as const,
+      name: "Copilot",
+      group: getCopilotGroup(result.mode),
+      label: "Usage:",
+      value: formatManagedUsageValue(result),
+      resetTimeIso: result.resetTimeIso,
+    };
+  }
+
+  return {
+    kind: "value" as const,
+    name:
+      result.mode === "enterprise_usage"
+        ? `Copilot Enterprise (${result.enterprise})`
+        : `Copilot Org (${result.organization})`,
+    value:
+      result.mode === "enterprise_usage"
+        ? [
+            `${result.used} used`,
+            formatBillingPeriod(result.period),
+            ...(result.organization ? [`org=${result.organization}`] : []),
+            ...(result.username ? [`user=${result.username}`] : []),
+          ].join(" | ")
+        : [
+            `${result.used} used`,
+            formatBillingPeriod(result.period),
+            ...(result.username ? [`user=${result.username}`] : []),
+          ].join(" | "),
+    resetTimeIso: result.resetTimeIso,
+  };
+}
+
+function buildUserQuotaEntry(
+  result: Extract<Awaited<ReturnType<typeof queryCopilotQuota>>, { success: true; mode: "user_quota" }>,
+  style: "classic" | "grouped",
+) {
+  if (result.unlimited) {
+    if (style === "grouped") {
+      return {
+        kind: "value" as const,
+        name: "Copilot",
+        group: getCopilotGroup(result.mode),
+        label: "Quota:",
+        value: "Unlimited",
+        resetTimeIso: result.resetTimeIso,
+      };
+    }
+
+    return {
+      kind: "value" as const,
+      name: "Copilot",
+      value: "Unlimited",
+      resetTimeIso: result.resetTimeIso,
+    };
+  }
+
+  if (style === "grouped") {
+    return {
+      name: "Copilot",
+      group: getCopilotGroup(result.mode),
+      label: "Quota:",
+      right: `${result.used}/${result.total}`,
+      percentRemaining: result.percentRemaining,
+      resetTimeIso: result.resetTimeIso,
+    };
+  }
+
+  return {
+    name: "Copilot",
+    percentRemaining: result.percentRemaining,
+    resetTimeIso: result.resetTimeIso,
+  };
+}
+
 export const copilotProvider: QuotaProvider = {
   id: "copilot",
 
@@ -77,70 +157,8 @@ export const copilotProvider: QuotaProvider = {
       attempted: true,
       entries:
         result.mode === "organization_usage" || result.mode === "enterprise_usage"
-          ? [
-              style === "grouped"
-                ? {
-                  kind: "value",
-                  name: "Copilot",
-                  group: getCopilotGroup(result.mode),
-                  label: "Usage:",
-                  value: formatManagedUsageValue(result),
-                  resetTimeIso: result.resetTimeIso,
-                }
-                : {
-                  kind: "value",
-                  name:
-                    result.mode === "enterprise_usage"
-                      ? `Copilot Enterprise (${result.enterprise})`
-                      : `Copilot Org (${result.organization})`,
-                  value:
-                    result.mode === "enterprise_usage"
-                      ? [
-                        `${result.used} used`,
-                        formatBillingPeriod(result.period),
-                        ...(result.organization ? [`org=${result.organization}`] : []),
-                        ...(result.username ? [`user=${result.username}`] : []),
-                      ].join(" | ")
-                      : [
-                        `${result.used} used`,
-                        formatBillingPeriod(result.period),
-                        ...(result.username ? [`user=${result.username}`] : []),
-                      ].join(" | "),
-                  resetTimeIso: result.resetTimeIso,
-                },
-            ]
-          : [
-              result.unlimited
-                ? style === "grouped"
-                  ? {
-                      kind: "value",
-                      name: "Copilot",
-                      group: getCopilotGroup(result.mode),
-                      label: "Quota:",
-                      value: "Unlimited",
-                      resetTimeIso: result.resetTimeIso,
-                    }
-                  : {
-                      kind: "value",
-                      name: "Copilot",
-                      value: "Unlimited",
-                      resetTimeIso: result.resetTimeIso,
-                    }
-                : style === "grouped"
-                  ? {
-                      name: "Copilot",
-                      group: getCopilotGroup(result.mode),
-                      label: "Quota:",
-                      right: `${result.used}/${result.total}`,
-                      percentRemaining: result.percentRemaining,
-                      resetTimeIso: result.resetTimeIso,
-                    }
-                  : {
-                      name: "Copilot",
-                      percentRemaining: result.percentRemaining,
-                      resetTimeIso: result.resetTimeIso,
-                    },
-            ],
+          ? [buildManagedUsageEntry(result, style)]
+          : [buildUserQuotaEntry(result, style)],
       errors: [],
     };
   },

--- a/src/providers/copilot.ts
+++ b/src/providers/copilot.ts
@@ -110,20 +110,36 @@ export const copilotProvider: QuotaProvider = {
                 },
             ]
           : [
-              style === "grouped"
-                ? {
-                  name: "Copilot",
-                  group: getCopilotGroup(result.mode),
-                  label: "Quota:",
-                  right: `${result.used}/${result.total}`,
-                  percentRemaining: result.percentRemaining,
-                  resetTimeIso: result.resetTimeIso,
-                }
-                : {
-                  name: "Copilot",
-                  percentRemaining: result.percentRemaining,
-                  resetTimeIso: result.resetTimeIso,
-                },
+              result.unlimited
+                ? style === "grouped"
+                  ? {
+                      kind: "value",
+                      name: "Copilot",
+                      group: getCopilotGroup(result.mode),
+                      label: "Quota:",
+                      value: "Unlimited",
+                      resetTimeIso: result.resetTimeIso,
+                    }
+                  : {
+                      kind: "value",
+                      name: "Copilot",
+                      value: "Unlimited",
+                      resetTimeIso: result.resetTimeIso,
+                    }
+                : style === "grouped"
+                  ? {
+                      name: "Copilot",
+                      group: getCopilotGroup(result.mode),
+                      label: "Quota:",
+                      right: `${result.used}/${result.total}`,
+                      percentRemaining: result.percentRemaining,
+                      resetTimeIso: result.resetTimeIso,
+                    }
+                  : {
+                      name: "Copilot",
+                      percentRemaining: result.percentRemaining,
+                      resetTimeIso: result.resetTimeIso,
+                    },
             ],
       errors: [],
     };

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -126,6 +126,29 @@ describe("formatQuotaRows", () => {
     expect(out).not.toMatch(/\d+[dhms]/);
   });
 
+  it("renders session request counts under the shared session token block", () => {
+    const out = formatQuotaRows({
+      version: "1.0.0",
+      layout: { maxWidth: 50, narrowAt: 42, tinyAt: 32 },
+      entries: [
+        {
+          name: "Copilot",
+          percentRemaining: 75,
+        },
+      ],
+      sessionTokens: {
+        models: [{ modelID: "openai/gpt-5.4-mini", input: 372, output: 41 }],
+        totalInput: 372,
+        totalOutput: 41,
+        requestCount: 3,
+      },
+    });
+
+    expect(out).toContain("Session input/output tokens");
+    expect(out).toMatch(/372 in\s+41 out/);
+    expect(out).toContain("(3 requests this session)");
+  });
+
   it("normalizes grouped headers in grouped toast output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -146,7 +146,7 @@ describe("formatQuotaRows", () => {
 
     expect(out).toContain("Session input/output tokens");
     expect(out).toMatch(/372 in\s+41 out/);
-    expect(out).toContain("(3 requests this session)");
+    expect(out).toContain("3 assistant responses");
   });
 
   it("normalizes grouped headers in grouped toast output", () => {

--- a/tests/lib.copilot.test.ts
+++ b/tests/lib.copilot.test.ts
@@ -210,6 +210,100 @@ describe("queryCopilotQuota", () => {
     expect(String(fetchMock.mock.calls[0]?.[0])).toBe("https://api.github.com/copilot_internal/user");
   });
 
+  it("treats unlimited premium_interactions as unlimited instead of rendering 0/1 quota", async () => {
+    authMocks.readAuthFile.mockResolvedValueOnce({
+      "github-copilot": { type: "oauth", access: "oauth_access_token", refresh: "refresh" },
+    });
+
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const target = String(url);
+
+      if (target === "https://api.github.com/copilot_internal/user") {
+        expect(init?.headers).toMatchObject({
+          Authorization: "Bearer oauth_access_token",
+        });
+        return new Response(
+          JSON.stringify({
+            quota_reset_date_utc: "2026-04-01T00:00:00.000Z",
+            quota_snapshots: {
+              premium_interactions: {
+                entitlement: 1,
+                remaining: 1,
+                percent_remaining: 100,
+                unlimited: true,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock as any);
+
+    const { formatCopilotQuota, queryCopilotQuota } = await import("../src/lib/copilot.js");
+    const result = await queryCopilotQuota();
+
+    expect(result).toEqual({
+      success: true,
+      mode: "user_quota",
+      used: 0,
+      total: 1,
+      percentRemaining: 100,
+      unlimited: true,
+      resetTimeIso: "2026-04-01T00:00:00.000Z",
+    });
+    expect(formatCopilotQuota(result)).toBe("Copilot Unlimited");
+  });
+
+  it("prefers percent_remaining from /copilot_internal/user when present", async () => {
+    authMocks.readAuthFile.mockResolvedValueOnce({
+      "github-copilot": { type: "oauth", access: "oauth_access_token", refresh: "refresh" },
+    });
+
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const target = String(url);
+
+      if (target === "https://api.github.com/copilot_internal/user") {
+        expect(init?.headers).toMatchObject({
+          Authorization: "Bearer oauth_access_token",
+        });
+        return new Response(
+          JSON.stringify({
+            quota_reset_date_utc: "2026-05-01T00:00:00.000Z",
+            quota_snapshots: {
+              premium_interactions: {
+                entitlement: 1500,
+                remaining: 401,
+                percent_remaining: 26.7,
+                unlimited: false,
+              },
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response("not found", { status: 404 });
+    });
+
+    vi.stubGlobal("fetch", fetchMock as any);
+
+    const { queryCopilotQuota } = await import("../src/lib/copilot.js");
+    const result = await queryCopilotQuota();
+
+    expect(result).toEqual({
+      success: true,
+      mode: "user_quota",
+      used: 1099,
+      total: 1500,
+      percentRemaining: 26,
+      resetTimeIso: "2026-05-01T00:00:00.000Z",
+    });
+  });
+
   it("returns a clear error when OAuth auth exists without an access token", async () => {
     authMocks.readAuthFile.mockResolvedValueOnce({
       "github-copilot": { type: "oauth", refresh: "refresh_only" },

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -719,6 +719,7 @@ describe("/quota command behavior", () => {
         models: [{ modelID: "session-b-model", input: 222, output: 22 }],
         totalInput: 222,
         totalOutput: 22,
+        requestCount: 2,
       },
       error: undefined,
     });
@@ -727,6 +728,7 @@ describe("/quota command behavior", () => {
         models: [{ modelID: "session-a-model", input: 111, output: 11 }],
         totalInput: 111,
         totalOutput: 11,
+        requestCount: 3,
       },
       error: undefined,
     });
@@ -744,9 +746,13 @@ describe("/quota command behavior", () => {
       promptOutputs.find((output) => output.sessionID === "session-b")?.text ?? "";
 
     expect(sessionAOutput).toContain("session-a-model");
+    expect(sessionAOutput).toContain("(3 requests this session)");
     expect(sessionAOutput).not.toContain("session-b-model");
+    expect(sessionAOutput).not.toContain("(2 requests this session)");
     expect(sessionBOutput).toContain("session-b-model");
+    expect(sessionBOutput).toContain("(2 requests this session)");
     expect(sessionBOutput).not.toContain("session-a-model");
+    expect(sessionBOutput).not.toContain("(3 requests this session)");
   });
 
   it("bypasses stale /quota cache for qwen local request-plan sessions", async () => {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -746,13 +746,13 @@ describe("/quota command behavior", () => {
       promptOutputs.find((output) => output.sessionID === "session-b")?.text ?? "";
 
     expect(sessionAOutput).toContain("session-a-model");
-    expect(sessionAOutput).toContain("(3 requests this session)");
+    expect(sessionAOutput).toContain("3 assistant responses");
     expect(sessionAOutput).not.toContain("session-b-model");
-    expect(sessionAOutput).not.toContain("(2 requests this session)");
+    expect(sessionAOutput).not.toContain("2 assistant responses");
     expect(sessionBOutput).toContain("session-b-model");
-    expect(sessionBOutput).toContain("(2 requests this session)");
+    expect(sessionBOutput).toContain("2 assistant responses");
     expect(sessionBOutput).not.toContain("session-a-model");
-    expect(sessionBOutput).not.toContain("(3 requests this session)");
+    expect(sessionBOutput).not.toContain("3 assistant responses");
   });
 
   it("bypasses stale /quota cache for qwen local request-plan sessions", async () => {

--- a/tests/providers.copilot.test.ts
+++ b/tests/providers.copilot.test.ts
@@ -68,6 +68,56 @@ describe("copilot provider", () => {
     ]);
   });
 
+  it("maps unlimited personal quota into a value toast entry", async () => {
+    const { queryCopilotQuota } = await import("../src/lib/copilot.js");
+    (queryCopilotQuota as any).mockResolvedValueOnce({
+      success: true,
+      mode: "user_quota",
+      used: 0,
+      total: 1,
+      percentRemaining: 100,
+      unlimited: true,
+      resetTimeIso: "2026-02-01T00:00:00.000Z",
+    });
+
+    const out = await copilotProvider.fetch({} as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        kind: "value",
+        name: "Copilot",
+        value: "Unlimited",
+        resetTimeIso: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("maps unlimited personal quota into a grouped value entry", async () => {
+    const { queryCopilotQuota } = await import("../src/lib/copilot.js");
+    (queryCopilotQuota as any).mockResolvedValueOnce({
+      success: true,
+      mode: "user_quota",
+      used: 0,
+      total: 1,
+      percentRemaining: 100,
+      unlimited: true,
+      resetTimeIso: "2026-02-01T00:00:00.000Z",
+    });
+
+    const out = await copilotProvider.fetch({ config: { formatStyle: "grouped" } } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        kind: "value",
+        name: "Copilot",
+        group: "Copilot (personal)",
+        label: "Quota:",
+        value: "Unlimited",
+        resetTimeIso: "2026-02-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
   it("maps organization usage into a value toast entry", async () => {
     const { queryCopilotQuota } = await import("../src/lib/copilot.js");
     (queryCopilotQuota as any).mockResolvedValueOnce({

--- a/tests/quota-command-format.test.ts
+++ b/tests/quota-command-format.test.ts
@@ -57,6 +57,7 @@ describe("formatQuotaCommand", () => {
         ],
         totalInput: 2221,
         totalOutput: 1221,
+        requestCount: 3,
       },
     });
 
@@ -80,6 +81,7 @@ describe("formatQuotaCommand", () => {
       Session input/output tokens
         openai/gpt-5            1.2K in     567 out
         github-copilot/clau…     987 in     654 out
+        (3 requests this session)
 
       Z.ai: Authentication expired"
     `);

--- a/tests/quota-command-format.test.ts
+++ b/tests/quota-command-format.test.ts
@@ -81,7 +81,7 @@ describe("formatQuotaCommand", () => {
       Session input/output tokens
         openai/gpt-5            1.2K in     567 out
         github-copilot/clau…     987 in     654 out
-        (3 requests this session)
+        3 assistant responses
 
       Z.ai: Authentication expired"
     `);

--- a/tests/session-tokens-format.test.ts
+++ b/tests/session-tokens-format.test.ts
@@ -14,11 +14,13 @@ describe("renderSessionTokensLines", () => {
       models: [{ modelID: "openai/gpt-5", input: 1234, output: 567 }],
       totalInput: 1234,
       totalOutput: 567,
+      requestCount: 3,
     });
 
     expect(lines).toEqual([
       SESSION_TOKEN_SECTION_HEADING,
       "  openai/gpt-5            1.2K in     567 out",
+      "  (3 requests this session)",
     ]);
     expect(lines[1]?.length).toBe(WIDE_SESSION_TOKEN_LINE_WIDTH);
   });
@@ -29,6 +31,7 @@ describe("renderSessionTokensLines", () => {
         models: [{ modelID: "openai/gpt-5.4-mini", input: 372, output: 41 }],
         totalInput: 372,
         totalOutput: 41,
+        requestCount: 3,
       },
       { maxWidth: 36 },
     );
@@ -38,6 +41,7 @@ describe("renderSessionTokensLines", () => {
       SESSION_TOKEN_SECTION_HEADING.slice(0, 36),
       "  openai/gpt-5.4-mini",
       "    372 in  41 out",
+      "  (3 requests this session)",
     ]);
   });
 
@@ -46,11 +50,15 @@ describe("renderSessionTokensLines", () => {
       models: [{ modelID: "openai/gpt-5", input: 1234, output: 567 }],
       totalInput: 1234,
       totalOutput: 567,
+      requestCount: 3,
     });
 
     expect(section).toEqual({
       heading: SESSION_TOKEN_SECTION_HEADING,
-      lines: ["  openai/gpt-5            1.2K in     567 out"],
+      lines: [
+        "  openai/gpt-5            1.2K in     567 out",
+        "  (3 requests this session)",
+      ],
     });
   });
 });
@@ -62,11 +70,16 @@ describe("renderSidebarSessionTokenSummaryLines", () => {
         models: [{ modelID: "openai/gpt-5.4-mini", input: 372, output: 41 }],
         totalInput: 372,
         totalOutput: 41,
+        requestCount: 3,
       },
       { maxWidth: 36 },
     );
 
-    expect(lines).toEqual([SESSION_TOKEN_SECTION_HEADING.slice(0, 36), "  372 in  41 out"]);
+    expect(lines).toEqual([
+      SESSION_TOKEN_SECTION_HEADING.slice(0, 36),
+      "  372 in  41 out",
+      "  (3 requests this session)",
+    ]);
     expect(lines.every((line) => line.length <= 36)).toBe(true);
   });
 });

--- a/tests/session-tokens-format.test.ts
+++ b/tests/session-tokens-format.test.ts
@@ -20,7 +20,7 @@ describe("renderSessionTokensLines", () => {
     expect(lines).toEqual([
       SESSION_TOKEN_SECTION_HEADING,
       "  openai/gpt-5            1.2K in     567 out",
-      "  (3 requests this session)",
+      "  3 assistant responses",
     ]);
     expect(lines[1]?.length).toBe(WIDE_SESSION_TOKEN_LINE_WIDTH);
   });
@@ -41,7 +41,7 @@ describe("renderSessionTokensLines", () => {
       SESSION_TOKEN_SECTION_HEADING.slice(0, 36),
       "  openai/gpt-5.4-mini",
       "    372 in  41 out",
-      "  (3 requests this session)",
+      "  3 assistant responses",
     ]);
   });
 
@@ -57,7 +57,7 @@ describe("renderSessionTokensLines", () => {
       heading: SESSION_TOKEN_SECTION_HEADING,
       lines: [
         "  openai/gpt-5            1.2K in     567 out",
-        "  (3 requests this session)",
+        "  3 assistant responses",
       ],
     });
   });
@@ -78,7 +78,7 @@ describe("renderSidebarSessionTokenSummaryLines", () => {
     expect(lines).toEqual([
       SESSION_TOKEN_SECTION_HEADING.slice(0, 36),
       "  372 in  41 out",
-      "  (3 requests this session)",
+      "  3 assistant responses",
     ]);
     expect(lines.every((line) => line.length <= 36)).toBe(true);
   });

--- a/tests/tui-sidebar-format.test.ts
+++ b/tests/tui-sidebar-format.test.ts
@@ -35,6 +35,7 @@ describe("buildSidebarQuotaPanelLines", () => {
         sessionTokens: {
           totalInput: 12,
           totalOutput: 34,
+          requestCount: 2,
           models: [
             {
               modelID: "gpt-5\u001b[99m",
@@ -55,6 +56,7 @@ describe("buildSidebarQuotaPanelLines", () => {
     expect(rendered).toContain("Err: Bad");
     expect(rendered).toContain(SESSION_TOKEN_SECTION_HEADING);
     expect(rendered).toContain("12 in  34 out");
+    expect(rendered).toContain("(2 requests this session)");
     expect(rendered).not.toContain("gpt-5");
   });
 
@@ -259,6 +261,7 @@ describe("buildSidebarQuotaPanelLines", () => {
         sessionTokens: {
           totalInput: 372,
           totalOutput: 41,
+          requestCount: 3,
           models: [
             {
               modelID: "openai/gpt-5.4-mini",
@@ -271,7 +274,11 @@ describe("buildSidebarQuotaPanelLines", () => {
     });
 
     expect(lines.every((line) => line.length <= TUI_SIDEBAR_MAX_WIDTH)).toBe(true);
-    expect(lines).toEqual([SESSION_TOKEN_SECTION_HEADING, "  372 in  41 out"]);
+    expect(lines).toEqual([
+      SESSION_TOKEN_SECTION_HEADING,
+      "  372 in  41 out",
+      "  (3 requests this session)",
+    ]);
   });
 
   it("keeps value-only rows unchanged when percentDisplayMode is used", () => {

--- a/tests/tui-sidebar-format.test.ts
+++ b/tests/tui-sidebar-format.test.ts
@@ -56,7 +56,7 @@ describe("buildSidebarQuotaPanelLines", () => {
     expect(rendered).toContain("Err: Bad");
     expect(rendered).toContain(SESSION_TOKEN_SECTION_HEADING);
     expect(rendered).toContain("12 in  34 out");
-    expect(rendered).toContain("(2 requests this session)");
+    expect(rendered).toContain("2 assistant responses");
     expect(rendered).not.toContain("gpt-5");
   });
 
@@ -277,7 +277,7 @@ describe("buildSidebarQuotaPanelLines", () => {
     expect(lines).toEqual([
       SESSION_TOKEN_SECTION_HEADING,
       "  372 in  41 out",
-      "  (3 requests this session)",
+      "  3 assistant responses",
     ]);
   });
 


### PR DESCRIPTION
## Summary

- increase the shared Copilot fallback request timeout and honor `percent_remaining` / `unlimited` from `GET /copilot_internal/user`
- render unlimited personal Copilot quota as `Unlimited` instead of a misleading `0/1` quota shape
- track session response counts and render `x assistant responses` under the existing session input/output token block
- update the README so `showSessionTokens` documents the new response-count line in toast, `/quota`, and sidebar output

## Linked Issue

No linked issue. This PR includes the rationale and scope directly because the work started from a reproduced user-reported Copilot quota regression on the current released OpenCode version, and the session response-count UI addition was requested during the same validation pass.

## OpenCode Validation

- Current production released OpenCode version tested: `1.14.21`
- Why this version is relevant to the fix: the Copilot timeout / misleading `0/1` behavior was reproduced against that installed release, the plugin install and command registration were verified there, and the resulting behavior was rechecked on the same version after the fix

## Quality Checklist

- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)

## Before

- Copilot personal quota checks could fail after 3 seconds even when GitHub would return data if given a bit longer
- unlimited-style `/copilot_internal/user` payloads were coerced into a normal quota shape, which could display as misleading `0/1` or `0%` usage instead of reflecting the live account state
- session token summaries showed token totals, but not how many assistant responses produced those totals

## This PR Solves

- extends the timeout window used by the Copilot fallback path so transiently slower GitHub responses do not fail immediately
- uses explicit `percent_remaining` and `unlimited` values when GitHub provides them, while keeping normal used/total math for standard quota payloads
- surfaces per-session assistant response counts alongside session token totals so the token summary has clearer context