### PR TITLE
Feature/opencode go all windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ export OPENCODE_GO_WORKSPACE_ID="your-workspace-id"
 export OPENCODE_GO_AUTH_COOKIE="your-auth-cookie"
 ```
 
-The provider reports three usage windows — **5h** rolling, **Weekly**, and **Monthly** — which you can filter with `experimental.quotaToast.opencodeGoWindows` (`rolling`, `weekly`, `monthly`).
+The provider can report three usage windows — **5h** rolling, **Weekly**, and **Monthly** — and emits whichever dashboard windows are available in that order. Filter displayed windows with `experimental.quotaToast.opencodeGoWindows` (`rolling`, `weekly`, `monthly`); non-default subsets report missing selected dashboard fields, while default/all-windows mode shows available windows and diagnostics indicate what was found.
 
 Environment variables take precedence over the optional `opencode-go.json` config file. Run `/quota_status` to see the exact paths checked on your machine.
 
@@ -462,6 +462,7 @@ Run `/quota_status` and check the `opencode_go` section.
 | Config not detected | Set both `OPENCODE_GO_WORKSPACE_ID` and `OPENCODE_GO_AUTH_COOKIE`, then rerun `/quota_status`. |
 | Incomplete config | `workspaceId` and `authCookie` must come from the same source. |
 | Scrape returns no data | Refresh the browser `auth` cookie from `opencode.ai`. |
+| Selected window missing | Check `/quota_status` for `selected_windows` and `live_fetch_error`; remove unavailable windows from `experimental.quotaToast.opencodeGoWindows` or refresh the dashboard cookie. |
 | Dashboard format changed | This integration scrapes the dashboard, so it can break if the dashboard markup changes. |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Show every quota window instead of the default most-constrained window:
 }
 ```
 
-Choose which OpenCode Go usage windows to display (default is all three):
+Choose which OpenCode Go usage windows to display (default is all three; `rolling` displays as `5h`):
 
 ```jsonc
 {
@@ -305,7 +305,7 @@ export OPENCODE_GO_WORKSPACE_ID="your-workspace-id"
 export OPENCODE_GO_AUTH_COOKIE="your-auth-cookie"
 ```
 
-The provider reports three usage windows — **Rolling** (~5h), **Weekly**, and **Monthly** — which you can filter with `experimental.quotaToast.opencodeGoWindows`.
+The provider reports three usage windows — **5h** rolling, **Weekly**, and **Monthly** — which you can filter with `experimental.quotaToast.opencodeGoWindows` (`rolling`, `weekly`, `monthly`).
 
 Environment variables take precedence over the optional `opencode-go.json` config file. Run `/quota_status` to see the exact paths checked on your machine.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ Show every quota window instead of the default most-constrained window:
 }
 ```
 
+Choose which OpenCode Go usage windows to display (default is all three):
+
+```jsonc
+{
+  "experimental": {
+    "quotaToast": {
+      "opencodeGoWindows": ["rolling", "weekly", "monthly"],
+    },
+  },
+}
+```
+
 Show percentages as used instead of remaining in toasts and the sidebar:
 
 ```jsonc
