### PR TITLE
update(opencode-go): fix dashboard scraping + display all three usage windows

### DIFF
--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -32,6 +32,9 @@ export type QuotaToastEntry =
 
       /** Optional ISO reset timestamp (shown when percentRemaining is < 100). */
       resetTimeIso?: string;
+
+      /** Optional static reset text (e.g. "5h 0m") to show instead of live countdown. */
+      resetText?: string;
     })
   | (GroupedQuotaEntryMeta & {
       /** Value-based entry (no percent bar). */
@@ -45,11 +48,12 @@ export type QuotaToastEntry =
 
       /** Optional ISO reset timestamp (shown when available). */
       resetTimeIso?: string;
+
+      /** Optional static reset text to show instead of live countdown. */
+      resetText?: string;
     });
 
-export function isValueEntry(
-  e: QuotaToastEntry,
-): e is Extract<QuotaToastEntry, { kind: "value" }> {
+export function isValueEntry(e: QuotaToastEntry): e is Extract<QuotaToastEntry, { kind: "value" }> {
   return e.kind === "value";
 }
 
@@ -82,6 +86,8 @@ export interface SessionTokensData {
 export interface QuotaProviderPresentation {
   singleWindowDisplayName?: string;
   singleWindowShowRight?: boolean;
+  /** If true, always project all entries regardless of format style. */
+  forceAllWindows?: boolean;
 }
 
 export interface QuotaProviderResult {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -62,8 +62,9 @@ export function formatQuotaRows(params: {
     DISPLAYED_PERCENT_LABEL_WIDTH,
     ...(params.entries ?? [])
       .filter((entry) => !isValueEntry(entry))
-      .map((entry) =>
-        formatDisplayedPercentLabel(entry.percentRemaining, params.percentDisplayMode).length,
+      .map(
+        (entry) =>
+          formatDisplayedPercentLabel(entry.percentRemaining, params.percentDisplayMode).length,
       ),
   );
 
@@ -81,6 +82,7 @@ export function formatQuotaRows(params: {
     resetIso: string | undefined,
     remaining: number,
     rightSummary?: string,
+    resetText?: string,
   ) => {
     const displayedPercent = resolveDisplayedPercent(remaining, params.percentDisplayMode);
     const percentLabel = formatDisplayedPercentLabel(remaining, params.percentDisplayMode);
@@ -88,8 +90,8 @@ export function formatQuotaRows(params: {
     const leftText = summary ? `${name} ${summary}` : name;
 
     // Show reset countdown whenever quota is not fully available.
-    // (i.e., any usage at all, or depleted)
-    const timeStr = remaining < 100 ? formatResetCountdown(resetIso, { missing: "-" }) : "";
+    const timeStr =
+      resetText || (remaining < 100 ? formatResetCountdown(resetIso, { missing: "-" }) : "");
 
     if (isTiny) {
       // In tiny mode: single line with name + time + percent
@@ -120,14 +122,18 @@ export function formatQuotaRows(params: {
     lines.push(barLine);
   };
 
-  const addValueEntry = (name: string, resetIso: string | undefined, value: string) => {
-    const timeStr = formatResetCountdown(resetIso, { missing: "-" });
+  const addValueEntry = (
+    name: string,
+    resetIso: string | undefined,
+    value: string,
+    resetText?: string,
+  ) => {
+    const timeStr = resetText || formatResetCountdown(resetIso, { missing: "-" });
 
     if (isTiny) {
       // Tiny: single line without percent; keep time col alignment.
       const valueCol = Math.min(value.length, Math.max(6, percentCol + 2));
-      const tinyNameCol =
-        maxWidth - separator.length - timeCol - separator.length - valueCol;
+      const tinyNameCol = maxWidth - separator.length - timeCol - separator.length - valueCol;
       const nameCol = Math.max(1, tinyNameCol);
       const line = [
         padRight(name, nameCol),
@@ -156,9 +162,15 @@ export function formatQuotaRows(params: {
 
   for (const entry of params.entries ?? []) {
     if (isValueEntry(entry)) {
-      addValueEntry(entry.name, entry.resetTimeIso, entry.value);
+      addValueEntry(entry.name, entry.resetTimeIso, entry.value, entry.resetText);
     } else {
-      addPercentEntry(entry.name, entry.resetTimeIso, entry.percentRemaining, entry.right);
+      addPercentEntry(
+        entry.name,
+        entry.resetTimeIso,
+        entry.percentRemaining,
+        entry.right,
+        entry.resetText,
+      );
     }
   }
 

--- a/src/lib/grouped-entry-normalization.ts
+++ b/src/lib/grouped-entry-normalization.ts
@@ -51,12 +51,13 @@ function getDurationRankFromText(value?: string): number | null {
   if (!text) return null;
 
   if (/\b(?:rpm|per minute|minute|minutes)\b/u.test(text)) return 1;
+  if (/\b(?:rolling)\b/u.test(text)) return 50;
   if (/\b(?:5h|5 h|5-hour|5 hour|five-hour|five hour)\b/u.test(text)) return 300;
   if (/\b(?:hourly|1h|1 h|1-hour|1 hour|hour)\b/u.test(text)) return 60;
-  if (/\b(?:7d|7 d|7-day|7 day|weekly|week)\b/u.test(text)) return 10080;
-  if (/\b(?:daily|1d|1 d|1-day|1 day|day)\b/u.test(text)) return 1440;
-  if (/\b(?:monthly|month)\b/u.test(text)) return 43200;
-  if (/\b(?:yearly|annual|annually|year)\b/u.test(text)) return 525600;
+  if (/\b(?:7d|7 d|7-day|7 day|weekly|week|weeks)\b/u.test(text)) return 10080;
+  if (/\b(?:daily|1d|1 d|1-day|1 day|day|days)\b/u.test(text)) return 1440;
+  if (/\b(?:monthly|month|months)\b/u.test(text)) return 43200;
+  if (/\b(?:yearly|annual|annually|year|years)\b/u.test(text)) return 525600;
 
   return null;
 }

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -16,13 +16,15 @@ const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/201001
 const SCRAPE_TIMEOUT_MS = 10_000;
 
 /**
- * Regex patterns matching the SolidJS SSR hydration output.
- * Field order may vary, so we try both orderings.
+ * Regex patterns matching the SolidJS SSR hydration output and general JSON-like objects.
+ * We use a "strategy" approach: first look for SolidJS markers, then fuzzy match objects.
  */
-const RE_MONTHLY_PCT_FIRST =
-  /monthlyUsage:\$R\[\d+\]=\{[^}]*usagePercent:(\d+)[^}]*resetInSec:(\d+)[^}]*\}/;
-const RE_MONTHLY_RESET_FIRST =
-  /monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:(\d+)[^}]*usagePercent:(\d+)[^}]*\}/;
+const RE_STRATEGY_HYDRATION =
+  /monthlyUsage[:\s]*\$R(?:[:\d\[\]]*)\s*=\s*\{.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
+const RE_STRATEGY_HYDRATION_REVERSE =
+  /monthlyUsage[:\s]*\$R(?:[:\d\[\]]*)\s*=\s*\{.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
+const RE_STRATEGY_FUZZY_OBJECT =
+  /\{.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
 
 interface ScrapedMonthlyUsage {
   usagePercent: number;
@@ -30,25 +32,64 @@ interface ScrapedMonthlyUsage {
 }
 
 function parseMonthlyUsage(html: string): ScrapedMonthlyUsage | null {
-  const pctFirstMatch = RE_MONTHLY_PCT_FIRST.exec(html);
-  if (pctFirstMatch) {
-    const usagePercent = Number(pctFirstMatch[1]);
-    const resetInSec = Number(pctFirstMatch[2]);
+  // Strategy 1: Standard or slightly varied SolidJS hydration
+  const hydrationMatch = RE_STRATEGY_HYDRATION.exec(html);
+  if (hydrationMatch) {
+    const usagePercent = Number(hydrationMatch[1]);
+    const resetInSec = Number(hydrationMatch[2]);
     if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
       return { usagePercent, resetInSec };
     }
   }
 
-  const resetFirstMatch = RE_MONTHLY_RESET_FIRST.exec(html);
-  if (resetFirstMatch) {
-    const resetInSec = Number(resetFirstMatch[1]);
-    const usagePercent = Number(resetFirstMatch[2]);
+  const hydrationReverseMatch = RE_STRATEGY_HYDRATION_REVERSE.exec(html);
+  if (hydrationReverseMatch) {
+    const resetInSec = Number(hydrationReverseMatch[1]);
+    const usagePercent = Number(hydrationReverseMatch[2]);
+    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+      return { usagePercent, resetInSec };
+    }
+  }
+
+  // Strategy 2: Fuzzy JSON-like object match (backup)
+  const fuzzyMatch = RE_STRATEGY_FUZZY_OBJECT.exec(html);
+  if (fuzzyMatch) {
+    const usagePercent = Number(fuzzyMatch[1]);
+    const resetInSec = Number(fuzzyMatch[2]);
     if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
       return { usagePercent, resetInSec };
     }
   }
 
   return null;
+}
+
+/**
+ * Extracts a masked snippet of the HTML for diagnostics.
+ */
+function getMaskedHtmlSnippet(html: string, maxLength = 200): string {
+  // Find "monthlyUsage" or "usagePercent" to center the snippet
+  const index =
+    html.indexOf("monthlyUsage") !== -1
+      ? html.indexOf("monthlyUsage")
+      : html.indexOf("usagePercent");
+
+  let snippet: string;
+  if (index === -1) {
+    // If not found, just take the first part of the HTML to see what we're looking at
+    snippet = `[Keys not found. Start of HTML]: ${html.slice(0, maxLength)}`;
+  } else {
+    const start = Math.max(0, index - 50);
+    const end = Math.min(html.length, start + maxLength);
+    snippet = html.slice(start, end);
+  }
+
+  // Mask digits and potential email-like patterns
+  return snippet
+    .replace(/\d+/g, "***")
+    .replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, "[EMAIL]")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function sanitizeMessage(text: string, maxLength = 120): string {
@@ -61,7 +102,17 @@ export async function queryOpenCodeGoQuota(
   authCookie: string,
 ): Promise<OpenCodeGoResult> {
   try {
-    const url = `${DASHBOARD_URL_PREFIX}${encodeURIComponent(workspaceId)}${DASHBOARD_URL_SUFFIX}`;
+    // If workspaceId is a full URL, strip the prefix and suffix to get just the ID.
+    // e.g. https://opencode.ai/workspace/wrk_123/go -> wrk_123
+    let normalizedId = workspaceId.trim();
+    if (normalizedId.includes("://")) {
+      const match = normalizedId.match(/\/workspace\/([^\/]+)/);
+      if (match) {
+        normalizedId = match[1];
+      }
+    }
+
+    const url = `${DASHBOARD_URL_PREFIX}${encodeURIComponent(normalizedId)}${DASHBOARD_URL_SUFFIX}`;
 
     const response = await fetchWithTimeout(
       url,
@@ -88,9 +139,11 @@ export async function queryOpenCodeGoQuota(
     const monthly = parseMonthlyUsage(html);
 
     if (!monthly) {
+      const snippet = getMaskedHtmlSnippet(html);
+      const maskedUrl = url.replace(workspaceId, "REDACTED");
       return {
         success: false,
-        error: "Could not parse monthly usage from OpenCode Go dashboard",
+        error: `Could not parse monthly usage from dashboard. Status: ${response.status}. URL: ${maskedUrl}. Snippet: ${snippet} (v3.3.2-diag)`,
       };
     }
 

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -2,7 +2,7 @@
  * OpenCode Go dashboard scraper.
  *
  * Fetches the OpenCode Go workspace page and parses SolidJS SSR hydration
- * output for `monthlyUsage` containing `usagePercent` and `resetInSec`.
+ * output for rolling, weekly, and monthly usage.
  */
 
 import { fetchWithTimeout } from "./http.js";
@@ -15,49 +15,127 @@ const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/201001
 
 const SCRAPE_TIMEOUT_MS = 10_000;
 
-/**
- * Regex patterns matching the SolidJS SSR hydration output and general JSON-like objects.
- * We use a "strategy" approach: first look for SolidJS markers, then fuzzy match objects.
- */
-const RE_STRATEGY_HYDRATION =
-  /monthlyUsage[:\s]*\$R(?:[:\d\[\]]*)\s*=\s*\{.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
-const RE_STRATEGY_HYDRATION_REVERSE =
-  /monthlyUsage[:\s]*\$R(?:[:\d\[\]]*)\s*=\s*\{.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
-const RE_STRATEGY_FUZZY_OBJECT =
-  /\{.*?["']?usagePercent["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?["']?resetInSec["']?\s*:\s*["']?(\d+(?:\.\d+)?)["']?.*?\}/i;
-
-interface ScrapedMonthlyUsage {
+interface ScrapedUsage {
   usagePercent: number;
   resetInSec: number;
 }
 
-function parseMonthlyUsage(html: string): ScrapedMonthlyUsage | null {
-  // Strategy 1: Standard or slightly varied SolidJS hydration
-  const hydrationMatch = RE_STRATEGY_HYDRATION.exec(html);
-  if (hydrationMatch) {
-    const usagePercent = Number(hydrationMatch[1]);
-    const resetInSec = Number(hydrationMatch[2]);
-    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
-      return { usagePercent, resetInSec };
+/**
+ * Parses usage data (usagePercent and resetInSec) for a specific key from the HTML.
+ *
+ * This version uses a strict anchor approach to ignore unrelated scalar properties
+ * (like billing metadata) and isolates the correct hydration object.
+ */
+function parseUsage(html: string, key: string): ScrapedUsage | null {
+  // Strategy 1: Strict Anchor Matching
+  // Find occurrences of the key that are part of a SolidJS hydration assignment
+  // e.g. weeklyUsage:$R[32]={...}
+  const anchorRegex = new RegExp(`${key}[:\\s]*\\$R(?:[:\\d\\[\\]]*)[:\\s]*=`, "gi");
+  const keyMatches = Array.from(html.matchAll(anchorRegex));
+
+  for (const match of keyMatches) {
+    const keyIndex = match.index!;
+
+    // Find the first '{' after this anchor
+    const startBraceIndex = html.indexOf("{", keyIndex);
+    if (startBraceIndex === -1 || startBraceIndex - keyIndex > 100) continue;
+
+    // Isolate the object string with string-aware brace matching
+    let endBraceIndex = -1;
+    let depth = 0;
+    let inString: string | null = null;
+    let isEscaped = false;
+
+    for (let i = startBraceIndex; i < html.length; i++) {
+      const char = html[i];
+
+      if (isEscaped) {
+        isEscaped = false;
+        continue;
+      }
+
+      if (char === "\\") {
+        isEscaped = true;
+        continue;
+      }
+
+      if (inString) {
+        if (char === inString) {
+          inString = null;
+        }
+        continue;
+      }
+
+      if (char === '"' || char === "'") {
+        inString = char;
+        continue;
+      }
+
+      if (char === "{") {
+        depth++;
+      } else if (char === "}") {
+        depth--;
+        if (depth === 0) {
+          endBraceIndex = i;
+          break;
+        }
+      }
+
+      // Safety break if we're scanning too much (e.g. 5KB per object)
+      if (i - startBraceIndex > 5000) break;
+    }
+
+    if (endBraceIndex === -1) continue;
+
+    const objectText = html.slice(startBraceIndex, endBraceIndex + 1);
+
+    // Extract fields using robust regexes that handle quotes and spacing
+    const RE_VAL = /:\s*["']?(\d+(?:\.\d+)?)["']?/;
+    const usageMatch = new RegExp(`["']?usagePercent["']?${RE_VAL.source}`, "i").exec(objectText);
+    const resetMatch = new RegExp(`["']?resetInSec["']?${RE_VAL.source}`, "i").exec(objectText);
+
+    if (usageMatch && resetMatch) {
+      const usagePercent = Number(usageMatch[1]);
+      const resetInSec = Number(resetMatch[1]);
+      if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+        return { usagePercent, resetInSec };
+      }
     }
   }
 
-  const hydrationReverseMatch = RE_STRATEGY_HYDRATION_REVERSE.exec(html);
-  if (hydrationReverseMatch) {
-    const resetInSec = Number(hydrationReverseMatch[1]);
-    const usagePercent = Number(hydrationReverseMatch[2]);
-    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
-      return { usagePercent, resetInSec };
-    }
-  }
+  // Strategy 2: Loose Fallback
+  // If no strict anchor found, try a looser search but still isolate the object.
+  // This handles cases where the dashboard might change its hydration pattern.
+  const looseMatches = Array.from(html.matchAll(new RegExp(`["']?${key}["']?[:\\s]*`, "gi")));
+  for (const match of looseMatches) {
+    const keyIndex = match.index!;
+    const startBraceIndex = html.indexOf("{", keyIndex);
+    if (startBraceIndex === -1 || startBraceIndex - keyIndex > 50) continue;
 
-  // Strategy 2: Fuzzy JSON-like object match (backup)
-  const fuzzyMatch = RE_STRATEGY_FUZZY_OBJECT.exec(html);
-  if (fuzzyMatch) {
-    const usagePercent = Number(fuzzyMatch[1]);
-    const resetInSec = Number(fuzzyMatch[2]);
-    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
-      return { usagePercent, resetInSec };
+    // Isolate and parse as above
+    let endBraceIndex = -1;
+    let depth = 0;
+    for (let i = startBraceIndex; i < html.length; i++) {
+      if (html[i] === "{") depth++;
+      else if (html[i] === "}") {
+        depth--;
+        if (depth === 0) {
+          endBraceIndex = i;
+          break;
+        }
+      }
+    }
+    if (endBraceIndex === -1) continue;
+    const objectText = html.slice(startBraceIndex, endBraceIndex + 1);
+    const RE_VAL = /:\s*["']?(\d+(?:\.\d+)?)["']?/;
+    const usageMatch = new RegExp(`["']?usagePercent["']?${RE_VAL.source}`, "i").exec(objectText);
+    const resetMatch = new RegExp(`["']?resetInSec["']?${RE_VAL.source}`, "i").exec(objectText);
+    if (usageMatch && resetMatch) {
+      const usagePercent = Number(usageMatch[1]);
+      const resetInSec = Number(resetMatch[1]);
+      if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+        return { usagePercent, resetInSec };
+      }
     }
   }
 
@@ -68,11 +146,16 @@ function parseMonthlyUsage(html: string): ScrapedMonthlyUsage | null {
  * Extracts a masked snippet of the HTML for diagnostics.
  */
 function getMaskedHtmlSnippet(html: string, maxLength = 200): string {
-  // Find "monthlyUsage" or "usagePercent" to center the snippet
-  const index =
-    html.indexOf("monthlyUsage") !== -1
-      ? html.indexOf("monthlyUsage")
-      : html.indexOf("usagePercent");
+  // Find "rollingUsage", "weeklyUsage", "monthlyUsage" or "usagePercent" to center the snippet
+  const keys = ["rollingUsage", "weeklyUsage", "monthlyUsage", "usagePercent"];
+  let index = -1;
+  for (const key of keys) {
+    const found = html.indexOf(key);
+    if (found !== -1) {
+      index = found;
+      break;
+    }
+  }
 
   let snippet: string;
   if (index === -1) {
@@ -103,7 +186,6 @@ export async function queryOpenCodeGoQuota(
 ): Promise<OpenCodeGoResult> {
   try {
     // If workspaceId is a full URL, strip the prefix and suffix to get just the ID.
-    // e.g. https://opencode.ai/workspace/wrk_123/go -> wrk_123
     let normalizedId = workspaceId.trim();
     if (normalizedId.includes("://")) {
       const match = normalizedId.match(/\/workspace\/([^\/]+)/);
@@ -136,28 +218,45 @@ export async function queryOpenCodeGoQuota(
     }
 
     const html = await response.text();
-    const monthly = parseMonthlyUsage(html);
+    const rolling = parseUsage(html, "rollingUsage");
+    const weekly = parseUsage(html, "weeklyUsage");
+    const monthly = parseUsage(html, "monthlyUsage");
 
-    if (!monthly) {
+    if (!rolling || !weekly || !monthly) {
       const snippet = getMaskedHtmlSnippet(html);
       const maskedUrl = url.replace(workspaceId, "REDACTED");
+      const missing = [!rolling && "rolling", !weekly && "weekly", !monthly && "monthly"]
+        .filter(Boolean)
+        .join(", ");
+
       return {
         success: false,
-        error: `Could not parse monthly usage from dashboard. Status: ${response.status}. URL: ${maskedUrl}. Snippet: ${snippet} (v3.3.2-diag)`,
+        error: `Could not parse ${missing} usage from dashboard. Status: ${response.status}. URL: ${maskedUrl}. Snippet: ${snippet} (v3.4.0-diag)`,
       };
     }
 
-    const usagePercent = Math.max(0, monthly.usagePercent);
-    const percentRemaining = 100 - usagePercent;
-    const resetInSec = Math.max(0, monthly.resetInSec);
-    const resetTimeIso = new Date(Date.now() + resetInSec * 1000).toISOString();
+    const now = Date.now();
 
     return {
       success: true,
-      usagePercent,
-      resetInSec,
-      percentRemaining,
-      resetTimeIso,
+      rolling: {
+        usagePercent: Math.max(0, rolling.usagePercent),
+        resetInSec: Math.max(0, rolling.resetInSec),
+        percentRemaining: Math.max(0, 100 - rolling.usagePercent),
+        resetTimeIso: new Date(now + Math.max(0, rolling.resetInSec) * 1000).toISOString(),
+      },
+      weekly: {
+        usagePercent: Math.max(0, weekly.usagePercent),
+        resetInSec: Math.max(0, weekly.resetInSec),
+        percentRemaining: Math.max(0, 100 - weekly.usagePercent),
+        resetTimeIso: new Date(now + Math.max(0, weekly.resetInSec) * 1000).toISOString(),
+      },
+      monthly: {
+        usagePercent: Math.max(0, monthly.usagePercent),
+        resetInSec: Math.max(0, monthly.resetInSec),
+        percentRemaining: Math.max(0, 100 - monthly.usagePercent),
+        resetTimeIso: new Date(now + Math.max(0, monthly.resetInSec) * 1000).toISOString(),
+      },
     };
   } catch (err) {
     return {
@@ -167,4 +266,4 @@ export async function queryOpenCodeGoQuota(
   }
 }
 
-export { parseMonthlyUsage as _parseMonthlyUsage };
+export { parseUsage as _parseUsage };

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -16,10 +16,7 @@ import { fetchSessionTokensForDisplay } from "./session-tokens.js";
 import { getQuotaProviderDisplayLabel } from "./provider-metadata.js";
 import { isCursorProviderId } from "./cursor-pricing.js";
 import { fetchQuotaProviderResult } from "./quota-state.js";
-import {
-  DEFAULT_QUOTA_FORMAT_STYLE,
-  getQuotaFormatStyleDefinition,
-} from "./quota-format-style.js";
+import { DEFAULT_QUOTA_FORMAT_STYLE, getQuotaFormatStyleDefinition } from "./quota-format-style.js";
 import { getProviders } from "../providers/registry.js";
 import { getAnthropicNoDataMessage } from "../providers/anthropic.js";
 
@@ -275,10 +272,7 @@ export async function collectQuotaStatusLiveProbes(params: {
   }));
 }
 
-function stripSingleWindowEntryMeta(
-  entry: QuotaToastEntry,
-  showRight: boolean,
-): QuotaToastEntry {
+function stripSingleWindowEntryMeta(entry: QuotaToastEntry, showRight: boolean): QuotaToastEntry {
   const { group: _group, label: _label, ...withoutGroupLabel } = entry;
   if (showRight) {
     return { ...withoutGroupLabel };
@@ -346,7 +340,7 @@ function projectProviderResultToStyle(
 ): QuotaToastEntry[] {
   const entries = result.entries.map((entry) => ({ ...entry }));
   const definition = getQuotaFormatStyleDefinition(style);
-  if (definition.projection === "allWindows") {
+  if (definition.projection === "allWindows" || result.presentation?.forceAllWindows) {
     return entries;
   }
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -1067,8 +1067,16 @@ export async function buildQuotaStatusReport(params: {
         openCodeGoRows.push({ key: "live_fetch_error", value: openCodeGoQuota.error });
       } else {
         openCodeGoRows.push({
+          key: "rolling_usage",
+          value: `used=${openCodeGoQuota.rolling.usagePercent}% rem=${openCodeGoQuota.rolling.percentRemaining}% reset=${openCodeGoQuota.rolling.resetInSec}s at=${openCodeGoQuota.rolling.resetTimeIso}`,
+        });
+        openCodeGoRows.push({
+          key: "weekly_usage",
+          value: `used=${openCodeGoQuota.weekly.usagePercent}% rem=${openCodeGoQuota.weekly.percentRemaining}% reset=${openCodeGoQuota.weekly.resetInSec}s at=${openCodeGoQuota.weekly.resetTimeIso}`,
+        });
+        openCodeGoRows.push({
           key: "monthly_usage",
-          value: `percent_used=${openCodeGoQuota.usagePercent} percent_remaining=${openCodeGoQuota.percentRemaining} reset_in_sec=${openCodeGoQuota.resetInSec} reset_at=${openCodeGoQuota.resetTimeIso}`,
+          value: `used=${openCodeGoQuota.monthly.usagePercent}% rem=${openCodeGoQuota.monthly.percentRemaining}% reset=${openCodeGoQuota.monthly.resetInSec}s at=${openCodeGoQuota.monthly.resetTimeIso}`,
         });
       }
     }

--- a/src/lib/toast-format-grouped.ts
+++ b/src/lib/toast-format-grouped.ts
@@ -42,8 +42,9 @@ export function formatQuotaRowsGrouped(params: {
     DISPLAYED_PERCENT_LABEL_WIDTH,
     ...(params.entries ?? [])
       .filter((entry) => !isValueEntry(entry))
-      .map((entry) =>
-        formatDisplayedPercentLabel(entry.percentRemaining, params.percentDisplayMode).length,
+      .map(
+        (entry) =>
+          formatDisplayedPercentLabel(entry.percentRemaining, params.percentDisplayMode).length,
       ),
   );
   const barWidth = Math.max(10, maxWidth - separator.length - percentCol);
@@ -76,7 +77,7 @@ export function formatQuotaRowsGrouped(params: {
       const right = entry.right ? entry.right.trim() : "";
 
       if (isValueEntry(entry)) {
-        const timeStr = formatResetCountdown(entry.resetTimeIso);
+        const timeStr = entry.resetText || formatResetCountdown(entry.resetTimeIso);
         const value = entry.value.trim();
 
         if (isTiny) {
@@ -105,19 +106,22 @@ export function formatQuotaRowsGrouped(params: {
         );
         const leftText = right ? `${label} ${right}` : label;
         lines.push(
-          (padRight(leftText, leftMax) +
+          (
+            padRight(leftText, leftMax) +
             separator +
             padLeft(value, valueWidth) +
             separator +
-            padLeft(timeStr, timeWidth)).slice(0, maxWidth),
+            padLeft(timeStr, timeWidth)
+          ).slice(0, maxWidth),
         );
         continue;
       }
 
       // Percent entries
       // Show reset countdown whenever quota is not fully available.
-      // (i.e., any usage at all, or depleted)
-      const timeStr = entry.percentRemaining < 100 ? formatResetCountdown(entry.resetTimeIso) : "";
+      const timeStr =
+        entry.resetText ||
+        (entry.percentRemaining < 100 ? formatResetCountdown(entry.resetTimeIso) : "");
       const displayedPercent = resolveDisplayedPercent(
         entry.percentRemaining,
         params.percentDisplayMode,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -577,14 +577,24 @@ export type SyntheticResult =
 export type OpenCodeGoResult =
   | {
       success: true;
-      /** Usage percentage [0..100] */
-      usagePercent: number;
-      /** Seconds until usage resets */
-      resetInSec: number;
-      /** Remaining percentage [0..100] */
-      percentRemaining: number;
-      /** ISO reset timestamp */
-      resetTimeIso: string;
+      rolling: {
+        usagePercent: number;
+        resetInSec: number;
+        percentRemaining: number;
+        resetTimeIso: string;
+      };
+      weekly: {
+        usagePercent: number;
+        resetInSec: number;
+        percentRemaining: number;
+        resetTimeIso: string;
+      };
+      monthly: {
+        usagePercent: number;
+        resetInSec: number;
+        percentRemaining: number;
+        resetTimeIso: string;
+      };
     }
   | QuotaError
   | null;

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -64,14 +64,34 @@ export const opencodeGoProvider: QuotaProvider = {
       return attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, result.error);
     }
 
-    return attemptedResult([
+    return attemptedResult(
+      [
+        {
+          name: `${OPENCODE_GO_PROVIDER_LABEL} Rolling`,
+          group: OPENCODE_GO_PROVIDER_LABEL,
+          label: "Rolling:",
+          percentRemaining: result.rolling.percentRemaining,
+          ...(result.rolling.usagePercent > 0 ? { resetTimeIso: result.rolling.resetTimeIso } : {}),
+        },
+        {
+          name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`,
+          group: OPENCODE_GO_PROVIDER_LABEL,
+          label: "Weekly:",
+          percentRemaining: result.weekly.percentRemaining,
+          resetTimeIso: result.weekly.resetTimeIso,
+        },
+        {
+          name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`,
+          group: OPENCODE_GO_PROVIDER_LABEL,
+          label: "Monthly:",
+          percentRemaining: result.monthly.percentRemaining,
+          resetTimeIso: result.monthly.resetTimeIso,
+        },
+      ],
+      [],
       {
-        name: OPENCODE_GO_PROVIDER_LABEL,
-        group: OPENCODE_GO_PROVIDER_LABEL,
-        label: "Monthly:",
-        percentRemaining: result.percentRemaining,
-        resetTimeIso: result.resetTimeIso,
+        forceAllWindows: true,
       },
-    ]);
+    );
   },
 };

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -235,4 +235,67 @@ describe("_parseMonthlyUsage", () => {
     const html = "monthlyUsage:$R[1]={usagePercent:10,foo:bar,resetInSec:500}";
     expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 10, resetInSec: 500 });
   });
+
+  it("handles quoted property names and spaces", () => {
+    const html = 'monthlyUsage:$R[123]={"usagePercent": 45, "resetInSec" : 7200}';
+    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 45, resetInSec: 7200 });
+  });
+
+  it("handles single quotes and decimal values", () => {
+    const html = "monthlyUsage:$R[0]={'usagePercent':12.5, 'resetInSec':30.5}";
+    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 12.5, resetInSec: 30.5 });
+  });
+
+  it("handles quoted numeric values", () => {
+    const html = 'monthlyUsage:$R[99]={usagePercent:"88",resetInSec:"1000"}';
+    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 88, resetInSec: 1000 });
+  });
+
+  it("handles variations of $R (e.g. no brackets, colon)", () => {
+    const html1 = "monthlyUsage:$R42={usagePercent:10,resetInSec:100}";
+    const html2 = "monthlyUsage:$R:7={usagePercent:20,resetInSec:200}";
+    const html3 = "monthlyUsage: $R = {usagePercent:30,resetInSec:300}";
+    expect(_parseMonthlyUsage(html1)).toEqual({ usagePercent: 10, resetInSec: 100 });
+    expect(_parseMonthlyUsage(html2)).toEqual({ usagePercent: 20, resetInSec: 200 });
+    expect(_parseMonthlyUsage(html3)).toEqual({ usagePercent: 30, resetInSec: 300 });
+  });
+
+  it("handles fuzzy matching of JSON objects without $R marker", () => {
+    const html = '<div>Data: {"usagePercent": 5, "resetInSec": 50}</div>';
+    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 5, resetInSec: 50 });
+  });
+
+  it("handles the exact pattern found in opencode.htm", () => {
+    const html = 'monthlyUsage:$R[33]={status:"ok",resetInSec:2066217,usagePercent:50}';
+    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 50, resetInSec: 2066217 });
+  });
+
+  it("normalizes workspaceId if it is a full URL", async () => {
+    const fullUrl = "https://opencode.ai/workspace/wrk_999/go";
+    mockConfigConfigured(fullUrl, "auth-token");
+    mockDashboardSuccess(buildDashboardHtml(10, 100));
+
+    await runProviderFetch();
+
+    // Verify fetchWithTimeout was called with the normalized URL
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledWith(
+      "https://opencode.ai/workspace/wrk_999/go",
+      expect.any(Object),
+      expect.any(Number),
+    );
+  });
+
+  it("returns error with masked snippet on parsing failure", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(
+      "<html><body>monthlyUsage:$R[1]={wrong:0} some sensitive info like 12345 and test@example.com</body></html>",
+    );
+
+    const out = await runProviderFetch();
+    expectAttemptedWithErrorLabel(out, "OpenCode Go");
+    expect(out.errors[0]?.message).toContain("Snippet:");
+    expect(out.errors[0]?.message).toContain("v3.3.2-diag");
+    expect(out.errors[0]?.message).toContain("***"); // Masked digits
+    expect(out.errors[0]?.message).toContain("[EMAIL]"); // Masked email
+  });
 });

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -21,7 +21,7 @@ vi.mock("../src/lib/http.js", () => ({
 }));
 
 import { opencodeGoProvider } from "../src/providers/opencode-go.js";
-import { _parseMonthlyUsage } from "../src/lib/opencode-go.js";
+import { _parseUsage } from "../src/lib/opencode-go.js";
 
 function mockConfigNone() {
   mocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({ state: "none" });
@@ -54,12 +54,16 @@ function mockConfigConfigured(workspaceId = "ws-123", authCookie = "cookie-abc")
   });
 }
 
-function buildDashboardHtml(usagePercent: number, resetInSec: number): string {
-  return `<html><script>monthlyUsage:$R[42]={usagePercent:${usagePercent},resetInSec:${resetInSec}}</script></html>`;
-}
-
-function buildDashboardHtmlResetFirst(usagePercent: number, resetInSec: number): string {
-  return `<html><script>monthlyUsage:$R[7]={resetInSec:${resetInSec},usagePercent:${usagePercent}}</script></html>`;
+function buildDashboardHtml(
+  rolling: [number, number],
+  weekly: [number, number],
+  monthly: [number, number],
+): string {
+  return `<html><script>
+    rollingUsage:$R[1]={status:"ok",resetInSec:${rolling[1]},usagePercent:${rolling[0]}},
+    weeklyUsage:$R[2]={status:"ok",resetInSec:${weekly[1]},usagePercent:${weekly[0]}},
+    monthlyUsage:$R[3]={status:"ok",resetInSec:${monthly[1]},usagePercent:${monthly[0]}}
+  </script></html>`;
 }
 
 function mockDashboardSuccess(html: string) {
@@ -108,33 +112,74 @@ describe("opencode-go provider", () => {
     expect(mocks.fetchWithTimeout).not.toHaveBeenCalled();
   });
 
-  it("returns usage entry on successful dashboard scrape", async () => {
+  it("returns all three usage entries on successful dashboard scrape", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    const rolling: [number, number] = [0, 18000]; // 0%, 5h
+    const weekly: [number, number] = [100, 10271]; // 100%, ~2.8h
+    const monthly: [number, number] = [50, 2066217]; // 50%, ~24d
+
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtml(42, 1209600));
+    mockDashboardSuccess(buildDashboardHtml(rolling, weekly, monthly));
 
     const out = await runProviderFetch();
 
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toHaveLength(1);
+    expect(out.entries).toHaveLength(3);
+
     expect(out.entries[0]).toMatchObject({
-      name: "OpenCode Go",
-      group: "OpenCode Go",
-      label: "Monthly:",
-      percentRemaining: 58,
+      label: "Rolling:",
+      percentRemaining: 100,
     });
-    expect(out.entries[0]).toHaveProperty("resetTimeIso");
+    expect(out.entries[0]).not.toHaveProperty("resetTimeIso");
+    expect(out.entries[0]).not.toHaveProperty("resetText");
+
+    expect(out.entries[1]).toMatchObject({
+      label: "Weekly:",
+      percentRemaining: 0,
+      resetTimeIso: new Date(now + weekly[1] * 1000).toISOString(),
+    });
+    expect(out.entries[2]).toMatchObject({
+      label: "Monthly:",
+      percentRemaining: 50,
+      resetTimeIso: new Date(now + monthly[1] * 1000).toISOString(),
+    });
+
+    for (const entry of out.entries) {
+      expect(entry.group).toBe("OpenCode Go");
+    }
   });
 
-  it("parses resetInSec-first field order", async () => {
+  it("always shows countdown for Weekly and Monthly even with 0% usage", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtmlResetFirst(75, 604800));
+    mockDashboardSuccess(buildDashboardHtml([0, 18000], [0, 604800], [0, 2592000]));
 
     const out = await runProviderFetch();
-
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toHaveLength(1);
+
+    // Rolling: 0% -> blank
     expect(out.entries[0]).toMatchObject({
-      percentRemaining: 25,
+      label: "Rolling:",
+      percentRemaining: 100,
+    });
+    expect(out.entries[0].resetTimeIso).toBeUndefined();
+
+    // Weekly: 0% -> countdown
+    expect(out.entries[1]).toMatchObject({
+      label: "Weekly:",
+      percentRemaining: 100,
+      resetTimeIso: new Date(now + 604800 * 1000).toISOString(),
+    });
+
+    // Monthly: 0% -> countdown
+    expect(out.entries[2]).toMatchObject({
+      label: "Monthly:",
+      percentRemaining: 100,
+      resetTimeIso: new Date(now + 2592000 * 1000).toISOString(),
     });
   });
 
@@ -163,15 +208,6 @@ describe("opencode-go provider", () => {
     const out = await runProviderFetch();
     expectAttemptedWithErrorLabel(out, "OpenCode Go");
     expect(out.errors[0]?.message).toContain("network timeout");
-  });
-
-  it("lower-bounds usagePercent at 0 and allows over-100 usage values", async () => {
-    mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtml(150, 100));
-
-    const out = await runProviderFetch();
-    expectAttemptedWithNoErrors(out);
-    expect(out.entries[0]).toMatchObject({ percentRemaining: -50 });
   });
 
   it("sanitizes error text from dashboard responses", async () => {
@@ -212,77 +248,50 @@ describe("opencode-go isAvailable", () => {
   });
 });
 
-describe("_parseMonthlyUsage", () => {
+describe("_parseUsage", () => {
   it("returns null for empty string", () => {
-    expect(_parseMonthlyUsage("")).toBeNull();
+    expect(_parseUsage("", "monthlyUsage")).toBeNull();
   });
 
-  it("parses usagePercent-first ordering", () => {
-    const html = "monthlyUsage:$R[42]={usagePercent:55,resetInSec:3600}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 55, resetInSec: 3600 });
+  it("parses rollingUsage specifically", () => {
+    const html = "rollingUsage:$R[1]={usagePercent:5,resetInSec:100}";
+    expect(_parseUsage(html, "rollingUsage")).toEqual({ usagePercent: 5, resetInSec: 100 });
   });
 
-  it("parses resetInSec-first ordering", () => {
-    const html = "monthlyUsage:$R[7]={resetInSec:7200,usagePercent:30}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 30, resetInSec: 7200 });
+  it("parses weeklyUsage specifically", () => {
+    const html = "weeklyUsage:$R[1]={usagePercent:80,resetInSec:5000}";
+    expect(_parseUsage(html, "weeklyUsage")).toEqual({ usagePercent: 80, resetInSec: 5000 });
   });
 
-  it("returns null when pattern is missing", () => {
-    expect(_parseMonthlyUsage("<html><body>hello</body></html>")).toBeNull();
+  it("parses monthlyUsage specifically", () => {
+    const html = "monthlyUsage:$R[1]={usagePercent:55,resetInSec:3600}";
+    expect(_parseUsage(html, "monthlyUsage")).toEqual({ usagePercent: 55, resetInSec: 3600 });
   });
 
-  it("handles extra fields in the object", () => {
-    const html = "monthlyUsage:$R[1]={usagePercent:10,foo:bar,resetInSec:500}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 10, resetInSec: 500 });
-  });
-
-  it("handles quoted property names and spaces", () => {
-    const html = 'monthlyUsage:$R[123]={"usagePercent": 45, "resetInSec" : 7200}';
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 45, resetInSec: 7200 });
-  });
-
-  it("handles single quotes and decimal values", () => {
-    const html = "monthlyUsage:$R[0]={'usagePercent':12.5, 'resetInSec':30.5}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 12.5, resetInSec: 30.5 });
-  });
-
-  it("handles quoted numeric values", () => {
-    const html = 'monthlyUsage:$R[99]={usagePercent:"88",resetInSec:"1000"}';
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 88, resetInSec: 1000 });
-  });
-
-  it("handles variations of $R (e.g. no brackets, colon)", () => {
-    const html1 = "monthlyUsage:$R42={usagePercent:10,resetInSec:100}";
-    const html2 = "monthlyUsage:$R:7={usagePercent:20,resetInSec:200}";
-    const html3 = "monthlyUsage: $R = {usagePercent:30,resetInSec:300}";
-    expect(_parseMonthlyUsage(html1)).toEqual({ usagePercent: 10, resetInSec: 100 });
-    expect(_parseMonthlyUsage(html2)).toEqual({ usagePercent: 20, resetInSec: 200 });
-    expect(_parseMonthlyUsage(html3)).toEqual({ usagePercent: 30, resetInSec: 300 });
-  });
-
-  it("handles fuzzy matching of JSON objects without $R marker", () => {
-    const html = '<div>Data: {"usagePercent": 5, "resetInSec": 50}</div>';
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 5, resetInSec: 50 });
+  it("handles fuzzy matching scoped to the key", () => {
+    const html = 'rollingUsage: {"usagePercent": 5, "resetInSec": 50}';
+    expect(_parseUsage(html, "rollingUsage")).toEqual({ usagePercent: 5, resetInSec: 50 });
   });
 
   it("handles the exact pattern found in opencode.htm", () => {
-    const html = 'monthlyUsage:$R[33]={status:"ok",resetInSec:2066217,usagePercent:50}';
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 50, resetInSec: 2066217 });
+    const html = 'weeklyUsage:$R[32]={status:"rate-limited",resetInSec:10271,usagePercent:100}';
+    expect(_parseUsage(html, "weeklyUsage")).toEqual({ usagePercent: 100, resetInSec: 10271 });
   });
 
-  it("normalizes workspaceId if it is a full URL", async () => {
-    const fullUrl = "https://opencode.ai/workspace/wrk_999/go";
-    mockConfigConfigured(fullUrl, "auth-token");
-    mockDashboardSuccess(buildDashboardHtml(10, 100));
+  it("ignores unrelated scalar fields and finds the correct hydration object", () => {
+    // This HTML snippet mimics production where monthlyUsage appears as a scalar first (billing),
+    // then as a hydration object.
+    const html = `
+      "monthlyUsage": 1322715454,
+      "other": {"foo": "bar"},
+      monthlyUsage:$R[33]={status:"ok",resetInSec:2066217,usagePercent:50}
+    `;
+    expect(_parseUsage(html, "monthlyUsage")).toEqual({ usagePercent: 50, resetInSec: 2066217 });
+  });
 
-    await runProviderFetch();
-
-    // Verify fetchWithTimeout was called with the normalized URL
-    expect(mocks.fetchWithTimeout).toHaveBeenCalledWith(
-      "https://opencode.ai/workspace/wrk_999/go",
-      expect.any(Object),
-      expect.any(Number),
-    );
+  it("handles braces inside string literals", () => {
+    const html = 'rollingUsage:$R[1]={status:"contains { braces }",usagePercent:10,resetInSec:100}';
+    expect(_parseUsage(html, "rollingUsage")).toEqual({ usagePercent: 10, resetInSec: 100 });
   });
 
   it("returns error with masked snippet on parsing failure", async () => {
@@ -294,7 +303,7 @@ describe("_parseMonthlyUsage", () => {
     const out = await runProviderFetch();
     expectAttemptedWithErrorLabel(out, "OpenCode Go");
     expect(out.errors[0]?.message).toContain("Snippet:");
-    expect(out.errors[0]?.message).toContain("v3.3.2-diag");
+    expect(out.errors[0]?.message).toContain("v3.4.0-diag");
     expect(out.errors[0]?.message).toContain("***"); // Masked digits
     expect(out.errors[0]?.message).toContain("[EMAIL]"); // Masked email
   });


### PR DESCRIPTION
## Summary

This PR adds support for all three OpenCode Go usage windows—Rolling, Weekly, and Monthly—alongside a rewritten dashboard scraper (for robustness).

The previous implementation only parsed `monthlyUsage` and relied on brittle regex patterns that broke on dashboard markup changes (e.g., extra fields like status appearing between usage data). The scraper has been replaced with a strategy-based approach; [according to an LLM explaining the regex] it now uses "string-aware brace-depth matching and strict anchor isolation against $R[...] hydration markers". This correctly handles decoy keys (like billing metadata), braces inside string literals, and field order variations.

**Behavioral details:**
- `Rolling`: Timer is _blank_ when idle (0% usage), showing a live countdown only once usage begins
- `Weekly` / `Monthly`: Timers always display live countdowns since they don't depend on the user to initiate a session
- The three windows are ordered Rolling -> Weekly -> Monthly in the TUI sidebar
- A forceAllWindows presentation flag ensures all three display regardless of the user's chosen formatStyle in the config
- Diagnostics in `/quota_status` now report all three windows separately

Example:
```
opencode_go:
- config_state: configured
- config_source: env
- config_checked_paths: /home/arjun/.config/opencode/opencode-quota/opencode-go.json
- rolling_usage: used=8% rem=92% reset=15359s at=2026-04-27T05:48:20.888Z
- weekly_usage: used=3% rem=97% reset=599258s at=2026-05-03T23:59:59.888Z
- monthly_usage: used=51% rem=49% reset=2050404s at=2026-05-20T19:05:45.888Z
- live_probe: success
- live_entry_1: Rolling: percent_remaining=92 reset_at=2026-04-27T05:48:21.388Z
- live_entry_2: Weekly: percent_remaining=97 reset_at=2026-05-04T00:00:00.388Z
- live_more: +1 additional rows suppressed
...
```

What it looks like now:

<img width="439" height="206" alt="image" src="https://github.com/user-attachments/assets/9acfb1d1-16f6-4944-965d-2130f4cbb3c2" />


## Linked Issue

No existing issue. Rationale: The OpenCode Go quota was failing to be scraped, "throwing a vague `live_fetch_error` and was previously also limited to a single monthly usage window. This expands the provider to parity with the actual dashboard, which has always exposed all three windows.

## OpenCode Validation

- Current production released OpenCode version tested: 1.14.25, 1.14.26, 1.14.27
- Why this version is relevant to the fix: This is the latest stable version of OpenCode (as of April 26, 2026)

## Quality Checklist

- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
