### PR TITLE
fix: parse Copilot Free tier quota from /copilot_internal/user

### DIFF
--- a/src/lib/copilot.ts
+++ b/src/lib/copilot.ts
@@ -801,6 +801,9 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     ["quota_limit"],
     ["monthly_limit"],
     ["included_premium_requests"],
+    // Copilot Free tier: `monthly_quotas.chat` and `monthly_quotas.completions`
+    ["monthly_quotas", "chat"],
+    ["monthly_quotas", "completions"],
   ];
   const usedPaths = [
     ["quota", "used"],
@@ -823,6 +826,9 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     ["quota_remaining"],
     ["monthly_remaining"],
     ["premium_requests_remaining"],
+    // Copilot Free tier: `limited_user_quotas` tracks remaining
+    ["limited_user_quotas", "chat"],
+    ["limited_user_quotas", "completions"],
   ];
   const resetPaths = [
     ["quota", "reset_at"],
@@ -833,6 +839,8 @@ function toUserQuotaResultFromCopilotInternal(response: unknown): CopilotQuotaRe
     ["quota_reset_date_utc"],
     ["quota_reset_date"],
     ["quota_reset_at"],
+    // Copilot Free tier
+    ["limited_user_reset_date"],
   ];
   const percentRemainingPaths = [
     ["quota", "percent_remaining"],


### PR DESCRIPTION
Copilot Free returns a different response structure than paid tiers. The API returns `monthly_quotas.chat` and `limited_user_quotas.chat` instead of `premium_requests` fields, and `limited_user_reset_date` instead of `quota_reset_at`.
This adds the missing path lookups so `toUserQuotaResultFromCopilotInternal` can extract total (500), remaining, and reset date for Free users.
Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)
## Summary
Copilot Free tier users see the error `"response did not include usable personal quota fields"` in the sidebar because the plugin only parses `premium_requests.*` fields from `/copilot_internal/user`.
The Free tier API returns a different JSON shape:
```json
{
  "monthly_quotas": { "chat": 500, "completions": 4000 },
  "limited_user_quotas": { "chat": 370, "completions": 3922 },
  "limited_user_reset_date": "2026-05-26"
}
```
This PR adds the missing path lookups to totalPaths, remainingPaths, and resetPaths arrays in toUserQuotaResultFromCopilotInternal(), matching the Free tier response structure.
## Linked Issue
No existing issue. Discovered during local debugging of a Copilot Free setup where the sidebar showed a parsing error instead of quota data.
## OpenCode Validation
- Current production released OpenCode version tested: 1.14.33
- Why this version is relevant to the fix: This version ships @slkiser/opencode-quota@3.5.0 which includes the Copilot provider but lacks Free tier path lookups. The fix is source-level only and does not depend on any OpenCode-specific API changes.
## Quality Checklist
- [ ] I ran npm run typecheck
- [ ] I ran npm test
- [ ] I ran npm run build
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [ ] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (README.md and CONTRIBUTING.md when applicable)
- [ ] For new API-key/token providers, I started from contributing/provider-template/ or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy .ts template in contributing/provider-template/ and verified README.md against src/lib/provider-metadata.ts (authentication/authFallbacks) and provider auth resolver/diagnostics behavior