### PR TITLE
Honor OpenCode config dir when resolving quota plugin config

### DIFF
--- a/src/lib/cli-show.ts
+++ b/src/lib/cli-show.ts
@@ -5,7 +5,7 @@ import type { QuotaToastConfig } from "./types.js";
 
 import { formatQuotaRows } from "./format.js";
 import { getQuotaProviderShape } from "./provider-metadata.js";
-import { findGitWorktreeRoot } from "./config-file-utils.js";
+import { findGitWorktreeRoot, getEffectiveConfigRoot } from "./config-file-utils.js";
 import {
   loadConfiguredOpenCodeConfig,
   loadConfiguredProviderIds,
@@ -101,9 +101,10 @@ function cloneCliConfig(config: QuotaToastConfig): QuotaToastConfig {
 function resolveCliRoots(cwd: string): { workspaceRoot: string; configRoot: string; fallbackDirectory: string } {
   const fallbackDirectory = resolve(cwd);
   const worktreeRoot = findGitWorktreeRoot(fallbackDirectory) ?? fallbackDirectory;
+  const configRoot = getEffectiveConfigRoot(worktreeRoot);
   return {
     workspaceRoot: worktreeRoot,
-    configRoot: worktreeRoot,
+    configRoot,
     fallbackDirectory,
   };
 }

--- a/src/lib/config-file-utils.ts
+++ b/src/lib/config-file-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "fs";
-import { dirname, join } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 
 export type ConfigFileKind = "opencode" | "tui";
 export type ConfigFileFormat = "json" | "jsonc";
@@ -42,6 +42,29 @@ function pickFirstNonEmptyString(items: Array<string | null | undefined>): strin
   return null;
 }
 
+/**
+ * Returns the effective config root directory.
+ *
+ * Priority:
+ * 1. `OPENCODE_CONFIG_DIR` environment variable (if set and non-empty)
+ * 2. The provided fallback directory
+ *
+ * This matches OpenCode's own behavior: when `OPENCODE_CONFIG_DIR` is set,
+ * config files are resolved relative to it rather than the current working directory.
+ */
+export function getEffectiveConfigRoot(fallback: string): string {
+  const envDir = process.env.OPENCODE_CONFIG_DIR?.trim();
+  if (!envDir) {
+    return fallback;
+  }
+
+  if (isAbsolute(envDir)) {
+    return envDir;
+  }
+
+  return resolve(fallback, envDir);
+}
+
 export function resolveRuntimeContextRoots(params: RuntimeContextRootHints): RuntimeContextRoots {
   const workspaceRoot =
     pickFirstNonEmptyString([
@@ -50,9 +73,10 @@ export function resolveRuntimeContextRoots(params: RuntimeContextRootHints): Run
       params.activeDirectory,
       params.fallbackDirectory,
     ]) ?? params.fallbackDirectory;
-  const configRoot =
-    pickFirstNonEmptyString([params.configRoot, workspaceRoot, params.activeDirectory]) ??
-    workspaceRoot;
+  const explicitConfigRoot = pickFirstNonEmptyString([params.configRoot]);
+  const computedConfigRoot =
+    pickFirstNonEmptyString([workspaceRoot, params.activeDirectory]) ?? workspaceRoot;
+  const configRoot = explicitConfigRoot ?? getEffectiveConfigRoot(computedConfigRoot);
 
   return { workspaceRoot, configRoot };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,6 +23,7 @@ import { existsSync } from "fs";
 import { readFile } from "fs/promises";
 import { join } from "path";
 
+import { getEffectiveConfigRoot } from "./config-file-utils.js";
 import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
 
 export const QUOTA_TOAST_CONFIG_RELATIVE_PATH = "opencode-quota/quota-toast.json";
@@ -768,7 +769,7 @@ export async function loadConfig(
     networkSettingSources: Record<string, string>;
     configIssues: LoadConfigIssue[];
   }> {
-    const configRootDir = options?.configRootDir ?? options?.cwd ?? process.cwd();
+    const configRootDir = options?.configRootDir ?? getEffectiveConfigRoot(options?.cwd ?? process.cwd());
     const { configDirs } = getOpencodeRuntimeDirCandidates();
     const config = cloneDefaultConfig();
     const usedPaths: string[] = [];

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -74,6 +74,7 @@ import {
   resolveQuotaRuntimeContext,
   type QuotaRuntimeContext,
 } from "./lib/quota-runtime-context.js";
+import { findGitWorktreeRoot, getEffectiveConfigRoot } from "./lib/config-file-utils.js";
 
 // =============================================================================
 // Types
@@ -522,9 +523,11 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
 
   function getPluginRuntimeRootHints() {
     const cwd = process.cwd();
+    const workspaceRoot = findGitWorktreeRoot(cwd) ?? cwd;
+    const configRoot = getEffectiveConfigRoot(workspaceRoot);
     return {
-      workspaceRoot: cwd,
-      configRoot: cwd,
+      workspaceRoot,
+      configRoot,
       fallbackDirectory: cwd,
     };
   }

--- a/tests/lib.cli-show.test.ts
+++ b/tests/lib.cli-show.test.ts
@@ -51,8 +51,11 @@ describe("runCliShowCommand", () => {
   let tempDir: string;
   let globalConfigDir: string;
   let workspaceDir: string;
+  let savedConfigDir: string | undefined;
 
   beforeEach(() => {
+    savedConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-cli-show-"));
     globalConfigDir = join(tempDir, "global-config", "opencode");
     workspaceDir = join(tempDir, "workspace");
@@ -69,6 +72,8 @@ describe("runCliShowCommand", () => {
   });
 
   afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.OPENCODE_CONFIG_DIR = savedConfigDir;
+    else delete process.env.OPENCODE_CONFIG_DIR;
     mockProviders.length = 0;
     __resetQuotaStateForTests();
     rmSync(tempDir, { recursive: true, force: true });
@@ -266,6 +271,39 @@ describe("runCliShowCommand", () => {
     expect(code).toBe(1);
     expect(stdout.output).toBe("");
     expect(stderr.output).toContain("Quota disabled in config");
+  });
+
+  it("resolves relative OPENCODE_CONFIG_DIR from the worktree root", async () => {
+    const nestedDir = join(workspaceDir, "packages", "app");
+    const provider = {
+      id: "synthetic",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      fetch: vi.fn(),
+    };
+    mockProviders.push(provider);
+    mkdirSync(nestedDir, { recursive: true });
+    mkdirSync(join(workspaceDir, ".git"));
+    mkdirSync(join(workspaceDir, ".opencode"), { recursive: true });
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    writeFileSync(
+      join(workspaceDir, ".opencode", "opencode.json"),
+      JSON.stringify({ experimental: { quotaToast: { enabled: false } } }),
+      "utf8",
+    );
+    const stdout = createCaptureStream();
+    const stderr = createCaptureStream();
+
+    const code = await runCliShowCommand({
+      argv: [],
+      cwd: nestedDir,
+      stdout: stdout.stream as any,
+      stderr: stderr.stream as any,
+    });
+
+    expect(code).toBe(1);
+    expect(stdout.output).toBe("");
+    expect(stderr.output).toContain("Quota disabled in config");
+    expect(provider.fetch).not.toHaveBeenCalled();
   });
 
   it("uses root-level OpenCode provider ids for standalone provider availability", async () => {

--- a/tests/lib.config-file-utils.test.ts
+++ b/tests/lib.config-file-utils.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { join } from "node:path";
+
+import { getEffectiveConfigRoot, resolveRuntimeContextRoots } from "../src/lib/config-file-utils.js";
+
+describe("getEffectiveConfigRoot", () => {
+  const original = process.env.OPENCODE_CONFIG_DIR;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.OPENCODE_CONFIG_DIR;
+    } else {
+      process.env.OPENCODE_CONFIG_DIR = original;
+    }
+  });
+
+  it("returns fallback when OPENCODE_CONFIG_DIR is not set", () => {
+    delete process.env.OPENCODE_CONFIG_DIR;
+    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/home/user/project");
+  });
+
+  it("returns OPENCODE_CONFIG_DIR when set", () => {
+    process.env.OPENCODE_CONFIG_DIR = "/custom/config";
+    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/custom/config");
+  });
+
+  it("resolves relative OPENCODE_CONFIG_DIR from fallback", () => {
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    expect(getEffectiveConfigRoot("/home/user/project")).toBe(join("/home/user/project", ".opencode"));
+  });
+
+  it("ignores whitespace-only OPENCODE_CONFIG_DIR", () => {
+    process.env.OPENCODE_CONFIG_DIR = "   ";
+    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/home/user/project");
+  });
+});
+
+describe("resolveRuntimeContextRoots", () => {
+  const original = process.env.OPENCODE_CONFIG_DIR;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.OPENCODE_CONFIG_DIR;
+    } else {
+      process.env.OPENCODE_CONFIG_DIR = original;
+    }
+  });
+
+  it("uses OPENCODE_CONFIG_DIR only when explicit configRoot is absent", () => {
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    expect(
+      resolveRuntimeContextRoots({
+        workspaceRoot: "/work/repo",
+        fallbackDirectory: "/work/repo/packages/app",
+      }),
+    ).toEqual({
+      workspaceRoot: "/work/repo",
+      configRoot: "/work/repo/.opencode",
+    });
+  });
+
+  it("uses explicit configRoot as-is without re-applying OPENCODE_CONFIG_DIR", () => {
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    expect(
+      resolveRuntimeContextRoots({
+        workspaceRoot: "/work/repo",
+        configRoot: "/work/repo/.explicit",
+        fallbackDirectory: "/work/repo/packages/app",
+      }),
+    ).toEqual({
+      workspaceRoot: "/work/repo",
+      configRoot: "/work/repo/.explicit",
+    });
+  });
+});

--- a/tests/lib.config.integration.test.ts
+++ b/tests/lib.config.integration.test.ts
@@ -32,6 +32,7 @@ describe("loadConfig integration runtime-path resolution", () => {
   let xdgConfigHome: string;
 
   beforeEach(() => {
+    delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-config-integration-"));
     mockedHomeDir.value = tempDir;
     workspaceDir = join(tempDir, "workspace");

--- a/tests/lib.config.security.test.ts
+++ b/tests/lib.config.security.test.ts
@@ -30,6 +30,7 @@ describe("loadConfig layered precedence", () => {
   let xdgConfigHome: string;
 
   beforeEach(() => {
+    delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-config-"));
     workspaceDir = join(tempDir, "workspace");
     xdgConfigHome = join(tempDir, "xdg-config");

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -20,8 +20,11 @@ import { createLoadConfigMeta, loadConfig } from "../src/lib/config.js";
 
 describe("loadConfig", () => {
   let isolatedCwd: string;
+  let savedConfigDir: string | undefined;
 
   beforeEach(() => {
+    savedConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    delete process.env.OPENCODE_CONFIG_DIR;
     isolatedCwd = mkdtempSync(join(tmpdir(), "opencode-quota-config-sdk-"));
     runtimeDirs.value = {
       dataDirs: [],
@@ -32,6 +35,8 @@ describe("loadConfig", () => {
   });
 
   afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.OPENCODE_CONFIG_DIR = savedConfigDir;
+    else delete process.env.OPENCODE_CONFIG_DIR;
     rmSync(isolatedCwd, { recursive: true, force: true });
   });
 
@@ -96,6 +101,24 @@ describe("loadConfig", () => {
       opencodeGoWindows: "client.config.get",
     });
     expect(explicit.meta.networkSettingSources).toEqual({});
+  });
+
+  it("resolves relative OPENCODE_CONFIG_DIR against cwd for file loading", async () => {
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    mkdirSync(join(isolatedCwd, ".opencode"), { recursive: true });
+    writeFileSync(
+      join(isolatedCwd, ".opencode", "opencode.json"),
+      JSON.stringify({ experimental: { quotaToast: { enabled: false } } }),
+      "utf8",
+    );
+
+    const meta = createLoadConfigMeta();
+    const config = await loadConfig(undefined, meta, { cwd: isolatedCwd });
+
+    expect(config.enabled).toBe(false);
+    expect(meta.paths).toContain(
+      `${join(isolatedCwd, ".opencode", "opencode.json")} (experimental.quotaToast)`,
+    );
   });
 
   it("ignores invalid OpenCode Go windows without recording a setting source", async () => {

--- a/tests/lib.quota-runtime-context.test.ts
+++ b/tests/lib.quota-runtime-context.test.ts
@@ -35,6 +35,7 @@ describe("quota runtime context", () => {
   let xdgConfigHome: string;
 
   beforeEach(() => {
+    delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-runtime-context-"));
     mockedHomeDir.value = tempDir;
     worktreeDir = join(tempDir, "worktree");
@@ -136,6 +137,53 @@ describe("quota runtime context", () => {
     expect(runtime.configMeta.globalConfigPaths).toEqual([]);
     expect(runtime.configMeta.workspaceConfigPaths).toEqual([worktreeConfigPath]);
     expect(runtime.configMeta.settingSources.enabled).toBe(worktreeConfigPath);
+  });
+
+  it("does not re-resolve OPENCODE_CONFIG_DIR when loadConfig receives resolved configRootDir", async () => {
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    mkdirSync(join(worktreeDir, ".opencode", ".opencode"), { recursive: true });
+    writeFileSync(
+      join(worktreeDir, ".opencode", "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: false,
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(worktreeDir, ".opencode", ".opencode", "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: true,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    const runtime = await resolveQuotaRuntimeContext({
+      client: createClient(),
+      roots: {
+        worktreeRoot: worktreeDir,
+        activeDirectory: nestedDir,
+        fallbackDirectory: nestedDir,
+      },
+      providers: [],
+    });
+
+    expect(runtime.roots).toEqual({
+      workspaceRoot: worktreeDir,
+      configRoot: join(worktreeDir, ".opencode"),
+    });
+    expect(runtime.config.enabled).toBe(false);
+    expect(runtime.configMeta.paths).toContain(quotaConfigSource(join(worktreeDir, ".opencode")));
+    expect(runtime.configMeta.paths).not.toContain(
+      quotaConfigSource(join(worktreeDir, ".opencode", ".opencode")),
+    );
   });
 
   it("resolves session meta only when the shared config requests it", async () => {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -66,7 +66,11 @@ vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
 }));
 
 describe("/quota command behavior", () => {
+  let savedConfigDir: string | undefined;
+
   beforeEach(async () => {
+    savedConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    delete process.env.OPENCODE_CONFIG_DIR;
     seedDefaultPluginBootstrapMocks(mocks, {
       configOverrides: {
         enabled: true,
@@ -84,6 +88,8 @@ describe("/quota command behavior", () => {
   });
 
   afterEach(async () => {
+    if (savedConfigDir !== undefined) process.env.OPENCODE_CONFIG_DIR = savedConfigDir;
+    else delete process.env.OPENCODE_CONFIG_DIR;
     const { __resetQuotaStateForTests } = await import("../src/lib/quota-state.js");
     __resetQuotaStateForTests();
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });

--- a/tests/plugin.quota-status-command.test.ts
+++ b/tests/plugin.quota-status-command.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COMMAND_HANDLED_SENTINEL } from "../src/lib/command-handled.js";
 import { DEFAULT_CONFIG } from "../src/lib/types.js";
@@ -75,7 +75,11 @@ vi.mock("../src/lib/google.js", () => ({
 }));
 
 describe("/quota_status command behavior", () => {
+  let savedConfigDir: string | undefined;
+
   beforeEach(() => {
+    savedConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    delete process.env.OPENCODE_CONFIG_DIR;
     seedDefaultPluginBootstrapMocks(mocks, {
       configOverrides: {
         ...DEFAULT_CONFIG,
@@ -120,6 +124,11 @@ describe("/quota_status command behavior", () => {
       },
     ]);
     mocks.buildQuotaStatusReport.mockResolvedValue("Injected quota status");
+  });
+
+  afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.OPENCODE_CONFIG_DIR = savedConfigDir;
+    else delete process.env.OPENCODE_CONFIG_DIR;
   });
 
   it("probes every enabled and available provider with fresh single-window status probes and still throws the handled sentinel", async () => {

--- a/tests/quota-surface-parity.test.ts
+++ b/tests/quota-surface-parity.test.ts
@@ -112,6 +112,7 @@ describe("quota surface parity regressions", () => {
     process.env.XDG_DATA_HOME = join(tempDir, "xdg-data");
     process.env.XDG_CACHE_HOME = join(tempDir, "xdg-cache");
     process.env.XDG_STATE_HOME = join(tempDir, "xdg-state");
+    delete process.env.OPENCODE_CONFIG_DIR;
 
     process.chdir(worktreeDir);
   });
@@ -221,6 +222,83 @@ describe("quota surface parity regressions", () => {
     expect(panel.status).toBe("ready");
     expect(panel.lines.join("\n")).toContain("64% left");
     expect(syntheticProvider.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves relative OPENCODE_CONFIG_DIR from the worktree root for plugin commands", async () => {
+    const syntheticProvider = {
+      id: "synthetic",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      fetch: vi.fn().mockResolvedValue({
+        attempted: true,
+        entries: [
+          {
+            name: "Synthetic Weekly",
+            group: "Synthetic",
+            label: "Weekly:",
+            percentRemaining: 64,
+            right: "$16/$24",
+            resetTimeIso: "2099-01-08T00:00:00.000Z",
+          },
+        ],
+        errors: [],
+      }),
+    };
+    mockProviders.push(syntheticProvider);
+
+    mkdirSync(join(worktreeDir, ".git"));
+    mkdirSync(join(worktreeDir, ".opencode"), { recursive: true });
+    mkdirSync(join(nestedDir, ".opencode"), { recursive: true });
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+
+    writeFileSync(
+      join(worktreeDir, ".opencode", "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: false,
+          },
+        },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      join(nestedDir, ".opencode", "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: true,
+            enabledProviders: ["synthetic"],
+            formatStyle: "allWindows",
+            showOnQuestion: false,
+            showSessionTokens: false,
+            minIntervalMs: 60_000,
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    process.chdir(nestedDir);
+
+    const client = createClient({
+      config: {
+        enabled: false,
+        enabledProviders: [],
+      },
+      sessionMeta: { modelID: "synthetic/default", providerID: "synthetic" },
+    });
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = await QuotaToastPlugin({ client } as any);
+    await expect(
+      hooks["command.execute.before"]?.({
+        command: "quota",
+        sessionID: "session-relative-config-root",
+      } as any),
+    ).rejects.toThrow(COMMAND_HANDLED_SENTINEL);
+
+    expect(getPromptText(client)).toBe("");
+    expect(syntheticProvider.fetch).not.toHaveBeenCalled();
   });
 
   it("keeps workspace overrides for formerly global-authoritative settings aligned between plugin and sidebar", async () => {

--- a/tests/tui-config-diagnostics.test.ts
+++ b/tests/tui-config-diagnostics.test.ts
@@ -15,8 +15,11 @@ describe("inspectTuiConfig", () => {
   let tempDir: string;
   let projectDir: string;
   let globalDir: string;
+  let savedConfigDir: string | undefined;
 
   beforeEach(() => {
+    savedConfigDir = process.env.OPENCODE_CONFIG_DIR;
+    delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-tui-diag-"));
     projectDir = join(tempDir, "project");
     globalDir = join(tempDir, "global", "opencode");
@@ -30,6 +33,8 @@ describe("inspectTuiConfig", () => {
   });
 
   afterEach(() => {
+    if (savedConfigDir !== undefined) process.env.OPENCODE_CONFIG_DIR = savedConfigDir;
+    else delete process.env.OPENCODE_CONFIG_DIR;
     rmSync(tempDir, { recursive: true, force: true });
     vi.clearAllMocks();
   });
@@ -121,6 +126,29 @@ describe("inspectTuiConfig", () => {
 
     expect(diagnostics.workspaceRoot).toBe(projectDir);
     expect(diagnostics.configRoot).toBe(projectDir);
+    expect(diagnostics.inferredSelectedPath).toBe(join(projectDir, ".opencode", "tui.json"));
+    expect(diagnostics.quotaPluginConfigured).toBe(true);
+    expect(diagnostics.quotaPluginConfigPaths).toEqual([join(projectDir, ".opencode", "tui.json")]);
+  });
+
+  it("resolves relative OPENCODE_CONFIG_DIR from discovered worktree root", async () => {
+    const nestedDir = join(projectDir, "packages", "feature");
+    mkdirSync(nestedDir, { recursive: true });
+    mkdirSync(join(projectDir, ".git"), { recursive: true });
+    mkdirSync(join(projectDir, ".opencode"), { recursive: true });
+    process.env.OPENCODE_CONFIG_DIR = ".opencode";
+
+    writeFileSync(
+      join(projectDir, ".opencode", "tui.json"),
+      JSON.stringify({ plugin: ["@slkiser/opencode-quota"] }),
+      "utf8",
+    );
+
+    const { inspectTuiConfig } = await import("../src/lib/tui-config-diagnostics.js");
+    const diagnostics = await inspectTuiConfig({ cwd: nestedDir });
+
+    expect(diagnostics.workspaceRoot).toBe(projectDir);
+    expect(diagnostics.configRoot).toBe(join(projectDir, ".opencode"));
     expect(diagnostics.inferredSelectedPath).toBe(join(projectDir, ".opencode", "tui.json"));
     expect(diagnostics.quotaPluginConfigured).toBe(true);
     expect(diagnostics.quotaPluginConfigPaths).toEqual([join(projectDir, ".opencode", "tui.json")]);

--- a/tests/tui-runtime.test.ts
+++ b/tests/tui-runtime.test.ts
@@ -56,6 +56,7 @@ describe("tui runtime helpers", () => {
     process.env.XDG_DATA_HOME = join(tempDir, "xdg-data");
     process.env.XDG_CACHE_HOME = join(tempDir, "xdg-cache");
     process.env.XDG_STATE_HOME = join(tempDir, "xdg-state");
+    delete process.env.OPENCODE_CONFIG_DIR;
 
     collectQuotaRenderData.mockReset();
     buildSidebarQuotaPanelLines.mockReset();


### PR DESCRIPTION
## Summary
- fix quota plugin config resolution so it honors the OpenCode-configured config directory instead of always reading from the current workspace path
- align plugin, CLI `show`, and TUI/runtime config loading so all quota surfaces use the same effective config root
- add regression tests for configured config dirs, nested worktrees, and surface parity

## Linked Issue
No issue. This fixes a config-resolution mismatch where OpenCode supports a custom config directory, but the plugin could ignore it and read the wrong config files.

## OpenCode Validation
- Current production released OpenCode version tested: 1.14.20
- Why this version is relevant to the fix: it is the production behavior this patch matches, including support for resolving config from the OpenCode-selected config directory

## Quality Checklist
- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)