### PR TITLE
fix: quote YAML description containing unescaped colon

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,7 +77,7 @@ body:
     id: logs
     attributes:
       label: Relevant logs/output
-      description: Required: paste `/quota_status` output (add test output if helpful).
+      description: "Required: paste `/quota_status` output (add test output if helpful)."
       render: shell
     validations:
       required: true


### PR DESCRIPTION
## Summary

Line 80 had an unquoted `:` in the description value which YAML parsed as a mapping separator, breaking the issue template.

## Linked Issue

Fixes #63 

## OpenCode Validation

- Current production released OpenCode version tested: N/A
- Why this version is relevant to the fix: N/A

## Quality Checklist

- [ ] I ran `npm run typecheck`
- [ ] I ran `npm test`
- [ ] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