@@ -292,6 +304,8 @@ OpenCode Go quota scrapes the dashboard and needs a workspace ID plus an `auth` 
 export OPENCODE_GO_WORKSPACE_ID="your-workspace-id"
 export OPENCODE_GO_AUTH_COOKIE="your-auth-cookie"
 ```
+
+The provider reports three usage windows — **Rolling** (~5h), **Weekly**, and **Monthly** — which you can filter with `experimental.quotaToast.opencodeGoWindows`.
 
 Environment variables take precedence over the optional `opencode-go.json` config file. Run `/quota_status` to see the exact paths checked on your machine.
 

--- a/src/lib/cli-show.ts
+++ b/src/lib/cli-show.ts
@@ -91,6 +91,7 @@ function cloneCliConfig(config: QuotaToastConfig): QuotaToastConfig {
       ? [...config.enabledProviders]
       : config.enabledProviders,
     googleModels: [...config.googleModels],
+    opencodeGoWindows: [...config.opencodeGoWindows],
     pricingSnapshot: { ...config.pricingSnapshot },
     layout: { ...config.layout },
     showSessionTokens: false,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -39,6 +39,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "cursorPlan",
   "cursorIncludedApiUsd",
   "cursorBillingCycleStartDay",
+  "opencodeGoWindows",
   "pricingSnapshot.source",
   "pricingSnapshot.autoRefresh",
   "showOnIdle",
@@ -121,6 +122,7 @@ type ValidatedQuotaToastPatch = {
   cursorPlan?: CursorQuotaPlan;
   cursorIncludedApiUsd?: number;
   cursorBillingCycleStartDay?: number;
+  opencodeGoWindows?: Array<"rolling" | "weekly" | "monthly">;
   pricingSnapshot?: PricingSnapshotPatch;
   showOnIdle?: boolean;
   showOnQuestion?: boolean;
@@ -179,6 +181,14 @@ function isPositiveNumber(value: unknown): value is number {
 
 function isValidCursorBillingCycleStartDay(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 28;
+}
+
+const VALID_OPENCODE_GO_WINDOWS = ["rolling", "weekly", "monthly"] as const;
+
+function isValidOpenCodeGoWindows(value: unknown): value is Array<"rolling" | "weekly" | "monthly"> {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0) return false;
+  return value.every((v) => typeof v === "string" && VALID_OPENCODE_GO_WINDOWS.includes(v as typeof VALID_OPENCODE_GO_WINDOWS[number]));
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -422,6 +432,13 @@ function extractValidatedQuotaToastPatch(
     patch.cursorBillingCycleStartDay = quotaToastConfig.cursorBillingCycleStartDay;
   }
 
+  if (
+    hasOwnKey(quotaToastConfig, "opencodeGoWindows") &&
+    isValidOpenCodeGoWindows(quotaToastConfig.opencodeGoWindows)
+  ) {
+    patch.opencodeGoWindows = quotaToastConfig.opencodeGoWindows;
+  }
+
   if (hasOwnKey(quotaToastConfig, "pricingSnapshot")) {
     const pricingSnapshot = extractPricingSnapshotPatch(quotaToastConfig.pricingSnapshot);
     if (pricingSnapshot) {
@@ -565,6 +582,11 @@ function applyValidatedQuotaToastPatch(
   if (hasOwnKey(patch, "cursorBillingCycleStartDay")) {
     config.cursorBillingCycleStartDay = patch.cursorBillingCycleStartDay;
     applySettingSource(settingSources, "cursorBillingCycleStartDay", sourcePath);
+  }
+
+  if (hasOwnKey(patch, "opencodeGoWindows")) {
+    config.opencodeGoWindows = [...patch.opencodeGoWindows!];
+    applySettingSource(settingSources, "opencodeGoWindows", sourcePath);
   }
 
   if (patch.pricingSnapshot) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -233,6 +233,7 @@ function cloneDefaultConfig(): QuotaToastConfig {
       ? [...DEFAULT_CONFIG.enabledProviders]
       : DEFAULT_CONFIG.enabledProviders,
     googleModels: [...DEFAULT_CONFIG.googleModels],
+    opencodeGoWindows: [...DEFAULT_CONFIG.opencodeGoWindows],
     pricingSnapshot: { ...DEFAULT_CONFIG.pricingSnapshot },
     layout: { ...DEFAULT_CONFIG.layout },
   };

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -106,6 +106,7 @@ export interface QuotaProviderContext {
     cursorPlan: CursorQuotaPlan;
     cursorIncludedApiUsd?: number;
     cursorBillingCycleStartDay?: number;
+    opencodeGoWindows?: Array<"rolling" | "weekly" | "monthly">;
     onlyCurrentModel?: boolean;
     currentModel?: string;
     currentProviderID?: string;

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -1,4 +1,4 @@
-import type { CursorQuotaPlan } from "./types.js";
+import type { CursorQuotaPlan, OpenCodeGoWindowKey } from "./types.js";
 
 /**
  * Normalized quota output model.
@@ -106,7 +106,7 @@ export interface QuotaProviderContext {
     cursorPlan: CursorQuotaPlan;
     cursorIncludedApiUsd?: number;
     cursorBillingCycleStartDay?: number;
-    opencodeGoWindows?: Array<"rolling" | "weekly" | "monthly">;
+    opencodeGoWindows?: OpenCodeGoWindowKey[];
     onlyCurrentModel?: boolean;
     currentModel?: string;
     currentProviderID?: string;

--- a/src/lib/grouped-entry-normalization.ts
+++ b/src/lib/grouped-entry-normalization.ts
@@ -51,7 +51,7 @@ function getDurationRankFromText(value?: string): number | null {
   if (!text) return null;
 
   if (/\b(?:rpm|per minute|minute|minutes)\b/u.test(text)) return 1;
-  if (/\b(?:5h|5 h|5-hour|5 hour|five-hour|five hour)\b/u.test(text)) return 300;
+  if (/\b(?:rolling|5h|5 h|5-hour|5 hour|five-hour|five hour)\b/u.test(text)) return 300;
   if (/\b(?:hourly|1h|1 h|1-hour|1 hour|hour)\b/u.test(text)) return 60;
   if (/\b(?:7d|7 d|7-day|7 day|weekly|week)\b/u.test(text)) return 10080;
   if (/\b(?:daily|1d|1 d|1-day|1 day|day)\b/u.test(text)) return 1440;

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -2,7 +2,8 @@
  * OpenCode Go dashboard scraper.
  *
  * Fetches the OpenCode Go workspace page and parses SolidJS SSR hydration
- * output for `monthlyUsage` containing `usagePercent` and `resetInSec`.
+ * output for `rollingUsage`, `weeklyUsage`, and `monthlyUsage` containing
+ * `usagePercent` and `resetInSec`.
  */
 
 import { fetchWithTimeout } from "./http.js";
@@ -19,18 +20,32 @@ const SCRAPE_TIMEOUT_MS = 10_000;
  * Regex patterns matching the SolidJS SSR hydration output.
  * Field order may vary, so we try both orderings.
  */
+const RE_ROLLING_PCT_FIRST =
+  /rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:(\d+)[^}]*resetInSec:(\d+)[^}]*\}/;
+const RE_ROLLING_RESET_FIRST =
+  /rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:(\d+)[^}]*usagePercent:(\d+)[^}]*\}/;
+
+const RE_WEEKLY_PCT_FIRST =
+  /weeklyUsage:\$R\[\d+\]=\{[^}]*usagePercent:(\d+)[^}]*resetInSec:(\d+)[^}]*\}/;
+const RE_WEEKLY_RESET_FIRST =
+  /weeklyUsage:\$R\[\d+\]=\{[^}]*resetInSec:(\d+)[^}]*usagePercent:(\d+)[^}]*\}/;
+
 const RE_MONTHLY_PCT_FIRST =
   /monthlyUsage:\$R\[\d+\]=\{[^}]*usagePercent:(\d+)[^}]*resetInSec:(\d+)[^}]*\}/;
 const RE_MONTHLY_RESET_FIRST =
   /monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:(\d+)[^}]*usagePercent:(\d+)[^}]*\}/;
 
-interface ScrapedMonthlyUsage {
+interface ScrapedWindowUsage {
   usagePercent: number;
   resetInSec: number;
 }
 
-function parseMonthlyUsage(html: string): ScrapedMonthlyUsage | null {
-  const pctFirstMatch = RE_MONTHLY_PCT_FIRST.exec(html);
+function parseWindowUsage(
+  html: string,
+  rePctFirst: RegExp,
+  reResetFirst: RegExp,
+): ScrapedWindowUsage | null {
+  const pctFirstMatch = rePctFirst.exec(html);
   if (pctFirstMatch) {
     const usagePercent = Number(pctFirstMatch[1]);
     const resetInSec = Number(pctFirstMatch[2]);
@@ -39,7 +54,7 @@ function parseMonthlyUsage(html: string): ScrapedMonthlyUsage | null {
     }
   }
 
-  const resetFirstMatch = RE_MONTHLY_RESET_FIRST.exec(html);
+  const resetFirstMatch = reResetFirst.exec(html);
   if (resetFirstMatch) {
     const resetInSec = Number(resetFirstMatch[1]);
     const usagePercent = Number(resetFirstMatch[2]);
@@ -85,26 +100,47 @@ export async function queryOpenCodeGoQuota(
     }
 
     const html = await response.text();
-    const monthly = parseMonthlyUsage(html);
+    const rolling = parseWindowUsage(html, RE_ROLLING_PCT_FIRST, RE_ROLLING_RESET_FIRST);
+    const weekly = parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST);
+    const monthly = parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST);
 
-    if (!monthly) {
+    if (!rolling || !weekly || !monthly) {
+      const missing: string[] = [];
+      if (!rolling) missing.push("rollingUsage");
+      if (!weekly) missing.push("weeklyUsage");
+      if (!monthly) missing.push("monthlyUsage");
       return {
         success: false,
-        error: "Could not parse monthly usage from OpenCode Go dashboard",
+        error: `Could not parse ${missing.join(", ")} from OpenCode Go dashboard`,
       };
     }
 
-    const usagePercent = Math.max(0, monthly.usagePercent);
-    const percentRemaining = 100 - usagePercent;
-    const resetInSec = Math.max(0, monthly.resetInSec);
-    const resetTimeIso = new Date(Date.now() + resetInSec * 1000).toISOString();
+    const now = Date.now();
+
+    const rollingUsagePercent = Math.max(0, rolling.usagePercent);
+    const weeklyUsagePercent = Math.max(0, weekly.usagePercent);
+    const monthlyUsagePercent = Math.max(0, monthly.usagePercent);
 
     return {
       success: true,
-      usagePercent,
-      resetInSec,
-      percentRemaining,
-      resetTimeIso,
+      rolling: {
+        usagePercent: rollingUsagePercent,
+        resetInSec: Math.max(0, rolling.resetInSec),
+        percentRemaining: 100 - rollingUsagePercent,
+        resetTimeIso: new Date(now + Math.max(0, rolling.resetInSec) * 1000).toISOString(),
+      },
+      weekly: {
+        usagePercent: weeklyUsagePercent,
+        resetInSec: Math.max(0, weekly.resetInSec),
+        percentRemaining: 100 - weeklyUsagePercent,
+        resetTimeIso: new Date(now + Math.max(0, weekly.resetInSec) * 1000).toISOString(),
+      },
+      monthly: {
+        usagePercent: monthlyUsagePercent,
+        resetInSec: Math.max(0, monthly.resetInSec),
+        percentRemaining: 100 - monthlyUsagePercent,
+        resetTimeIso: new Date(now + Math.max(0, monthly.resetInSec) * 1000).toISOString(),
+      },
     };
   } catch (err) {
     return {
@@ -114,4 +150,4 @@ export async function queryOpenCodeGoQuota(
   }
 }
 
-export { parseMonthlyUsage as _parseMonthlyUsage };
+export { parseWindowUsage as _parseWindowUsage };

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -2,13 +2,13 @@
  * OpenCode Go dashboard scraper.
  *
  * Fetches the OpenCode Go workspace page and parses SolidJS SSR hydration
- * output for `rollingUsage`, `weeklyUsage`, and `monthlyUsage` containing
- * `usagePercent` and `resetInSec`.
+ * output for known usage windows (`rollingUsage`, `weeklyUsage`, and
+ * `monthlyUsage`) containing `usagePercent` and `resetInSec`.
  */
 
 import { fetchWithTimeout } from "./http.js";
 import { sanitizeDisplayText } from "./display-sanitize.js";
-import type { OpenCodeGoResult } from "./types.js";
+import type { OpenCodeGoResult, OpenCodeGoWindow } from "./types.js";
 
 const DASHBOARD_URL_PREFIX = "https://opencode.ai/workspace/";
 const DASHBOARD_URL_SUFFIX = "/go";
@@ -71,6 +71,18 @@ function sanitizeMessage(text: string, maxLength = 120): string {
   return (sanitized || "unknown").slice(0, maxLength);
 }
 
+function normalizeWindowUsage(window: ScrapedWindowUsage, now: number): OpenCodeGoWindow {
+  const usagePercent = Math.max(0, window.usagePercent);
+  const resetInSec = Math.max(0, window.resetInSec);
+
+  return {
+    usagePercent,
+    resetInSec,
+    percentRemaining: 100 - usagePercent,
+    resetTimeIso: new Date(now + resetInSec * 1000).toISOString(),
+  };
+}
+
 export async function queryOpenCodeGoQuota(
   workspaceId: string,
   authCookie: string,
@@ -104,43 +116,21 @@ export async function queryOpenCodeGoQuota(
     const weekly = parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST);
     const monthly = parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST);
 
-    if (!rolling || !weekly || !monthly) {
-      const missing: string[] = [];
-      if (!rolling) missing.push("rollingUsage");
-      if (!weekly) missing.push("weeklyUsage");
-      if (!monthly) missing.push("monthlyUsage");
+    if (!rolling && !weekly && !monthly) {
       return {
         success: false,
-        error: `Could not parse ${missing.join(", ")} from OpenCode Go dashboard`,
+        error:
+          "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)",
       };
     }
 
     const now = Date.now();
 
-    const rollingUsagePercent = Math.max(0, rolling.usagePercent);
-    const weeklyUsagePercent = Math.max(0, weekly.usagePercent);
-    const monthlyUsagePercent = Math.max(0, monthly.usagePercent);
-
     return {
       success: true,
-      rolling: {
-        usagePercent: rollingUsagePercent,
-        resetInSec: Math.max(0, rolling.resetInSec),
-        percentRemaining: 100 - rollingUsagePercent,
-        resetTimeIso: new Date(now + Math.max(0, rolling.resetInSec) * 1000).toISOString(),
-      },
-      weekly: {
-        usagePercent: weeklyUsagePercent,
-        resetInSec: Math.max(0, weekly.resetInSec),
-        percentRemaining: 100 - weeklyUsagePercent,
-        resetTimeIso: new Date(now + Math.max(0, weekly.resetInSec) * 1000).toISOString(),
-      },
-      monthly: {
-        usagePercent: monthlyUsagePercent,
-        resetInSec: Math.max(0, monthly.resetInSec),
-        percentRemaining: 100 - monthlyUsagePercent,
-        resetTimeIso: new Date(now + Math.max(0, monthly.resetInSec) * 1000).toISOString(),
-      },
+      ...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
+      ...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
+      ...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
     };
   } catch (err) {
     return {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -105,6 +105,7 @@ function buildQuotaProviderContext(params: {
       cursorPlan: config.cursorPlan,
       cursorIncludedApiUsd: config.cursorIncludedApiUsd,
       cursorBillingCycleStartDay: config.cursorBillingCycleStartDay,
+      opencodeGoWindows: config.opencodeGoWindows,
       onlyCurrentModel: config.onlyCurrentModel,
       currentModel,
       currentProviderID,

--- a/src/lib/quota-runtime-context.ts
+++ b/src/lib/quota-runtime-context.ts
@@ -111,6 +111,7 @@ export function createQuotaProviderRuntimeContext(
       cursorPlan: runtime.config.cursorPlan,
       cursorIncludedApiUsd: runtime.config.cursorIncludedApiUsd,
       cursorBillingCycleStartDay: runtime.config.cursorBillingCycleStartDay,
+      opencodeGoWindows: runtime.config.opencodeGoWindows,
       onlyCurrentModel: runtime.config.onlyCurrentModel,
       currentModel: runtime.session.sessionMeta?.modelID,
       currentProviderID: runtime.session.sessionMeta?.providerID,

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -43,12 +43,13 @@ export function buildQuotaProviderStateCacheKey(
   const cursorPlan = ctx.config.cursorPlan;
   const cursorIncludedApiUsd = ctx.config.cursorIncludedApiUsd ?? "";
   const cursorBillingCycleStartDay = ctx.config.cursorBillingCycleStartDay ?? "";
+  const opencodeGoWindows = ctx.config.opencodeGoWindows?.join(",") ?? "";
   const onlyCurrentModel = ctx.config.onlyCurrentModel ? "yes" : "no";
   const currentModel = ctx.config.currentModel ?? "";
   const currentProviderID = ctx.config.currentProviderID ?? "";
   const anthropicBinaryPath = ctx.config.anthropicBinaryPath ?? "";
 
-  return `${providerId}|anthropicBinaryPath=${anthropicBinaryPath}|googleModels=${googleModels}|alibabaTier=${alibabaCodingPlanTier}|cursorPlan=${cursorPlan}|cursorIncludedApiUsd=${cursorIncludedApiUsd}|cursorBillingCycleStartDay=${cursorBillingCycleStartDay}|onlyCurrentModel=${onlyCurrentModel}|currentModel=${currentModel}|currentProviderID=${currentProviderID}`;
+  return `${providerId}|anthropicBinaryPath=${anthropicBinaryPath}|googleModels=${googleModels}|alibabaTier=${alibabaCodingPlanTier}|cursorPlan=${cursorPlan}|cursorIncludedApiUsd=${cursorIncludedApiUsd}|cursorBillingCycleStartDay=${cursorBillingCycleStartDay}|opencodeGoWindows=${opencodeGoWindows}|onlyCurrentModel=${onlyCurrentModel}|currentModel=${currentModel}|currentProviderID=${currentProviderID}`;
 }
 
 function getQuotaProviderCacheDir(): string {

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -1067,8 +1067,16 @@ export async function buildQuotaStatusReport(params: {
         openCodeGoRows.push({ key: "live_fetch_error", value: openCodeGoQuota.error });
       } else {
         openCodeGoRows.push({
+          key: "rolling_usage",
+          value: `percent_used=${openCodeGoQuota.rolling.usagePercent} percent_remaining=${openCodeGoQuota.rolling.percentRemaining} reset_in_sec=${openCodeGoQuota.rolling.resetInSec} reset_at=${openCodeGoQuota.rolling.resetTimeIso}`,
+        });
+        openCodeGoRows.push({
+          key: "weekly_usage",
+          value: `percent_used=${openCodeGoQuota.weekly.usagePercent} percent_remaining=${openCodeGoQuota.weekly.percentRemaining} reset_in_sec=${openCodeGoQuota.weekly.resetInSec} reset_at=${openCodeGoQuota.weekly.resetTimeIso}`,
+        });
+        openCodeGoRows.push({
           key: "monthly_usage",
-          value: `percent_used=${openCodeGoQuota.usagePercent} percent_remaining=${openCodeGoQuota.percentRemaining} reset_in_sec=${openCodeGoQuota.resetInSec} reset_at=${openCodeGoQuota.resetTimeIso}`,
+          value: `percent_used=${openCodeGoQuota.monthly.usagePercent} percent_remaining=${openCodeGoQuota.monthly.percentRemaining} reset_in_sec=${openCodeGoQuota.monthly.resetInSec} reset_at=${openCodeGoQuota.monthly.resetTimeIso}`,
         });
       }
     }

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -83,7 +83,12 @@ import { getCursorPlanDisplayName, getEffectiveCursorIncludedApiUsd } from "./cu
 import { getQuotaProviderDisplayLabel } from "./provider-metadata.js";
 import type { QuotaProviderResult, QuotaToastEntry, QuotaToastError } from "./entries.js";
 import { isValueEntry } from "./entries.js";
-import type { CursorQuotaPlan, PricingSnapshotSource } from "./types.js";
+import type {
+  CursorQuotaPlan,
+  OpenCodeGoWindow,
+  OpenCodeGoWindowKey,
+  PricingSnapshotSource,
+} from "./types.js";
 import { queryMiniMaxQuota } from "../providers/minimax-coding-plan.js";
 import { queryZaiQuota } from "./zai.js";
 import {
@@ -139,6 +144,12 @@ const STATUS_SAMPLE_LIMIT = 5;
 const STATUS_LIVE_ENTRY_LIMIT = 2;
 const STATUS_LIVE_ERROR_LIMIT = 2;
 const STATUS_LIVE_ROW_MAX_LENGTH = 120;
+const OPENCODE_GO_STATUS_WINDOW_ORDER: OpenCodeGoWindowKey[] = ["rolling", "weekly", "monthly"];
+const OPENCODE_GO_STATUS_WINDOW_FIELDS: Record<OpenCodeGoWindowKey, string> = {
+  rolling: "rollingUsage",
+  weekly: "weeklyUsage",
+  monthly: "monthlyUsage",
+};
 
 type ProviderLiveProbe = {
   providerId: string;
@@ -147,6 +158,25 @@ type ProviderLiveProbe = {
 
 function joinOrNone(values: string[]): string {
   return values.length > 0 ? values.join(" | ") : "(none)";
+}
+
+function formatOpenCodeGoWindowSelection(windows: OpenCodeGoWindowKey[]): string {
+  return windows.join(",");
+}
+
+function isDefaultOpenCodeGoStatusWindowSelection(windows: OpenCodeGoWindowKey[]): boolean {
+  return (
+    windows.length === OPENCODE_GO_STATUS_WINDOW_ORDER.length &&
+    OPENCODE_GO_STATUS_WINDOW_ORDER.every((window, index) => windows[index] === window)
+  );
+}
+
+function formatOpenCodeGoMissingWindows(windows: OpenCodeGoWindowKey[]): string {
+  return windows.map((window) => `${window} (${OPENCODE_GO_STATUS_WINDOW_FIELDS[window]})`).join(", ");
+}
+
+function formatOpenCodeGoUsage(window: OpenCodeGoWindow): string {
+  return `percent_used=${window.usagePercent} percent_remaining=${window.percentRemaining} reset_in_sec=${window.resetInSec} reset_at=${window.resetTimeIso}`;
 }
 
 function formatSettingSources(sources: QuotaToastSettingSources | undefined): string {
@@ -563,6 +593,7 @@ export async function buildQuotaStatusReport(params: {
   cursorPlan: CursorQuotaPlan;
   cursorIncludedApiUsd?: number;
   cursorBillingCycleStartDay?: number;
+  opencodeGoWindows?: OpenCodeGoWindowKey[];
   pricingSnapshotSource: PricingSnapshotSource;
   onlyCurrentModel: boolean;
   currentModel?: string;
@@ -1047,6 +1078,11 @@ export async function buildQuotaStatusReport(params: {
     openCodeGoRows.push({ key: "config_error", value: sanitizeDisplayText(openCodeGoDiag.error) });
   }
   openCodeGoRows.push({ key: "config_checked_paths", value: joinOrNone(openCodeGoDiag.checkedPaths) });
+  const openCodeGoSelectedWindows = params.opencodeGoWindows ?? OPENCODE_GO_STATUS_WINDOW_ORDER;
+  openCodeGoRows.push({
+    key: "selected_windows",
+    value: formatOpenCodeGoWindowSelection(openCodeGoSelectedWindows),
+  });
   if (openCodeGoDiag.state === "configured") {
     const openCodeGoConfig = await resolveOpenCodeGoConfigCached({
       maxAgeMs: DEFAULT_OPENCODE_GO_CONFIG_CACHE_MAX_AGE_MS,
@@ -1066,18 +1102,26 @@ export async function buildQuotaStatusReport(params: {
       } else if (!openCodeGoQuota.success) {
         openCodeGoRows.push({ key: "live_fetch_error", value: openCodeGoQuota.error });
       } else {
-        openCodeGoRows.push({
-          key: "rolling_usage",
-          value: `percent_used=${openCodeGoQuota.rolling.usagePercent} percent_remaining=${openCodeGoQuota.rolling.percentRemaining} reset_in_sec=${openCodeGoQuota.rolling.resetInSec} reset_at=${openCodeGoQuota.rolling.resetTimeIso}`,
-        });
-        openCodeGoRows.push({
-          key: "weekly_usage",
-          value: `percent_used=${openCodeGoQuota.weekly.usagePercent} percent_remaining=${openCodeGoQuota.weekly.percentRemaining} reset_in_sec=${openCodeGoQuota.weekly.resetInSec} reset_at=${openCodeGoQuota.weekly.resetTimeIso}`,
-        });
-        openCodeGoRows.push({
-          key: "monthly_usage",
-          value: `percent_used=${openCodeGoQuota.monthly.usagePercent} percent_remaining=${openCodeGoQuota.monthly.percentRemaining} reset_in_sec=${openCodeGoQuota.monthly.resetInSec} reset_at=${openCodeGoQuota.monthly.resetTimeIso}`,
-        });
+        for (const window of OPENCODE_GO_STATUS_WINDOW_ORDER) {
+          const usage = openCodeGoQuota[window];
+          if (!usage) continue;
+
+          openCodeGoRows.push({
+            key: `${window}_usage`,
+            value: formatOpenCodeGoUsage(usage),
+          });
+        }
+
+        const missingSelectedWindows = openCodeGoSelectedWindows.filter((window) => !openCodeGoQuota[window]);
+        if (
+          missingSelectedWindows.length > 0 &&
+          !isDefaultOpenCodeGoStatusWindowSelection(openCodeGoSelectedWindows)
+        ) {
+          openCodeGoRows.push({
+            key: "live_fetch_error",
+            value: `Selected OpenCode Go dashboard window(s) missing: ${formatOpenCodeGoMissingWindows(missingSelectedWindows)}`,
+          });
+        }
       }
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -573,18 +573,28 @@ export type SyntheticResult =
   | QuotaError
   | null;
 
+/** Single usage window from OpenCode Go dashboard */
+export interface OpenCodeGoWindow {
+  /** Usage percentage [0..100] */
+  usagePercent: number;
+  /** Seconds until usage resets */
+  resetInSec: number;
+  /** Remaining percentage [0..100] */
+  percentRemaining: number;
+  /** ISO reset timestamp */
+  resetTimeIso: string;
+}
+
 /** Result from scraping OpenCode Go dashboard usage */
 export type OpenCodeGoResult =
   | {
       success: true;
-      /** Usage percentage [0..100] */
-      usagePercent: number;
-      /** Seconds until usage resets */
-      resetInSec: number;
-      /** Remaining percentage [0..100] */
-      percentRemaining: number;
-      /** ISO reset timestamp */
-      resetTimeIso: string;
+      /** Rolling (~5h) usage window */
+      rolling: OpenCodeGoWindow;
+      /** Weekly usage window */
+      weekly: OpenCodeGoWindow;
+      /** Monthly usage window */
+      monthly: OpenCodeGoWindow;
     }
   | QuotaError
   | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export type GeminiCliAuthSourceKey =
 export type CursorQuotaPlan = "none" | "pro" | "pro-plus" | "ultra";
 export type PricingSnapshotSource = "auto" | "bundled" | "runtime";
 export type PercentDisplayMode = "remaining" | "used";
+export type OpenCodeGoWindowKey = "rolling" | "weekly" | "monthly";
 
 export interface PricingSnapshotConfig {
   source: PricingSnapshotSource;
@@ -77,7 +78,7 @@ export interface QuotaToastConfig {
    * Which OpenCode Go usage windows to display.
    * Defaults to ["rolling", "weekly", "monthly"].
    */
-  opencodeGoWindows: Array<"rolling" | "weekly" | "monthly">;
+  opencodeGoWindows: OpenCodeGoWindowKey[];
   cursorIncludedApiUsd?: number;
   cursorBillingCycleStartDay?: number;
   pricingSnapshot: PricingSnapshotConfig;
@@ -595,12 +596,12 @@ export interface OpenCodeGoWindow {
 export type OpenCodeGoResult =
   | {
       success: true;
-      /** Rolling (~5h) usage window */
-      rolling: OpenCodeGoWindow;
-      /** Weekly usage window */
-      weekly: OpenCodeGoWindow;
-      /** Monthly usage window */
-      monthly: OpenCodeGoWindow;
+      /** Rolling (~5h) usage window, when present in the dashboard payload */
+      rolling?: OpenCodeGoWindow;
+      /** Weekly usage window, when present in the dashboard payload */
+      weekly?: OpenCodeGoWindow;
+      /** Monthly usage window, when present in the dashboard payload */
+      monthly?: OpenCodeGoWindow;
     }
   | QuotaError
   | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,11 @@ export interface QuotaToastConfig {
   googleModels: GoogleModelId[];
   alibabaCodingPlanTier: AlibabaCodingPlanTier;
   cursorPlan: CursorQuotaPlan;
+  /**
+   * Which OpenCode Go usage windows to display.
+   * Defaults to ["rolling", "weekly", "monthly"].
+   */
+  opencodeGoWindows: Array<"rolling" | "weekly" | "monthly">;
   cursorIncludedApiUsd?: number;
   cursorBillingCycleStartDay?: number;
   pricingSnapshot: PricingSnapshotConfig;
@@ -125,6 +130,7 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
   googleModels: ["CLAUDE"],
   alibabaCodingPlanTier: "lite",
   cursorPlan: "none",
+  opencodeGoWindows: ["rolling", "weekly", "monthly"],
   pricingSnapshot: {
     source: "auto",
     autoRefresh: 7,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1399,6 +1399,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       cursorPlan: runtimeConfig.cursorPlan,
       cursorIncludedApiUsd: runtimeConfig.cursorIncludedApiUsd,
       cursorBillingCycleStartDay: runtimeConfig.cursorBillingCycleStartDay,
+      opencodeGoWindows: runtimeConfig.opencodeGoWindows,
       pricingSnapshotSource: runtimeConfig.pricingSnapshot.source,
       onlyCurrentModel: runtimeConfig.onlyCurrentModel,
       currentModel,

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -5,7 +5,13 @@
  * weekly, and monthly usage as percentage-based quota entries.
  */
 
-import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import type { OpenCodeGoResult, OpenCodeGoWindowKey } from "../lib/types.js";
 import {
   DEFAULT_OPENCODE_GO_CONFIG_CACHE_MAX_AGE_MS,
   resolveOpenCodeGoConfigCached,
@@ -15,6 +21,64 @@ import { normalizeQuotaProviderId } from "../lib/provider-metadata.js";
 import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
 
 const OPENCODE_GO_PROVIDER_LABEL = "OpenCode Go";
+const OPENCODE_GO_WINDOW_ORDER: OpenCodeGoWindowKey[] = ["rolling", "weekly", "monthly"];
+const OPENCODE_GO_WINDOW_LABELS: Record<
+  OpenCodeGoWindowKey,
+  { name: string; label: string; dashboardField: string }
+> = {
+  rolling: {
+    name: `${OPENCODE_GO_PROVIDER_LABEL} 5h`,
+    label: "5h:",
+    dashboardField: "rollingUsage",
+  },
+  weekly: {
+    name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`,
+    label: "Weekly:",
+    dashboardField: "weeklyUsage",
+  },
+  monthly: {
+    name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`,
+    label: "Monthly:",
+    dashboardField: "monthlyUsage",
+  },
+};
+
+function isDefaultOpenCodeGoWindowSelection(windows: OpenCodeGoWindowKey[]): boolean {
+  return (
+    windows.length === OPENCODE_GO_WINDOW_ORDER.length &&
+    OPENCODE_GO_WINDOW_ORDER.every((window, index) => windows[index] === window)
+  );
+}
+
+function formatMissingWindowList(windows: OpenCodeGoWindowKey[]): string {
+  return windows.map((window) => `${window} (${OPENCODE_GO_WINDOW_LABELS[window].dashboardField})`).join(", ");
+}
+
+function buildOpenCodeGoEntries(
+  result: Extract<OpenCodeGoResult, { success: true }>,
+  selectedWindows: OpenCodeGoWindowKey[],
+): QuotaToastEntry[] {
+  const selected = new Set(selectedWindows);
+  const entries: QuotaToastEntry[] = [];
+
+  for (const window of OPENCODE_GO_WINDOW_ORDER) {
+    if (!selected.has(window)) continue;
+
+    const usage = result[window];
+    if (!usage) continue;
+
+    const labels = OPENCODE_GO_WINDOW_LABELS[window];
+    entries.push({
+      name: labels.name,
+      group: OPENCODE_GO_PROVIDER_LABEL,
+      label: labels.label,
+      percentRemaining: usage.percentRemaining,
+      resetTimeIso: usage.resetTimeIso,
+    });
+  }
+
+  return entries;
+}
 
 export const opencodeGoProvider: QuotaProvider = {
   id: "opencode-go",
@@ -64,37 +128,17 @@ export const opencodeGoProvider: QuotaProvider = {
       return attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, result.error);
     }
 
-    const windows = _ctx.config.opencodeGoWindows ?? ["rolling", "weekly", "monthly"];
-    const entries = [];
+    const windows = _ctx.config.opencodeGoWindows ?? OPENCODE_GO_WINDOW_ORDER;
+    const entries = buildOpenCodeGoEntries(result, windows);
+    const missingSelectedWindows = windows.filter((window) => !result[window]);
 
-    if (windows.includes("rolling")) {
-      entries.push({
-        name: `${OPENCODE_GO_PROVIDER_LABEL} 5h`,
-        group: OPENCODE_GO_PROVIDER_LABEL,
-        label: "5h:",
-        percentRemaining: result.rolling.percentRemaining,
-        resetTimeIso: result.rolling.resetTimeIso,
-      });
-    }
-
-    if (windows.includes("weekly")) {
-      entries.push({
-        name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`,
-        group: OPENCODE_GO_PROVIDER_LABEL,
-        label: "Weekly:",
-        percentRemaining: result.weekly.percentRemaining,
-        resetTimeIso: result.weekly.resetTimeIso,
-      });
-    }
-
-    if (windows.includes("monthly")) {
-      entries.push({
-        name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`,
-        group: OPENCODE_GO_PROVIDER_LABEL,
-        label: "Monthly:",
-        percentRemaining: result.monthly.percentRemaining,
-        resetTimeIso: result.monthly.resetTimeIso,
-      });
+    if (missingSelectedWindows.length > 0 && !isDefaultOpenCodeGoWindowSelection(windows)) {
+      return attemptedResult(entries, [
+        {
+          label: OPENCODE_GO_PROVIDER_LABEL,
+          message: `Selected OpenCode Go dashboard window(s) missing: ${formatMissingWindowList(missingSelectedWindows)}`,
+        },
+      ]);
     }
 
     return attemptedResult(entries);

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -69,9 +69,9 @@ export const opencodeGoProvider: QuotaProvider = {
 
     if (windows.includes("rolling")) {
       entries.push({
-        name: `${OPENCODE_GO_PROVIDER_LABEL} Rolling`,
+        name: `${OPENCODE_GO_PROVIDER_LABEL} 5h`,
         group: OPENCODE_GO_PROVIDER_LABEL,
-        label: "Rolling:",
+        label: "5h:",
         percentRemaining: result.rolling.percentRemaining,
         resetTimeIso: result.rolling.resetTimeIso,
       });

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -64,28 +64,39 @@ export const opencodeGoProvider: QuotaProvider = {
       return attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, result.error);
     }
 
-    return attemptedResult([
-      {
+    const windows = _ctx.config.opencodeGoWindows ?? ["rolling", "weekly", "monthly"];
+    const entries = [];
+
+    if (windows.includes("rolling")) {
+      entries.push({
         name: `${OPENCODE_GO_PROVIDER_LABEL} Rolling`,
         group: OPENCODE_GO_PROVIDER_LABEL,
         label: "Rolling:",
         percentRemaining: result.rolling.percentRemaining,
         resetTimeIso: result.rolling.resetTimeIso,
-      },
-      {
+      });
+    }
+
+    if (windows.includes("weekly")) {
+      entries.push({
         name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`,
         group: OPENCODE_GO_PROVIDER_LABEL,
         label: "Weekly:",
         percentRemaining: result.weekly.percentRemaining,
         resetTimeIso: result.weekly.resetTimeIso,
-      },
-      {
+      });
+    }
+
+    if (windows.includes("monthly")) {
+      entries.push({
         name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`,
         group: OPENCODE_GO_PROVIDER_LABEL,
         label: "Monthly:",
         percentRemaining: result.monthly.percentRemaining,
         resetTimeIso: result.monthly.resetTimeIso,
-      },
-    ]);
+      });
+    }
+
+    return attemptedResult(entries);
   },
 };

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -1,8 +1,8 @@
 /**
  * OpenCode Go provider wrapper.
  *
- * Scrapes the OpenCode Go workspace dashboard and reports monthly usage
- * as a percentage-based quota entry.
+ * Scrapes the OpenCode Go workspace dashboard and reports rolling (~5h),
+ * weekly, and monthly usage as percentage-based quota entries.
  */
 
 import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
@@ -66,11 +66,25 @@ export const opencodeGoProvider: QuotaProvider = {
 
     return attemptedResult([
       {
-        name: OPENCODE_GO_PROVIDER_LABEL,
+        name: `${OPENCODE_GO_PROVIDER_LABEL} Rolling`,
+        group: OPENCODE_GO_PROVIDER_LABEL,
+        label: "Rolling:",
+        percentRemaining: result.rolling.percentRemaining,
+        resetTimeIso: result.rolling.resetTimeIso,
+      },
+      {
+        name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`,
+        group: OPENCODE_GO_PROVIDER_LABEL,
+        label: "Weekly:",
+        percentRemaining: result.weekly.percentRemaining,
+        resetTimeIso: result.weekly.resetTimeIso,
+      },
+      {
+        name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`,
         group: OPENCODE_GO_PROVIDER_LABEL,
         label: "Monthly:",
-        percentRemaining: result.percentRemaining,
-        resetTimeIso: result.resetTimeIso,
+        percentRemaining: result.monthly.percentRemaining,
+        resetTimeIso: result.monthly.resetTimeIso,
       },
     ]);
   },

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, rmSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -84,6 +84,54 @@ describe("loadConfig", () => {
     expect(explicit.config.cursorPlan).toBe("pro-plus");
     expect(explicit.config.cursorIncludedApiUsd).toBe(42);
     expect(explicit.config.cursorBillingCycleStartDay).toBe(7);
+  });
+
+  it("defaults OpenCode Go windows and accepts valid explicit windows", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.opencodeGoWindows).toEqual(["rolling", "weekly", "monthly"]);
+
+    const explicit = await loadSdkConfig({ opencodeGoWindows: ["monthly", "rolling"] });
+    expect(explicit.config.opencodeGoWindows).toEqual(["monthly", "rolling"]);
+    expect(explicit.meta.settingSources).toEqual({
+      opencodeGoWindows: "client.config.get",
+    });
+    expect(explicit.meta.networkSettingSources).toEqual({});
+  });
+
+  it("ignores invalid OpenCode Go windows without recording a setting source", async () => {
+    const invalidValues: unknown[] = [[], ["rolling", "daily"], ["weekly", 5], "weekly"];
+
+    for (const opencodeGoWindows of invalidValues) {
+      const { config, meta } = await loadSdkConfig({ opencodeGoWindows });
+      expect(config.opencodeGoWindows).toEqual(["rolling", "weekly", "monthly"]);
+      expect(meta.settingSources).not.toHaveProperty("opencodeGoWindows");
+      expect(meta.networkSettingSources).toEqual({});
+    }
+  });
+
+  it("records file-backed OpenCode Go windows setting source", async () => {
+    const workspaceConfigPath = join(isolatedCwd, "opencode.json");
+    writeFileSync(
+      workspaceConfigPath,
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            opencodeGoWindows: ["weekly", "monthly"],
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const meta = createLoadConfigMeta();
+    const config = await loadConfig(undefined, meta, { cwd: isolatedCwd });
+
+    expect(config.opencodeGoWindows).toEqual(["weekly", "monthly"]);
+    expect(meta.source).toBe("files");
+    expect(meta.settingSources).toEqual({
+      opencodeGoWindows: `${workspaceConfigPath} (experimental.quotaToast)`,
+    });
+    expect(meta.networkSettingSources).toEqual({});
   });
 
   it("defaults pricingSnapshot config and accepts valid overrides", async () => {

--- a/tests/lib.grouped-entry-normalization.test.ts
+++ b/tests/lib.grouped-entry-normalization.test.ts
@@ -59,6 +59,35 @@ describe("normalizeGroupedQuotaEntries", () => {
     ]);
   });
 
+  it("sorts OpenCode Go windows as rolling, weekly, monthly", () => {
+    const entries = [
+      {
+        name: "OpenCode Go Weekly",
+        group: "OpenCode Go",
+        label: "Weekly:",
+        percentRemaining: 98,
+      },
+      {
+        name: "OpenCode Go Monthly",
+        group: "OpenCode Go",
+        label: "Monthly:",
+        percentRemaining: 84,
+      },
+      {
+        name: "OpenCode Go Rolling",
+        group: "OpenCode Go",
+        label: "Rolling:",
+        percentRemaining: 93,
+      },
+    ];
+
+    expect(normalizeGroupedQuotaEntries(entries, "toast").map((entry) => entry.label)).toEqual([
+      "Rolling:",
+      "Weekly:",
+      "Monthly:",
+    ]);
+  });
+
   it("keeps unknown grouped rows after duration rows while preserving unknown-row order for /quota", () => {
     const entries = [
       {

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -1249,6 +1249,7 @@ describe("buildQuotaStatusReport", () => {
     expect(report).toContain("opencode_go:");
     expect(report).toContain("- config_state: configured");
     expect(report).toContain("- config_source: env");
+    expect(report).toContain("- selected_windows: rolling,weekly,monthly");
     expect(report).toContain(
       "- rolling_usage: percent_used=7 percent_remaining=93 reset_in_sec=18000 reset_at=2026-03-12T17:45:00.000Z",
     );
@@ -1260,6 +1261,86 @@ describe("buildQuotaStatusReport", () => {
     );
     expect(openCodeGoMocks.resolveOpenCodeGoConfigCached).toHaveBeenCalledWith({ maxAgeMs: 30_000 });
     expect(openCodeGoMocks.queryOpenCodeGoQuota).toHaveBeenCalledWith("ws-123", "cookie-abc");
+  });
+
+  it("reports available OpenCode Go live usage without failing when a default window is absent", async () => {
+    openCodeGoMocks.getOpenCodeGoConfigDiagnostics.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      missing: null,
+      error: null,
+      checkedPaths: ["env:OPENCODE_GO_WORKSPACE_ID", "env:OPENCODE_GO_AUTH_COOKIE"],
+    });
+    openCodeGoMocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      config: { workspaceId: "ws-123", authCookie: "cookie-abc" },
+    });
+    openCodeGoMocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: true,
+      rolling: {
+        usagePercent: 7,
+        percentRemaining: 93,
+        resetInSec: 18000,
+        resetTimeIso: "2026-03-12T17:45:00.000Z",
+      },
+      weekly: {
+        usagePercent: 22,
+        percentRemaining: 78,
+        resetInSec: 540000,
+        resetTimeIso: "2026-03-18T18:45:00.000Z",
+      },
+    });
+
+    const report = await buildOpenCodeGoStatusReport();
+
+    expect(report).toContain("- selected_windows: rolling,weekly,monthly");
+    expect(report).toContain(
+      "- rolling_usage: percent_used=7 percent_remaining=93 reset_in_sec=18000 reset_at=2026-03-12T17:45:00.000Z",
+    );
+    expect(report).toContain(
+      "- weekly_usage: percent_used=22 percent_remaining=78 reset_in_sec=540000 reset_at=2026-03-18T18:45:00.000Z",
+    );
+    expect(report).not.toContain("- monthly_usage:");
+    expect(report).not.toContain("- live_fetch_error:");
+  });
+
+  it("reports a clear OpenCode Go status error when a selected window is absent", async () => {
+    openCodeGoMocks.getOpenCodeGoConfigDiagnostics.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      missing: null,
+      error: null,
+      checkedPaths: ["env:OPENCODE_GO_WORKSPACE_ID", "env:OPENCODE_GO_AUTH_COOKIE"],
+    });
+    openCodeGoMocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      config: { workspaceId: "ws-123", authCookie: "cookie-abc" },
+    });
+    openCodeGoMocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: true,
+      rolling: {
+        usagePercent: 7,
+        percentRemaining: 93,
+        resetInSec: 18000,
+        resetTimeIso: "2026-03-12T17:45:00.000Z",
+      },
+      monthly: {
+        usagePercent: 64,
+        percentRemaining: 36,
+        resetInSec: 2480000,
+        resetTimeIso: "2026-04-10T05:38:20.000Z",
+      },
+    });
+
+    const report = await buildOpenCodeGoStatusReport({ opencodeGoWindows: ["weekly"] });
+
+    expect(report).toContain("- selected_windows: weekly");
+    expect(report).toContain(
+      "- rolling_usage: percent_used=7 percent_remaining=93 reset_in_sec=18000 reset_at=2026-03-12T17:45:00.000Z",
+    );
+    expect(report).toContain("- live_fetch_error: Selected OpenCode Go dashboard window(s) missing: weekly (weeklyUsage)");
   });
 
   it("reports OpenCode Go invalid config details without attempting a live fetch", async () => {

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -1201,6 +1201,67 @@ describe("buildQuotaStatusReport", () => {
     expect(report).toContain("- live_error_balance: NanoGPT API error 401: Unauthorized");
   });
 
+  it("reports OpenCode Go rolling, weekly, and monthly live usage when configured", async () => {
+    openCodeGoMocks.getOpenCodeGoConfigDiagnostics.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      missing: null,
+      error: null,
+      checkedPaths: ["env:OPENCODE_GO_WORKSPACE_ID", "env:OPENCODE_GO_AUTH_COOKIE"],
+    });
+    openCodeGoMocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({
+      state: "configured",
+      source: "env",
+      config: { workspaceId: "ws-123", authCookie: "cookie-abc" },
+    });
+    openCodeGoMocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: true,
+      rolling: {
+        usagePercent: 7,
+        percentRemaining: 93,
+        resetInSec: 18000,
+        resetTimeIso: "2026-03-12T17:45:00.000Z",
+      },
+      weekly: {
+        usagePercent: 22,
+        percentRemaining: 78,
+        resetInSec: 540000,
+        resetTimeIso: "2026-03-18T18:45:00.000Z",
+      },
+      monthly: {
+        usagePercent: 64,
+        percentRemaining: 36,
+        resetInSec: 2480000,
+        resetTimeIso: "2026-04-10T05:38:20.000Z",
+      },
+    });
+
+    const report = await buildOpenCodeGoStatusReport({
+      providerAvailability: [
+        {
+          id: "opencode-go",
+          enabled: true,
+          available: true,
+        },
+      ],
+    });
+
+    expect(report).toContain("opencode_go:");
+    expect(report).toContain("- config_state: configured");
+    expect(report).toContain("- config_source: env");
+    expect(report).toContain(
+      "- rolling_usage: percent_used=7 percent_remaining=93 reset_in_sec=18000 reset_at=2026-03-12T17:45:00.000Z",
+    );
+    expect(report).toContain(
+      "- weekly_usage: percent_used=22 percent_remaining=78 reset_in_sec=540000 reset_at=2026-03-18T18:45:00.000Z",
+    );
+    expect(report).toContain(
+      "- monthly_usage: percent_used=64 percent_remaining=36 reset_in_sec=2480000 reset_at=2026-04-10T05:38:20.000Z",
+    );
+    expect(openCodeGoMocks.resolveOpenCodeGoConfigCached).toHaveBeenCalledWith({ maxAgeMs: 30_000 });
+    expect(openCodeGoMocks.queryOpenCodeGoQuota).toHaveBeenCalledWith("ws-123", "cookie-abc");
+  });
+
   it("reports OpenCode Go invalid config details without attempting a live fetch", async () => {
     openCodeGoMocks.getOpenCodeGoConfigDiagnostics.mockResolvedValueOnce({
       state: "invalid",

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -191,6 +191,20 @@ describe("opencode-go provider", () => {
     expect(out.entries[1]).toMatchObject({ name: "OpenCode Go Monthly" });
   });
 
+  it("keeps selected windows in canonical order", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
+
+    const out = await runProviderFetch(["weekly", "monthly", "rolling"]);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries.map((entry) => entry.name)).toEqual([
+      "OpenCode Go Rolling",
+      "OpenCode Go Weekly",
+      "OpenCode Go Monthly",
+    ]);
+  });
+
   it("parses resetInSec-first field order", async () => {
     mockConfigConfigured();
     mockDashboardSuccess(buildDashboardHtmlResetFirst(10, 3600, 20, 7200, 30, 14400));

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -199,7 +199,7 @@ describe("opencode-go provider", () => {
 
     expectAttemptedWithNoErrors(out);
     expect(out.entries.map((entry) => entry.name)).toEqual([
-      "OpenCode Go Rolling",
+      "OpenCode Go 5h",
       "OpenCode Go Weekly",
       "OpenCode Go Monthly",
     ]);

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -21,7 +21,7 @@ vi.mock("../src/lib/http.js", () => ({
 }));
 
 import { opencodeGoProvider } from "../src/providers/opencode-go.js";
-import { _parseMonthlyUsage } from "../src/lib/opencode-go.js";
+import { _parseWindowUsage } from "../src/lib/opencode-go.js";
 
 function mockConfigNone() {
   mocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({ state: "none" });
@@ -54,12 +54,26 @@ function mockConfigConfigured(workspaceId = "ws-123", authCookie = "cookie-abc")
   });
 }
 
-function buildDashboardHtml(usagePercent: number, resetInSec: number): string {
-  return `<html><script>monthlyUsage:$R[42]={usagePercent:${usagePercent},resetInSec:${resetInSec}}</script></html>`;
+function buildDashboardHtml(
+  rollingUsagePercent: number,
+  rollingResetInSec: number,
+  weeklyUsagePercent: number,
+  weeklyResetInSec: number,
+  monthlyUsagePercent: number,
+  monthlyResetInSec: number,
+): string {
+  return `<html><script>rollingUsage:$R[10]={usagePercent:${rollingUsagePercent},resetInSec:${rollingResetInSec}}weeklyUsage:$R[11]={usagePercent:${weeklyUsagePercent},resetInSec:${weeklyResetInSec}}monthlyUsage:$R[12]={usagePercent:${monthlyUsagePercent},resetInSec:${monthlyResetInSec}}</script></html>`;
 }
 
-function buildDashboardHtmlResetFirst(usagePercent: number, resetInSec: number): string {
-  return `<html><script>monthlyUsage:$R[7]={resetInSec:${resetInSec},usagePercent:${usagePercent}}</script></html>`;
+function buildDashboardHtmlResetFirst(
+  rollingUsagePercent: number,
+  rollingResetInSec: number,
+  weeklyUsagePercent: number,
+  weeklyResetInSec: number,
+  monthlyUsagePercent: number,
+  monthlyResetInSec: number,
+): string {
+  return `<html><script>rollingUsage:$R[10]={resetInSec:${rollingResetInSec},usagePercent:${rollingUsagePercent}}weeklyUsage:$R[11]={resetInSec:${weeklyResetInSec},usagePercent:${weeklyUsagePercent}}monthlyUsage:$R[12]={resetInSec:${monthlyResetInSec},usagePercent:${monthlyUsagePercent}}</script></html>`;
 }
 
 function mockDashboardSuccess(html: string) {
@@ -108,34 +122,48 @@ describe("opencode-go provider", () => {
     expect(mocks.fetchWithTimeout).not.toHaveBeenCalled();
   });
 
-  it("returns usage entry on successful dashboard scrape", async () => {
+  it("returns usage entries on successful dashboard scrape", async () => {
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtml(42, 1209600));
+    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
 
     const out = await runProviderFetch();
 
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toHaveLength(1);
+    expect(out.entries).toHaveLength(3);
     expect(out.entries[0]).toMatchObject({
-      name: "OpenCode Go",
+      name: "OpenCode Go Rolling",
       group: "OpenCode Go",
-      label: "Monthly:",
-      percentRemaining: 58,
+      label: "Rolling:",
+      percentRemaining: 93,
     });
     expect(out.entries[0]).toHaveProperty("resetTimeIso");
+    expect(out.entries[1]).toMatchObject({
+      name: "OpenCode Go Weekly",
+      group: "OpenCode Go",
+      label: "Weekly:",
+      percentRemaining: 98,
+    });
+    expect(out.entries[1]).toHaveProperty("resetTimeIso");
+    expect(out.entries[2]).toMatchObject({
+      name: "OpenCode Go Monthly",
+      group: "OpenCode Go",
+      label: "Monthly:",
+      percentRemaining: 84,
+    });
+    expect(out.entries[2]).toHaveProperty("resetTimeIso");
   });
 
   it("parses resetInSec-first field order", async () => {
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtmlResetFirst(75, 604800));
+    mockDashboardSuccess(buildDashboardHtmlResetFirst(10, 3600, 20, 7200, 30, 14400));
 
     const out = await runProviderFetch();
 
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toHaveLength(1);
-    expect(out.entries[0]).toMatchObject({
-      percentRemaining: 25,
-    });
+    expect(out.entries).toHaveLength(3);
+    expect(out.entries[0]).toMatchObject({ percentRemaining: 90 });
+    expect(out.entries[1]).toMatchObject({ percentRemaining: 80 });
+    expect(out.entries[2]).toMatchObject({ percentRemaining: 70 });
   });
 
   it("returns error on HTTP failure", async () => {
@@ -167,11 +195,13 @@ describe("opencode-go provider", () => {
 
   it("lower-bounds usagePercent at 0 and allows over-100 usage values", async () => {
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtml(150, 100));
+    mockDashboardSuccess(buildDashboardHtml(150, 100, 0, 200, 50, 300));
 
     const out = await runProviderFetch();
     expectAttemptedWithNoErrors(out);
     expect(out.entries[0]).toMatchObject({ percentRemaining: -50 });
+    expect(out.entries[1]).toMatchObject({ percentRemaining: 100 });
+    expect(out.entries[2]).toMatchObject({ percentRemaining: 50 });
   });
 
   it("sanitizes error text from dashboard responses", async () => {
@@ -212,27 +242,41 @@ describe("opencode-go isAvailable", () => {
   });
 });
 
-describe("_parseMonthlyUsage", () => {
+describe("_parseWindowUsage", () => {
+  const rollingRePctFirst = /rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:(\d+)[^}]*resetInSec:(\d+)[^}]*\}/;
+  const rollingReResetFirst = /rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:(\d+)[^}]*usagePercent:(\d+)[^}]*\}/;
+
   it("returns null for empty string", () => {
-    expect(_parseMonthlyUsage("")).toBeNull();
+    expect(_parseWindowUsage("", rollingRePctFirst, rollingReResetFirst)).toBeNull();
   });
 
   it("parses usagePercent-first ordering", () => {
-    const html = "monthlyUsage:$R[42]={usagePercent:55,resetInSec:3600}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 55, resetInSec: 3600 });
+    const html = "rollingUsage:$R[42]={usagePercent:55,resetInSec:3600}";
+    expect(_parseWindowUsage(html, rollingRePctFirst, rollingReResetFirst)).toEqual({
+      usagePercent: 55,
+      resetInSec: 3600,
+    });
   });
 
   it("parses resetInSec-first ordering", () => {
-    const html = "monthlyUsage:$R[7]={resetInSec:7200,usagePercent:30}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 30, resetInSec: 7200 });
+    const html = "rollingUsage:$R[7]={resetInSec:7200,usagePercent:30}";
+    expect(_parseWindowUsage(html, rollingRePctFirst, rollingReResetFirst)).toEqual({
+      usagePercent: 30,
+      resetInSec: 7200,
+    });
   });
 
   it("returns null when pattern is missing", () => {
-    expect(_parseMonthlyUsage("<html><body>hello</body></html>")).toBeNull();
+    expect(
+      _parseWindowUsage("<html><body>hello</body></html>", rollingRePctFirst, rollingReResetFirst),
+    ).toBeNull();
   });
 
   it("handles extra fields in the object", () => {
-    const html = "monthlyUsage:$R[1]={usagePercent:10,foo:bar,resetInSec:500}";
-    expect(_parseMonthlyUsage(html)).toEqual({ usagePercent: 10, resetInSec: 500 });
+    const html = "rollingUsage:$R[1]={usagePercent:10,foo:bar,resetInSec:500}";
+    expect(_parseWindowUsage(html, rollingRePctFirst, rollingReResetFirst)).toEqual({
+      usagePercent: 10,
+      resetInSec: 500,
+    });
   });
 });

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -91,8 +91,8 @@ function mockDashboardHttpFailure(status: number, text: string) {
   });
 }
 
-async function runProviderFetch() {
-  return opencodeGoProvider.fetch({ config: {} } as any);
+async function runProviderFetch(opencodeGoWindows?: Array<"rolling" | "weekly" | "monthly">) {
+  return opencodeGoProvider.fetch({ config: { opencodeGoWindows } } as any);
 }
 
 describe("opencode-go provider", () => {
@@ -151,6 +151,44 @@ describe("opencode-go provider", () => {
       percentRemaining: 84,
     });
     expect(out.entries[2]).toHaveProperty("resetTimeIso");
+  });
+
+  it("filters windows based on opencodeGoWindows config", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
+
+    const out = await runProviderFetch(["weekly"]);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(1);
+    expect(out.entries[0]).toMatchObject({
+      name: "OpenCode Go Weekly",
+      group: "OpenCode Go",
+      label: "Weekly:",
+      percentRemaining: 98,
+    });
+  });
+
+  it("defaults to all windows when opencodeGoWindows is not set", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(3);
+  });
+
+  it("supports custom window combinations", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
+
+    const out = await runProviderFetch(["rolling", "monthly"]);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0]).toMatchObject({ name: "OpenCode Go Rolling" });
+    expect(out.entries[1]).toMatchObject({ name: "OpenCode Go Monthly" });
   });
 
   it("parses resetInSec-first field order", async () => {

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -54,6 +54,14 @@ function mockConfigConfigured(workspaceId = "ws-123", authCookie = "cookie-abc")
   });
 }
 
+type OpenCodeGoTestWindow = "rolling" | "weekly" | "monthly";
+
+const DASHBOARD_FIELD_BY_WINDOW: Record<OpenCodeGoTestWindow, string> = {
+  rolling: "rollingUsage",
+  weekly: "weeklyUsage",
+  monthly: "monthlyUsage",
+};
+
 function buildDashboardHtml(
   rollingUsagePercent: number,
   rollingResetInSec: number,
@@ -62,7 +70,11 @@ function buildDashboardHtml(
   monthlyUsagePercent: number,
   monthlyResetInSec: number,
 ): string {
-  return `<html><script>rollingUsage:$R[10]={usagePercent:${rollingUsagePercent},resetInSec:${rollingResetInSec}}weeklyUsage:$R[11]={usagePercent:${weeklyUsagePercent},resetInSec:${weeklyResetInSec}}monthlyUsage:$R[12]={usagePercent:${monthlyUsagePercent},resetInSec:${monthlyResetInSec}}</script></html>`;
+  return buildPartialDashboardHtml({
+    rolling: [rollingUsagePercent, rollingResetInSec],
+    weekly: [weeklyUsagePercent, weeklyResetInSec],
+    monthly: [monthlyUsagePercent, monthlyResetInSec],
+  });
 }
 
 function buildDashboardHtmlResetFirst(
@@ -74,6 +86,21 @@ function buildDashboardHtmlResetFirst(
   monthlyResetInSec: number,
 ): string {
   return `<html><script>rollingUsage:$R[10]={resetInSec:${rollingResetInSec},usagePercent:${rollingUsagePercent}}weeklyUsage:$R[11]={resetInSec:${weeklyResetInSec},usagePercent:${weeklyUsagePercent}}monthlyUsage:$R[12]={resetInSec:${monthlyResetInSec},usagePercent:${monthlyUsagePercent}}</script></html>`;
+}
+
+function buildPartialDashboardHtml(
+  windows: Partial<Record<OpenCodeGoTestWindow, [usagePercent: number, resetInSec: number]>>,
+): string {
+  const chunks = (["rolling", "weekly", "monthly"] as const)
+    .map((window, index) => {
+      const usage = windows[window];
+      if (!usage) return "";
+      const [usagePercent, resetInSec] = usage;
+      return `${DASHBOARD_FIELD_BY_WINDOW[window]}:$R[${10 + index}]={usagePercent:${usagePercent},resetInSec:${resetInSec}}`;
+    })
+    .join("");
+
+  return `<html><script>${chunks}</script></html>`;
 }
 
 function mockDashboardSuccess(html: string) {
@@ -169,14 +196,42 @@ describe("opencode-go provider", () => {
     });
   });
 
-  it("defaults to all windows when opencodeGoWindows is not set", async () => {
+  it("defaults to available windows when opencodeGoWindows is not set", async () => {
     mockConfigConfigured();
-    mockDashboardSuccess(buildDashboardHtml(7, 18000, 2, 540000, 16, 2480000));
+    mockDashboardSuccess(buildPartialDashboardHtml({ rolling: [7, 18000], monthly: [16, 2480000] }));
 
     const out = await runProviderFetch();
 
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toHaveLength(3);
+    expect(out.entries.map((entry) => entry.name)).toEqual(["OpenCode Go 5h", "OpenCode Go Monthly"]);
+  });
+
+  it("succeeds when weekly is selected and only weeklyUsage is present", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildPartialDashboardHtml({ weekly: [2, 540000] }));
+
+    const out = await runProviderFetch(["weekly"]);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(1);
+    expect(out.entries[0]).toMatchObject({
+      name: "OpenCode Go Weekly",
+      group: "OpenCode Go",
+      label: "Weekly:",
+      percentRemaining: 98,
+    });
+  });
+
+  it("returns a clear error when a selected weekly window is missing", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(buildPartialDashboardHtml({ rolling: [7, 18000], monthly: [16, 2480000] }));
+
+    const out = await runProviderFetch(["weekly"]);
+
+    expectAttemptedWithErrorLabel(out, "OpenCode Go");
+    expect(out.entries).toHaveLength(0);
+    expect(out.errors[0]?.message).toContain("weekly");
+    expect(out.errors[0]?.message).toContain("weeklyUsage");
   });
 
   it("supports custom window combinations", async () => {
@@ -227,13 +282,13 @@ describe("opencode-go provider", () => {
     expect(out.errors[0]?.message).toContain("403");
   });
 
-  it("returns error when dashboard HTML does not contain usage data", async () => {
+  it("returns parse error when dashboard HTML does not contain any known usage windows", async () => {
     mockConfigConfigured();
     mockDashboardSuccess("<html><body>No usage data here</body></html>");
 
     const out = await runProviderFetch();
     expectAttemptedWithErrorLabel(out, "OpenCode Go");
-    expect(out.errors[0]?.message).toContain("Could not parse");
+    expect(out.errors[0]?.message).toContain("Could not parse any known OpenCode Go dashboard usage windows");
   });
 
   it("returns error on network failure", async () => {

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -131,9 +131,9 @@ describe("opencode-go provider", () => {
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toHaveLength(3);
     expect(out.entries[0]).toMatchObject({
-      name: "OpenCode Go Rolling",
+      name: "OpenCode Go 5h",
       group: "OpenCode Go",
-      label: "Rolling:",
+      label: "5h:",
       percentRemaining: 93,
     });
     expect(out.entries[0]).toHaveProperty("resetTimeIso");
@@ -187,7 +187,7 @@ describe("opencode-go provider", () => {
 
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toHaveLength(2);
-    expect(out.entries[0]).toMatchObject({ name: "OpenCode Go Rolling" });
+    expect(out.entries[0]).toMatchObject({ name: "OpenCode Go 5h" });
     expect(out.entries[1]).toMatchObject({ name: "OpenCode Go Monthly" });
   });
 


### PR DESCRIPTION
## Summary
OpenCode Go dashboard exposes three usage windows (`rollingUsage`, `weeklyUsage`, `monthlyUsage`), but the provider previously only scraped `monthlyUsage`. This PR updates the scraper, provider, types, status report, and tests to support all three windows.
Additionally, this adds a new `experimental.quotaToast.opencodeGoWindows` config option so users can choose which windows to display (defaults to `[\"rolling\", \"weekly\", \"monthly\"]`).
## Linked Issue
No existing issue. This is a feature addition to match the multi-window support that other providers (e.g. Alibaba Coding Plan, Synthetic, Z.ai) already have.
## OpenCode Validation
- Current production released OpenCode version tested: >= 1.4.3 (peer dependency)
- Why this version is relevant to the fix: The plugin architecture and provider context haven't changed between versions; this is a pure provider enhancement.
## Quality Checklist
- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md`)