### PR TITLE
feat: add Zhipu Coding Plan provider (domestic China)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If you want the `Quota` sidebar panel, you need the plugin in both OpenCode conf
 | Google Antigravity  | [Needs quick setup](#google-antigravity-quick-setup) | `["opencode-antigravity-auth", "@slkiser/opencode-quota"]`     | Remote API               |
 | Gemini CLI          | [Needs quick setup](#gemini-cli-quick-setup)         | `["opencode-gemini-auth", "@slkiser/opencode-quota"]`          | Remote API               |
 | Z.ai Coding Plan    | Automatic                                            | Existing OpenCode auth, global config, or env                  | Remote API               |
+| Zhipu Coding Plan   | Automatic                                            | Existing OpenCode auth, global config, or env                  | Remote API               |
 | NanoGPT             | Usually automatic                                    | Existing OpenCode auth, global config, or env                  | Remote API               |
 | OpenCode Go         | [Needs quick setup](#opencode-go-quick-setup)        | Set workspace ID and `auth` cookie                             | Dashboard scraping       |
 
@@ -495,7 +496,7 @@ Run `/quota_status` and check the Alibaba auth, resolved tier, state-file path, 
 </details>
 
 <details>
-<summary><strong>MiniMax, Kimi, Chutes AI, Crof.ai, Synthetic, Z.ai, and NanoGPT</strong></summary>
+<summary><strong>MiniMax, Kimi, Chutes AI, Crof.ai, Synthetic, Z.ai, Zhipu, and NanoGPT</strong></summary>
 
 These providers use trusted env vars, trusted user/global OpenCode config, or native OpenCode auth. Run `/quota_status` and check the provider-specific API-key diagnostics (Crof.ai is env/config only).
 
@@ -507,6 +508,7 @@ These providers use trusted env vars, trusted user/global OpenCode config, or na
 | Crof.ai             | Use `CROF_API_KEY`, `CROFAI_API_KEY`, or trusted user/global config.                              |
 | Synthetic           | Use `SYNTHETIC_API_KEY`, trusted user/global config, or OpenCode auth.                                |
 | Z.ai Coding Plan    | Use `ZAI_API_KEY` or `ZAI_CODING_PLAN_API_KEY`; malformed fallback auth is surfaced as an auth error. |
+| Zhipu Coding Plan   | Use `ZHIPU_API_KEY` or `ZHIPU_CODING_PLAN_API_KEY`; malformed fallback auth is surfaced as an auth error. |
 | NanoGPT             | Use `NANOGPT_API_KEY`, `NANO_GPT_API_KEY`, trusted user/global config, or OpenCode auth.              |
 
 For security, repo-local `opencode.json` / `opencode.jsonc` is ignored for provider secrets in these integrations. Put secrets in environment variables or trusted user/global config.

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -11,6 +11,7 @@ export type CanonicalQuotaProviderId =
   | "google-antigravity"
   | "google-gemini-cli"
   | "zai"
+  | "zhipu"
   | "nanogpt"
   | "minimax-coding-plan"
   | "kimi-for-coding"
@@ -60,6 +61,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   "qwen-code": "Qwen",
   "alibaba-coding-plan": "Alibaba Coding Plan",
   zai: "Z.ai",
+  zhipu: "Zhipu",
   nanogpt: "NanoGPT",
   "minimax-coding-plan": "MiniMax Coding Plan",
   "kimi-for-coding": "Kimi Code",
@@ -88,6 +90,7 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   "google-gemini": "google-gemini-cli",
   "opencode-gemini-auth": "google-gemini-cli",
   gemini: "google-gemini-cli",
+  "glm-coding-plan": "zhipu",
 };
 
 export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
@@ -109,6 +112,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
     "google",
   ],
   zai: ["zai", "glm", "zai-coding-plan"],
+  zhipu: ["zhipu", "glm-coding-plan", "zhipu-coding-plan"],
   nanogpt: ["nanogpt", "nano-gpt"],
   "minimax-coding-plan": ["minimax-coding-plan", "minimax"],
   "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
@@ -202,6 +206,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
   },
   {
     id: "zai",
+    autoSetup: "yes",
+    authentication: "opencode_auth_api_key",
+    authFallbacks: ["env_api_key", "global_opencode_config"],
+    quota: "remote_api",
+  },
+  {
+    id: "zhipu",
     autoSetup: "yes",
     authentication: "opencode_auth_api_key",
     authFallbacks: ["env_api_key", "global_opencode_config"],

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -91,6 +91,7 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   "opencode-gemini-auth": "google-gemini-cli",
   gemini: "google-gemini-cli",
   "glm-coding-plan": "zhipu",
+  "zhipu-coding-plan": "zhipu",
 };
 
 export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -34,6 +34,7 @@ import {
   resolveMiniMaxAuthCached,
 } from "./minimax-auth.js";
 import { DEFAULT_ZAI_AUTH_CACHE_MAX_AGE_MS, getZaiAuthDiagnostics } from "./zai-auth.js";
+import { DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS, getZhipuAuthDiagnostics } from "./zhipu-auth.js";
 import {
   DEFAULT_KIMI_AUTH_CACHE_MAX_AGE_MS,
   getKimiAuthDiagnostics,
@@ -92,6 +93,7 @@ import type {
 } from "./types.js";
 import { queryMiniMaxQuota } from "../providers/minimax-coding-plan.js";
 import { queryZaiQuota } from "./zai.js";
+import { queryZhipuQuota } from "./zhipu.js";
 import {
   getOpenCodeGoConfigDiagnostics,
   resolveOpenCodeGoConfigCached,
@@ -1186,6 +1188,55 @@ export async function buildQuotaStatusReport(params: {
   }
   appendProviderCompactLiveProbeRows(zaiRows, "zai", params.providerLiveProbes);
   sections.push(createKvSection("zai", "zai:", zaiRows));
+
+  // === zhipu ===
+  const zhipuRows: ReportKvRow[] = [];
+  const zhipuAuth = await getZhipuAuthDiagnostics({
+    maxAgeMs: DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS,
+  });
+  zhipuRows.push({ key: "auth_state", value: zhipuAuth.state });
+  zhipuRows.push({
+    key: "api_key_configured",
+    value: zhipuAuth.state === "configured" ? "true" : "false",
+  });
+  zhipuRows.push({ key: "api_key_source", value: zhipuAuth.source ?? "(none)" });
+  zhipuRows.push({ key: "api_key_checked_paths", value: joinOrNone(zhipuAuth.checkedPaths) });
+  zhipuRows.push({ key: "api_key_auth_paths", value: joinOrNone(zhipuAuth.authPaths) });
+  if (zhipuAuth.state === "invalid") {
+    zhipuRows.push({ key: "auth_error", value: sanitizeDisplayText(zhipuAuth.error) });
+  }
+  if (zhipuAuth.state === "configured") {
+    const zhipuQuota = await queryZhipuQuota();
+    if (!zhipuQuota) {
+      zhipuRows.push({ key: "live_fetch_error", value: "Zhipu API key became unavailable before fetch" });
+    } else if (!zhipuQuota.success) {
+      zhipuRows.push({ key: "live_fetch_error", value: zhipuQuota.error });
+    } else {
+      if (zhipuQuota.windows.fiveHour) {
+        zhipuRows.push({
+          key: "five_hour_remaining",
+          value: `${zhipuQuota.windows.fiveHour.percentRemaining}% reset_at=${zhipuQuota.windows.fiveHour.resetTimeIso ?? "(none)"}`,
+        });
+      }
+      if (zhipuQuota.windows.weekly) {
+        zhipuRows.push({
+          key: "weekly_remaining",
+          value: `${zhipuQuota.windows.weekly.percentRemaining}% reset_at=${zhipuQuota.windows.weekly.resetTimeIso ?? "(none)"}`,
+        });
+      }
+      if (zhipuQuota.windows.mcp) {
+        zhipuRows.push({
+          key: "mcp_remaining",
+          value: `${zhipuQuota.windows.mcp.percentRemaining}% reset_at=${zhipuQuota.windows.mcp.resetTimeIso ?? "(none)"}`,
+        });
+      }
+      if (!zhipuQuota.windows.fiveHour && !zhipuQuota.windows.weekly && !zhipuQuota.windows.mcp) {
+        zhipuRows.push({ key: "live_state", value: "no reportable Zhipu quota windows" });
+      }
+    }
+  }
+  appendProviderCompactLiveProbeRows(zhipuRows, "zhipu", params.providerLiveProbes);
+  sections.push(createKvSection("zhipu", "zhipu:", zhipuRows));
 
   // === simple API key sections ===
   const syntheticDiag = await readBasicApiKeyDiagnostics(getSyntheticKeyDiagnostics);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -321,6 +321,10 @@ export interface AuthData {
     type: "api";
     key: string;
   };
+  "zhipu-coding-plan"?: {
+    type: "api";
+    key: string;
+  };
   "minimax-coding-plan"?: MiniMaxAuthData;
   "kimi-code"?: KimiAuthData;
   kimi?: KimiAuthData;

--- a/src/lib/zhipu-auth.ts
+++ b/src/lib/zhipu-auth.ts
@@ -1,0 +1,174 @@
+import {
+  extractProviderOptionsApiKey,
+  getApiKeyCheckedPaths,
+  getFirstAuthEntryValue,
+  getGlobalOpencodeConfigCandidatePaths,
+  resolveApiKeyFromEnvAndConfig,
+} from "./api-key-resolver.js";
+import { sanitizeDisplayText } from "./display-sanitize.js";
+import { getAuthPaths, readAuthFileCached } from "./opencode-auth.js";
+
+import type { AuthData, ZaiAuthData } from "./types.js";
+
+export const DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS = 5_000;
+const ZHIPU_AUTH_KEYS = ["zhipu-coding-plan"] as const;
+const ZHIPU_PROVIDER_KEYS = ["zhipu", "zhipu-coding-plan", "glm-coding-plan"] as const;
+const ALLOWED_ZHIPU_ENV_VARS = ["ZHIPU_API_KEY", "ZHIPU_CODING_PLAN_API_KEY"] as const;
+
+export type ZhipuKeySource =
+  | "env:ZHIPU_API_KEY"
+  | "env:ZHIPU_CODING_PLAN_API_KEY"
+  | "opencode.json"
+  | "opencode.jsonc"
+  | "auth.json";
+
+export type ResolvedZhipuAuth =
+  | { state: "none" }
+  | { state: "configured"; apiKey: string }
+  | { state: "invalid"; error: string };
+
+export type ZhipuAuthDiagnostics =
+  | {
+      state: "none";
+      source: null;
+      checkedPaths: string[];
+      authPaths: string[];
+    }
+  | {
+      state: "configured";
+      source: ZhipuKeySource;
+      checkedPaths: string[];
+      authPaths: string[];
+    }
+  | {
+      state: "invalid";
+      source: "auth.json";
+      checkedPaths: string[];
+      authPaths: string[];
+      error: string;
+    };
+
+export { getGlobalOpencodeConfigCandidatePaths as getOpencodeConfigCandidatePaths } from "./api-key-resolver.js";
+
+function getZhipuAuthEntry(auth: AuthData | null | undefined): unknown {
+  return getFirstAuthEntryValue(auth, ZHIPU_AUTH_KEYS);
+}
+
+function isZhipuAuthData(value: unknown): value is ZaiAuthData {
+  return value !== null && typeof value === "object";
+}
+
+function sanitizeZhipuAuthValue(value: string): string {
+  const sanitized = sanitizeDisplayText(value).replace(/\s+/g, " ").trim();
+  return (sanitized || "unknown").slice(0, 120);
+}
+
+export function resolveZhipuAuth(auth: AuthData | null | undefined): ResolvedZhipuAuth {
+  const zhipu = getZhipuAuthEntry(auth);
+  if (zhipu === null || zhipu === undefined) {
+    return { state: "none" };
+  }
+
+  if (!isZhipuAuthData(zhipu)) {
+    return { state: "invalid", error: "Zhipu auth entry has invalid shape" };
+  }
+
+  if (typeof zhipu.type !== "string") {
+    return { state: "invalid", error: "Zhipu auth entry present but type is missing or invalid" };
+  }
+
+  if (zhipu.type !== "api") {
+    return {
+      state: "invalid",
+      error: `Unsupported Zhipu auth type: "${sanitizeZhipuAuthValue(zhipu.type)}"`,
+    };
+  }
+
+  const key = typeof zhipu.key === "string" ? zhipu.key.trim() : "";
+  if (!key) {
+    return { state: "invalid", error: "Zhipu auth entry present but key is empty" };
+  }
+
+  return { state: "configured", apiKey: key };
+}
+
+async function resolveZhipuAuthWithSource(params?: {
+  maxAgeMs?: number;
+}): Promise<{ auth: ResolvedZhipuAuth; source: ZhipuKeySource | null }> {
+  const resolvedFromEnvOrConfig = await resolveApiKeyFromEnvAndConfig<ZhipuKeySource>({
+    envVars: [
+      { name: "ZHIPU_API_KEY", source: "env:ZHIPU_API_KEY" },
+      {
+        name: "ZHIPU_CODING_PLAN_API_KEY",
+        source: "env:ZHIPU_CODING_PLAN_API_KEY",
+      },
+    ],
+    extractFromConfig: (config) =>
+      extractProviderOptionsApiKey(config, {
+        providerKeys: ZHIPU_PROVIDER_KEYS,
+        allowedEnvVars: ALLOWED_ZHIPU_ENV_VARS,
+      }),
+    configJsonSource: "opencode.json",
+    configJsoncSource: "opencode.jsonc",
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+  });
+
+  if (resolvedFromEnvOrConfig) {
+    return {
+      auth: { state: "configured", apiKey: resolvedFromEnvOrConfig.key },
+      source: resolvedFromEnvOrConfig.source,
+    };
+  }
+
+  const maxAgeMs = Math.max(0, params?.maxAgeMs ?? DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS);
+  const authData = await readAuthFileCached({ maxAgeMs });
+  const auth = resolveZhipuAuth(authData);
+
+  return {
+    auth,
+    source: auth.state === "none" ? null : "auth.json",
+  };
+}
+
+export async function resolveZhipuAuthCached(params?: {
+  maxAgeMs?: number;
+}): Promise<ResolvedZhipuAuth> {
+  return (await resolveZhipuAuthWithSource(params)).auth;
+}
+
+export async function getZhipuAuthDiagnostics(params?: {
+  maxAgeMs?: number;
+}): Promise<ZhipuAuthDiagnostics> {
+  const { auth, source } = await resolveZhipuAuthWithSource(params);
+  const checkedPaths = getApiKeyCheckedPaths({
+    envVarNames: [...ALLOWED_ZHIPU_ENV_VARS],
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+  });
+  const authPaths = getAuthPaths();
+
+  if (auth.state === "none") {
+    return {
+      state: "none",
+      source: null,
+      checkedPaths,
+      authPaths,
+    };
+  }
+
+  if (auth.state === "invalid") {
+    return {
+      state: "invalid",
+      source: "auth.json",
+      checkedPaths,
+      authPaths,
+      error: auth.error,
+    };
+  }
+
+  return {
+    state: "configured",
+    source: source ?? "auth.json",
+    checkedPaths,
+    authPaths,
+  };
+}

--- a/src/lib/zhipu.ts
+++ b/src/lib/zhipu.ts
@@ -1,0 +1,98 @@
+/**
+ * Zhipu quota fetcher
+ *
+ * Uses OpenCode's auth.json (zhipu-coding-plan) and queries:
+ * https://bigmodel.cn/api/monitor/usage/quota/limit
+ */
+
+import { clampPercent } from "./format-utils.js";
+import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
+import { fetchWithTimeout } from "./http.js";
+import type {
+  ZaiResult,
+  ZaiQuotaResponse,
+} from "./types.js";
+import { resolveZhipuAuthCached } from "./zhipu-auth.js";
+
+const ZHIPU_QUOTA_URL = "https://bigmodel.cn/api/monitor/usage/quota/limit";
+
+export async function queryZhipuQuota(options: { requestTimeoutMs?: number } = {}): Promise<ZaiResult> {
+  const auth = await resolveZhipuAuthCached();
+  if (auth.state === "none") return null;
+  if (auth.state === "invalid") {
+    return { success: false, error: auth.error };
+  }
+
+  try {
+    const headers: Record<string, string> = {
+      Authorization: auth.apiKey,
+      "User-Agent": "OpenCode-Quota-Toast/1.0",
+      "Content-Type": "application/json",
+    };
+
+    const resp = await fetchWithTimeout(ZHIPU_QUOTA_URL, { headers }, options.requestTimeoutMs);
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        success: false,
+        error: `Zhipu API error ${resp.status}: ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    const data = (await resp.json()) as ZaiQuotaResponse;
+    const limits = data.data.limits;
+
+    if (!limits || !Array.isArray(limits)) {
+      return { success: false, error: "Invalid quota data" };
+    }
+
+    let fiveHourWindow: { percentRemaining: number; resetTimeIso?: string } | undefined;
+    let weeklyWindow: { percentRemaining: number; resetTimeIso?: string } | undefined;
+    let mcpWindow: { percentRemaining: number; resetTimeIso?: string } | undefined;
+
+    for (const limit of limits) {
+      const percentRemaining = clampPercent(100 - limit.percentage);
+      let resetTimeIso: string | undefined;
+
+      if (limit.nextResetTime) {
+        const ms = Math.round(limit.nextResetTime);
+        if (Number.isFinite(ms) && ms > 0) {
+          resetTimeIso = new Date(ms).toISOString();
+        }
+      }
+
+      const window = { percentRemaining, resetTimeIso };
+
+      if (limit.type === "TOKENS_LIMIT") {
+        if (limit.unit === 3) {
+          // unit 3 is the 5-hour token window (Standard Lite/Pro/Max).
+          fiveHourWindow = window;
+        } else if (limit.unit === 6) {
+          // unit 6 is the weekly token window.
+          weeklyWindow = window;
+        } else if (limit.unit === 4) {
+          // unit 4 is daily. Do not surface it as weekly in the current UI/report shape.
+          continue;
+        }
+      } else if (limit.type === "TIME_LIMIT") {
+        // TIME_LIMIT (unit 5) is typically the Monthly MCP limit
+        mcpWindow = window;
+      }
+    }
+
+    return {
+      success: true,
+      label: "Zhipu",
+      windows: {
+        fiveHour: fiveHourWindow,
+        weekly: weeklyWindow,
+        mcp: mcpWindow,
+      },
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -17,6 +17,7 @@ import { crofProvider } from "./crof.js";
 import { qwenCodeProvider } from "./qwen-code.js";
 import { alibabaCodingPlanProvider } from "./alibaba-coding-plan.js";
 import { zaiProvider } from "./zai.js";
+import { zhipuProvider } from "./zhipu.js";
 import { nanoGptProvider } from "./nanogpt.js";
 import { minimaxCodingPlanProvider } from "./minimax-coding-plan.js";
 import { opencodeGoProvider } from "./opencode-go.js";
@@ -37,6 +38,7 @@ export function getProviders(): QuotaProvider[] {
     googleAntigravityProvider,
     googleGeminiCliProvider,
     zaiProvider,
+    zhipuProvider,
     nanoGptProvider,
     minimaxCodingPlanProvider,
     kimiCodeProvider,

--- a/src/providers/zhipu.ts
+++ b/src/providers/zhipu.ts
@@ -1,0 +1,101 @@
+/**
+ * Zhipu provider wrapper.
+ *
+ * Normalizes Zhipu quota into generic toast entries.
+ */
+
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import { queryZhipuQuota } from "../lib/zhipu.js";
+import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
+import {
+  DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS,
+  resolveZhipuAuthCached,
+} from "../lib/zhipu-auth.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+export const zhipuProvider: QuotaProvider = {
+  id: "zhipu",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const providerAvailable = await isCanonicalProviderAvailable({
+      ctx,
+      providerId: "zhipu",
+      fallbackOnError: false,
+    });
+    if (!providerAvailable) {
+      return false;
+    }
+
+    const auth = await resolveZhipuAuthCached({
+      maxAgeMs: DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS,
+    });
+    return auth.state === "configured" || auth.state === "invalid";
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    const lower = model.toLowerCase();
+    const provider = lower.split("/")[0];
+    return !!provider && (provider.includes("zhipu") || provider === "glm-coding-plan");
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const result = await queryZhipuQuota({ requestTimeoutMs: ctx.config?.requestTimeoutMs });
+
+    if (!result) {
+      return notAttemptedResult();
+    }
+
+    if (!result.success) {
+      return attemptedErrorResult("Zhipu", result.error);
+    }
+
+    const entries: QuotaToastEntry[] = [];
+    const group = result.label;
+
+    const fiveHour = result.windows.fiveHour;
+    if (fiveHour) {
+      entries.push({
+        name: `${group} 5h`,
+        group,
+        label: "5h:",
+        percentRemaining: fiveHour.percentRemaining,
+        resetTimeIso: fiveHour.resetTimeIso,
+      });
+    }
+
+    const weekly = result.windows.weekly;
+    if (weekly) {
+      entries.push({
+        name: `${group} Weekly`,
+        group,
+        label: "Weekly:",
+        percentRemaining: weekly.percentRemaining,
+        resetTimeIso: weekly.resetTimeIso,
+      });
+    }
+
+    const mcp = result.windows.mcp;
+    if (mcp) {
+      entries.push({
+        name: `${group} MCP`,
+        group,
+        label: "MCP:",
+        percentRemaining: mcp.percentRemaining,
+        resetTimeIso: mcp.resetTimeIso,
+      });
+    }
+
+    if (entries.length === 0) {
+      entries.push({ name: result.label, percentRemaining: 0 });
+    }
+
+    return attemptedResult(entries, [], {
+      singleWindowDisplayName: result.label,
+    });
+  },
+};

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -99,6 +99,13 @@ describe("provider-metadata", () => {
         quota: "remote_api",
       },
       {
+        id: "zhipu",
+        autoSetup: "yes",
+        authentication: "opencode_auth_api_key",
+        authFallbacks: ["env_api_key", "global_opencode_config"],
+        quota: "remote_api",
+      },
+      {
         id: "nanogpt",
         autoSetup: "usually",
         authentication: "opencode_auth_api_key",

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -176,6 +176,11 @@ describe("provider-metadata", () => {
       "google",
     ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.zai).toEqual(["zai", "glm", "zai-coding-plan"]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS.zhipu).toEqual([
+      "zhipu",
+      "glm-coding-plan",
+      "zhipu-coding-plan",
+    ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.nanogpt).toEqual(["nanogpt", "nano-gpt"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS["minimax-coding-plan"]).toEqual([
       "minimax-coding-plan",
@@ -211,6 +216,16 @@ describe("provider-metadata", () => {
       "google",
     ]);
     expect(getQuotaProviderRuntimeIds("zai")).toEqual(["zai", "glm", "zai-coding-plan"]);
+    expect(getQuotaProviderRuntimeIds("zhipu-coding-plan")).toEqual([
+      "zhipu",
+      "glm-coding-plan",
+      "zhipu-coding-plan",
+    ]);
+    expect(getQuotaProviderRuntimeIds("glm-coding-plan")).toEqual([
+      "zhipu",
+      "glm-coding-plan",
+      "zhipu-coding-plan",
+    ]);
     expect(getQuotaProviderRuntimeIds("minimax")).toEqual(["minimax-coding-plan", "minimax"]);
     expect(getQuotaProviderRuntimeIds("kimi")).toEqual(["kimi-for-coding", "kimi", "kimi-code"]);
     expect(getQuotaProviderRuntimeIds("not-a-provider")).toEqual([]);
@@ -255,6 +270,8 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("alibaba-coding-plan")).toBe("Alibaba Coding Plan");
     expect(getQuotaProviderDisplayLabel("synthetic")).toBe("Synthetic");
     expect(getQuotaProviderDisplayLabel("zai")).toBe("Z.ai");
+    expect(getQuotaProviderDisplayLabel("zhipu")).toBe("Zhipu");
+    expect(getQuotaProviderDisplayLabel("zhipu-coding-plan")).toBe("Zhipu");
     expect(getQuotaProviderDisplayLabel("nanogpt")).toBe("NanoGPT");
     expect(getQuotaProviderDisplayLabel("nano-gpt")).toBe("NanoGPT");
     expect(getQuotaProviderDisplayLabel("minimax")).toBe("MiniMax Coding Plan");

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -118,7 +118,7 @@ const zhipuMocks = vi.hoisted(() => ({
     checkedPaths: [],
     authPaths: ["/tmp/auth.json"],
   })),
-  resolveZhipuAuthCached: vi.fn(async () => ({ state: "none" as const })),
+  queryZhipuQuota: vi.fn(async () => null),
 }));
 
 const nanoGptMocks = vi.hoisted(() => ({
@@ -308,7 +308,7 @@ vi.mock("../src/lib/zhipu-auth.js", () => ({
 }));
 
 vi.mock("../src/lib/zhipu.js", () => ({
-  queryZhipuQuota: vi.fn(async () => null),
+  queryZhipuQuota: zhipuMocks.queryZhipuQuota,
 }));
 
 vi.mock("../src/lib/cursor-detection.js", () => ({
@@ -493,6 +493,29 @@ describe("buildQuotaStatusReport", () => {
       providerAvailability: [
         {
           id: "zai",
+          enabled: true,
+          available: true,
+        },
+      ],
+      generatedAtMs: Date.UTC(2026, 2, 12, 12, 45, 0),
+      ...overrides,
+    } as any);
+  }
+
+  async function buildZhipuStatusReport(overrides: Record<string, unknown> = {}) {
+    const { buildQuotaStatusReport } = await import("../src/lib/quota-status.js");
+
+    return buildQuotaStatusReport({
+      configSource: "test",
+      configPaths: [],
+      enabledProviders: ["zhipu"],
+      alibabaCodingPlanTier: "lite",
+      cursorPlan: "none",
+      pricingSnapshotSource: "auto",
+      onlyCurrentModel: false,
+      providerAvailability: [
+        {
+          id: "zhipu",
           enabled: true,
           available: true,
         },
@@ -1613,6 +1636,74 @@ describe("buildQuotaStatusReport", () => {
     const report = await buildZaiStatusReport();
 
     expect(report).toContain("- live_fetch_error: Z.ai API error 401: Unauthorized");
+  });
+
+  it("reports Zhipu auth diagnostics and live quota details when configured", async () => {
+    zhipuMocks.getZhipuAuthDiagnostics.mockResolvedValueOnce({
+      state: "configured",
+      source: "auth.json",
+      checkedPaths: [],
+      authPaths: ["/tmp/auth.json"],
+    });
+    zhipuMocks.queryZhipuQuota.mockResolvedValueOnce({
+      success: true,
+      label: "Zhipu",
+      windows: {
+        fiveHour: { percentRemaining: 67, resetTimeIso: "2026-03-25T18:00:00.000Z" },
+        weekly: { percentRemaining: 44, resetTimeIso: "2026-04-01T00:00:00.000Z" },
+        mcp: { percentRemaining: 90, resetTimeIso: "2026-04-10T00:00:00.000Z" },
+      },
+    });
+
+    const report = await buildZhipuStatusReport();
+
+    expect(report).toContain("zhipu:");
+    expect(report).toContain("- auth_state: configured");
+    expect(report).toContain("- api_key_configured: true");
+    expect(report).toContain("- api_key_source: auth.json");
+    expect(report).toContain("- api_key_checked_paths: (none)");
+    expect(report).toContain("- api_key_auth_paths: /tmp/auth.json");
+    expect(report).toContain("- five_hour_remaining: 67% reset_at=2026-03-25T18:00:00.000Z");
+    expect(report).toContain("- weekly_remaining: 44% reset_at=2026-04-01T00:00:00.000Z");
+    expect(report).toContain("- mcp_remaining: 90% reset_at=2026-04-10T00:00:00.000Z");
+  });
+
+  it("reports Zhipu auth errors", async () => {
+    zhipuMocks.getZhipuAuthDiagnostics.mockResolvedValueOnce({
+      state: "invalid",
+      source: "auth.json",
+      checkedPaths: [],
+      authPaths: ["/tmp/auth.json"],
+      error: 'Unsupported Zhipu auth type: "oauth"',
+    });
+
+    const report = await buildZhipuStatusReport();
+
+    expect(report).toContain("zhipu:");
+    expect(report).toContain("- auth_state: invalid");
+    expect(report).toContain("- api_key_configured: false");
+    expect(report).toContain("- api_key_source: auth.json");
+    expect(report).toContain("- api_key_checked_paths: (none)");
+    expect(report).toContain("- api_key_auth_paths: /tmp/auth.json");
+    expect(report).toContain('- auth_error: Unsupported Zhipu auth type: "oauth"');
+    expect(zhipuMocks.queryZhipuQuota).not.toHaveBeenCalled();
+  });
+
+  it("reports Zhipu endpoint errors", async () => {
+    zhipuMocks.getZhipuAuthDiagnostics.mockResolvedValueOnce({
+      state: "configured",
+      source: "auth.json",
+      checkedPaths: [],
+      authPaths: ["/tmp/auth.json"],
+    });
+    zhipuMocks.queryZhipuQuota.mockResolvedValueOnce({
+      success: false,
+      error: "Zhipu API error 401: Unauthorized",
+    });
+
+    const report = await buildZhipuStatusReport();
+
+    expect(report).toContain("- live_fetch_error: Zhipu API error 401: Unauthorized");
   });
 
   it("reports enterprise billing scope and token compatibility notes", async () => {

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -111,6 +111,16 @@ const zaiMocks = vi.hoisted(() => ({
   queryZaiQuota: vi.fn(async () => null),
 }));
 
+const zhipuMocks = vi.hoisted(() => ({
+  getZhipuAuthDiagnostics: vi.fn(async () => ({
+    state: "none" as const,
+    source: null,
+    checkedPaths: [],
+    authPaths: ["/tmp/auth.json"],
+  })),
+  resolveZhipuAuthCached: vi.fn(async () => ({ state: "none" as const })),
+}));
+
 const nanoGptMocks = vi.hoisted(() => ({
   getNanoGptKeyDiagnostics: vi.fn(async () => ({
     configured: false,
@@ -290,6 +300,15 @@ vi.mock("../src/lib/zai-auth.js", () => ({
 
 vi.mock("../src/lib/zai.js", () => ({
   queryZaiQuota: zaiMocks.queryZaiQuota,
+}));
+
+vi.mock("../src/lib/zhipu-auth.js", () => ({
+  DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS: 5_000,
+  getZhipuAuthDiagnostics: zhipuMocks.getZhipuAuthDiagnostics,
+}));
+
+vi.mock("../src/lib/zhipu.js", () => ({
+  queryZhipuQuota: vi.fn(async () => null),
 }));
 
 vi.mock("../src/lib/cursor-detection.js", () => ({
@@ -1753,26 +1772,27 @@ describe("buildQuotaStatusReport", () => {
       .join("\n");
     expect(titles).toMatchInlineSnapshot(`
       "toast:
-      paths:
-      openai:
-      anthropic:
-      cursor:
-      minimax:
-      kimi:
-      opencode_go:
-      zai:
-      synthetic:
-      chutes:
-      crof:
-      nanogpt:
-      copilot_quota_auth:
-      google_antigravity:
-      google_gemini_cli:
-      storage:
-      pricing_snapshot:
-      supported_providers_pricing:
-      unpriced_models:
-      unknown_pricing:"
+paths:
+openai:
+anthropic:
+cursor:
+minimax:
+kimi:
+opencode_go:
+zai:
+zhipu:
+synthetic:
+chutes:
+crof:
+nanogpt:
+copilot_quota_auth:
+google_antigravity:
+google_gemini_cli:
+storage:
+pricing_snapshot:
+supported_providers_pricing:
+unpriced_models:
+unknown_pricing:"
     `);
   });
 });

--- a/tests/lib.zhipu-auth.test.ts
+++ b/tests/lib.zhipu-auth.test.ts
@@ -1,0 +1,228 @@
+import { homedir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createRuntimePathsMockModule,
+  getTrustedOpencodeConfigPaths,
+  getWorkspaceOpencodeConfigPaths,
+  loadFsConfigMocks,
+  mockTrustedConfigFile,
+  resetFsConfigMocks,
+  resetProcessEnv,
+} from "./helpers/trusted-config-test-harness.js";
+
+const mocks = vi.hoisted(() => ({
+  getAuthPaths: vi.fn(() => ["/tmp/auth.json"]),
+  readAuthFileCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => createRuntimePathsMockModule());
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  getAuthPaths: mocks.getAuthPaths,
+  readAuthFileCached: mocks.readAuthFileCached,
+}));
+
+import {
+  DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS,
+  getOpencodeConfigCandidatePaths,
+  getZhipuAuthDiagnostics,
+  resolveZhipuAuth,
+  resolveZhipuAuthCached,
+} from "../src/lib/zhipu-auth.js";
+
+const withZhipuAuth = (entry: unknown) => ({
+  "zhipu-coding-plan": entry,
+});
+
+describe("zhipu auth resolution", () => {
+  const originalEnv = process.env;
+  const trustedPaths = getTrustedOpencodeConfigPaths();
+  const workspacePaths = getWorkspaceOpencodeConfigPaths();
+  const expectedTrustedCandidates = [
+    { path: join(homedir(), ".config", "opencode", "opencode.jsonc"), isJsonc: true },
+    { path: join(homedir(), ".config", "opencode", "opencode.json"), isJsonc: false },
+  ];
+  let fsConfigMocks: Awaited<ReturnType<typeof loadFsConfigMocks>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    resetProcessEnv(originalEnv, ["ZHIPU_API_KEY", "ZHIPU_CODING_PLAN_API_KEY"]);
+
+    mocks.getAuthPaths.mockReset().mockReturnValue(["/tmp/auth.json"]);
+    mocks.readAuthFileCached.mockReset();
+
+    fsConfigMocks = await loadFsConfigMocks();
+    resetFsConfigMocks(fsConfigMocks);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe("resolveZhipuAuth", () => {
+    it.each([
+      ["auth is null", null, { state: "none" }],
+      ["auth is undefined", undefined, { state: "none" }],
+      ["zhipu-coding-plan entry is missing", {}, { state: "none" }],
+    ])("returns %j when %s", (_label, auth, expected) => {
+      expect(resolveZhipuAuth(auth as any)).toEqual(expected);
+    });
+
+    it.each([
+      [
+        "auth entry is not an object",
+        withZhipuAuth("bad-shape"),
+        { state: "invalid", error: "Zhipu auth entry has invalid shape" },
+      ],
+      [
+        "auth type is missing or invalid",
+        withZhipuAuth({ type: { bad: true }, key: "key" }),
+        { state: "invalid", error: "Zhipu auth entry present but type is missing or invalid" },
+      ],
+      [
+        "type is not api",
+        withZhipuAuth({ type: "oauth", key: "key" }),
+        { state: "invalid", error: 'Unsupported Zhipu auth type: "oauth"' },
+      ],
+      [
+        "invalid auth type text is sanitized",
+        withZhipuAuth({ type: "\u001b[31moauth\nretry\u001b[0m", key: "key" }),
+        { state: "invalid", error: 'Unsupported Zhipu auth type: "oauth retry"' },
+      ],
+      [
+        "key is empty",
+        withZhipuAuth({ type: "api", key: "" }),
+        { state: "invalid", error: "Zhipu auth entry present but key is empty" },
+      ],
+    ])("returns %j when %s", (_label, auth, expected) => {
+      expect(resolveZhipuAuth(auth as any)).toEqual(expected);
+    });
+
+    it("returns configured when a trimmed key is present", () => {
+      expect(resolveZhipuAuth(withZhipuAuth({ type: "api", key: " zhipu-key " }) as any)).toEqual({
+        state: "configured",
+        apiKey: "zhipu-key",
+      });
+    });
+  });
+
+  describe("resolveZhipuAuthCached", () => {
+    it("prefers ZHIPU_API_KEY over invalid auth.json", async () => {
+      process.env.ZHIPU_API_KEY = "env-key";
+      mocks.readAuthFileCached.mockResolvedValueOnce(withZhipuAuth({ type: "oauth", key: "token" }));
+
+      await expect(resolveZhipuAuthCached()).resolves.toEqual({
+        state: "configured",
+        apiKey: "env-key",
+      });
+      expect(mocks.readAuthFileCached).not.toHaveBeenCalled();
+    });
+
+    it("reads from trusted global config aliases in provider-key order", async () => {
+      mockTrustedConfigFile(
+        fsConfigMocks,
+        trustedPaths.json,
+        JSON.stringify({
+          provider: {
+            zhipu: {
+              options: {
+                apiKey: "{env:NOT_ALLOWED}",
+              },
+            },
+            "glm-coding-plan": {
+              options: {
+                apiKey: "glm-key",
+              },
+            },
+          },
+        }),
+      );
+
+      await expect(resolveZhipuAuthCached()).resolves.toEqual({
+        state: "configured",
+        apiKey: "glm-key",
+      });
+      expect(mocks.readAuthFileCached).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["opencode.json", workspacePaths.json],
+      ["opencode.jsonc", workspacePaths.jsonc],
+    ])("ignores workspace-local %s when resolving provider secrets", async (_label, workspacePath) => {
+      fsConfigMocks.existsSync.mockImplementation((path: string) => path === workspacePath);
+      mocks.readAuthFileCached.mockResolvedValueOnce(null);
+
+      await expect(resolveZhipuAuthCached()).resolves.toEqual({ state: "none" });
+    });
+
+    it("falls back to auth.json when env/config are not configured", async () => {
+      mocks.readAuthFileCached.mockResolvedValueOnce(withZhipuAuth({ type: "api", key: "zhipu-key" }));
+
+      await expect(resolveZhipuAuthCached()).resolves.toEqual({
+        state: "configured",
+        apiKey: "zhipu-key",
+      });
+      expect(mocks.readAuthFileCached).toHaveBeenCalledWith({
+        maxAgeMs: DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS,
+      });
+    });
+
+    it("surfaces invalid auth.json when the fallback entry wins", async () => {
+      mocks.readAuthFileCached.mockResolvedValueOnce(withZhipuAuth({ type: "oauth", key: "token" }));
+
+      await expect(resolveZhipuAuthCached()).resolves.toEqual({
+        state: "invalid",
+        error: 'Unsupported Zhipu auth type: "oauth"',
+      });
+    });
+
+    it("clamps negative maxAgeMs to 0", async () => {
+      mocks.readAuthFileCached.mockResolvedValueOnce({});
+
+      await resolveZhipuAuthCached({ maxAgeMs: -1 });
+      expect(mocks.readAuthFileCached).toHaveBeenCalledWith({ maxAgeMs: 0 });
+    });
+  });
+
+  describe("getZhipuAuthDiagnostics", () => {
+    it("reports env/config checked paths separately from auth paths", async () => {
+      process.env.ZHIPU_CODING_PLAN_API_KEY = "diag-key";
+
+      await expect(getZhipuAuthDiagnostics()).resolves.toEqual({
+        state: "configured",
+        source: "env:ZHIPU_CODING_PLAN_API_KEY",
+        checkedPaths: ["env:ZHIPU_CODING_PLAN_API_KEY"],
+        authPaths: ["/tmp/auth.json"],
+      });
+    });
+
+    it("reports invalid auth.json diagnostics when fallback auth is malformed", async () => {
+      mocks.readAuthFileCached.mockResolvedValueOnce(withZhipuAuth({ type: "oauth", key: "token" }));
+
+      await expect(getZhipuAuthDiagnostics()).resolves.toEqual({
+        state: "invalid",
+        source: "auth.json",
+        checkedPaths: [],
+        authPaths: ["/tmp/auth.json"],
+        error: 'Unsupported Zhipu auth type: "oauth"',
+      });
+    });
+  });
+
+  describe("getOpencodeConfigCandidatePaths", () => {
+    it("returns trusted global paths only", () => {
+      const paths = getOpencodeConfigCandidatePaths();
+
+      expect(paths).toEqual(expectedTrustedCandidates);
+    });
+  });
+});

--- a/tests/lib.zhipu.test.ts
+++ b/tests/lib.zhipu.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { queryZhipuQuota } from "../src/lib/zhipu.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveZhipuAuthCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/zhipu-auth.js", () => ({
+  resolveZhipuAuthCached: mocks.resolveZhipuAuthCached,
+}));
+
+async function mockZhipuAuth(key: string = "zhipu-test-key"): Promise<void> {
+  mocks.resolveZhipuAuthCached.mockResolvedValueOnce({
+    state: "configured",
+    apiKey: key,
+  });
+}
+
+describe("queryZhipuQuota", () => {
+  it("returns null when not configured", async () => {
+    mocks.resolveZhipuAuthCached.mockResolvedValueOnce({ state: "none" });
+
+    await expect(queryZhipuQuota()).resolves.toBeNull();
+  });
+
+  it("returns auth errors when zhipu-coding-plan auth is invalid", async () => {
+    mocks.resolveZhipuAuthCached.mockResolvedValueOnce({
+      state: "invalid",
+      error: 'Unsupported Zhipu auth type: "oauth"',
+    });
+    await expect(queryZhipuQuota()).resolves.toEqual({
+      success: false,
+      error: 'Unsupported Zhipu auth type: "oauth"',
+    });
+  });
+
+  it("returns API status errors with truncated response body", async () => {
+    await mockZhipuAuth();
+    const body = "x".repeat(200);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 500 })) as any,
+    );
+
+    const out = await queryZhipuQuota();
+    expect(out && !out.success ? out.error : "").toBe(
+      `Zhipu API error 500: ${body.slice(0, 120)}`,
+    );
+  });
+
+  it("returns invalid quota data when limits is missing or not an array", async () => {
+    await mockZhipuAuth();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: 0,
+              msg: "ok",
+              success: true,
+              data: { level: "pro", limits: null },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryZhipuQuota();
+    expect(out).toEqual({ success: false, error: "Invalid quota data" });
+  });
+
+  it("maps unit windows and clamps percentages", async () => {
+    const fiveHourResetMs = 1_735_776_000_000;
+    const weeklyResetMs = 1_736_121_600_000;
+    const mcpResetMs = 1_735_948_800_000;
+
+    await mockZhipuAuth();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: 0,
+              msg: "ok",
+              success: true,
+              data: {
+                level: "pro",
+                limits: [
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 3,
+                    number: 100,
+                    usage: 33.3,
+                    percentage: 33.3,
+                    nextResetTime: fiveHourResetMs,
+                  },
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 6,
+                    number: 100,
+                    usage: 55.5,
+                    percentage: 55.5,
+                    nextResetTime: weeklyResetMs,
+                  },
+                  {
+                    type: "TIME_LIMIT",
+                    unit: 5,
+                    number: 100,
+                    usage: 10,
+                    percentage: 10,
+                    nextResetTime: mcpResetMs,
+                  },
+                ],
+              },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryZhipuQuota();
+    expect(out && out.success ? out.label : "").toBe("Zhipu");
+    expect(out && out.success ? out.windows.fiveHour : undefined).toEqual({
+      percentRemaining: 67,
+      resetTimeIso: new Date(fiveHourResetMs).toISOString(),
+    });
+    expect(out && out.success ? out.windows.weekly : undefined).toEqual({
+      percentRemaining: 45,
+      resetTimeIso: new Date(weeklyResetMs).toISOString(),
+    });
+    expect(out && out.success ? out.windows.mcp : undefined).toEqual({
+      percentRemaining: 90,
+      resetTimeIso: new Date(mcpResetMs).toISOString(),
+    });
+  });
+
+  it("prefers the weekly unit when both daily and weekly token windows are present", async () => {
+    await mockZhipuAuth();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: 0,
+              msg: "ok",
+              success: true,
+              data: {
+                level: "pro",
+                limits: [
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 4,
+                    number: 100,
+                    usage: 20,
+                    percentage: 20,
+                    nextResetTime: 1_735_862_400_000,
+                  },
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 6,
+                    number: 100,
+                    usage: 70,
+                    percentage: 70,
+                    nextResetTime: 1_736_121_600_000,
+                  },
+                ],
+              },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryZhipuQuota();
+    expect(out && out.success ? out.windows.weekly : undefined).toEqual({
+      percentRemaining: 30,
+      resetTimeIso: "2025-01-06T00:00:00.000Z",
+    });
+  });
+
+  it("still uses the weekly unit when it appears before the daily token window", async () => {
+    await mockZhipuAuth();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              code: 0,
+              msg: "ok",
+              success: true,
+              data: {
+                level: "pro",
+                limits: [
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 6,
+                    number: 100,
+                    usage: 70,
+                    percentage: 70,
+                    nextResetTime: 1_736_121_600_000,
+                  },
+                  {
+                    type: "TOKENS_LIMIT",
+                    unit: 4,
+                    number: 100,
+                    usage: 20,
+                    percentage: 20,
+                    nextResetTime: 1_735_862_400_000,
+                  },
+                ],
+              },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryZhipuQuota();
+    expect(out && out.success ? out.windows.weekly : undefined).toEqual({
+      percentRemaining: 30,
+      resetTimeIso: "2025-01-06T00:00:00.000Z",
+    });
+  });
+
+  it("returns caught errors when fetch fails", async () => {
+    await mockZhipuAuth();
+    vi.stubGlobal("fetch", vi.fn(async () => Promise.reject(new Error("network down"))) as any);
+
+    const out = await queryZhipuQuota();
+    expect(out).toEqual({ success: false, error: "network down" });
+  });
+});

--- a/tests/providers.zhipu.test.ts
+++ b/tests/providers.zhipu.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+import { createProviderAvailabilityContext } from "./helpers/provider-test-harness.js";
+import { zhipuProvider } from "../src/providers/zhipu.js";
+
+vi.mock("../src/lib/zhipu.js", () => ({
+  queryZhipuQuota: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  resolveZhipuAuthCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/zhipu-auth.js", () => ({
+  DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS: 5_000,
+  resolveZhipuAuthCached: authMocks.resolveZhipuAuthCached,
+}));
+
+describe("zhipu provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMocks.resolveZhipuAuthCached.mockResolvedValue({
+      state: "configured",
+      apiKey: "zhipu-test-key",
+    });
+  });
+
+  it("returns attempted:false when not configured", async () => {
+    const { queryZhipuQuota } = await import("../src/lib/zhipu.js");
+    (queryZhipuQuota as any).mockResolvedValueOnce(null);
+
+    const out = await zhipuProvider.fetch({} as any);
+    expectNotAttempted(out);
+  });
+
+  it("maps success into canonical grouped-capable entries with single-window display metadata", async () => {
+    const { queryZhipuQuota } = await import("../src/lib/zhipu.js");
+    (queryZhipuQuota as any).mockResolvedValueOnce({
+      success: true,
+      label: "Zhipu",
+      windows: {
+        fiveHour: { percentRemaining: 80, resetTimeIso: "2026-01-01T00:00:00.000Z" },
+        weekly: { percentRemaining: 30, resetTimeIso: "2026-01-02T00:00:00.000Z" },
+        mcp: { percentRemaining: 90, resetTimeIso: "2026-01-03T00:00:00.000Z" },
+      },
+    });
+
+    const out = await zhipuProvider.fetch({} as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "Zhipu 5h",
+        group: "Zhipu",
+        label: "5h:",
+        percentRemaining: 80,
+        resetTimeIso: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        name: "Zhipu Weekly",
+        group: "Zhipu",
+        label: "Weekly:",
+        percentRemaining: 30,
+        resetTimeIso: "2026-01-02T00:00:00.000Z",
+      },
+      {
+        name: "Zhipu MCP",
+        group: "Zhipu",
+        label: "MCP:",
+        percentRemaining: 90,
+        resetTimeIso: "2026-01-03T00:00:00.000Z",
+      },
+    ]);
+    expect(out.presentation).toEqual({
+      singleWindowDisplayName: "Zhipu",
+    });
+  });
+
+  it("maps errors into toast errors", async () => {
+    const { queryZhipuQuota } = await import("../src/lib/zhipu.js");
+    (queryZhipuQuota as any).mockResolvedValueOnce({
+      success: false,
+      error: "Unauthorized",
+    });
+
+    const out = await zhipuProvider.fetch({} as any);
+    expectAttemptedWithErrorLabel(out, "Zhipu");
+  });
+
+  it("matches Zhipu-specific model ids without matching the international Z.ai glm provider", () => {
+    expect(zhipuProvider.matchesCurrentModel?.("zhipu/glm-4.5")).toBe(true);
+    expect(zhipuProvider.matchesCurrentModel?.("zhipu-coding-plan/glm-4.5")).toBe(true);
+    expect(zhipuProvider.matchesCurrentModel?.("glm-coding-plan/glm-4.5")).toBe(true);
+    expect(zhipuProvider.matchesCurrentModel?.("zai/glm-4.5")).toBe(false);
+    expect(zhipuProvider.matchesCurrentModel?.("glm/glm-4.5")).toBe(false);
+    expect(zhipuProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+
+  it("is available when provider ids include zhipu/zhipu-coding-plan/glm-coding-plan and auth is configured", async () => {
+    await expect(
+      zhipuProvider.isAvailable(createProviderAvailabilityContext({ providerIds: ["zhipu"] })),
+    ).resolves.toBe(true);
+    await expect(
+      zhipuProvider.isAvailable(
+        createProviderAvailabilityContext({ providerIds: ["zhipu-coding-plan"] }),
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      zhipuProvider.isAvailable(
+        createProviderAvailabilityContext({ providerIds: ["glm-coding-plan"] }),
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      zhipuProvider.isAvailable(createProviderAvailabilityContext({ providerIds: ["openai"] })),
+    ).resolves.toBe(false);
+  });
+
+  it("is available when auth is invalid so the provider can surface the error", async () => {
+    authMocks.resolveZhipuAuthCached.mockResolvedValueOnce({
+      state: "invalid",
+      error: 'Unsupported Zhipu auth type: "oauth"',
+    });
+
+    const ctx = createProviderAvailabilityContext({ providerIds: ["zhipu"] });
+
+    await expect(zhipuProvider.isAvailable(ctx)).resolves.toBe(true);
+    expect(authMocks.resolveZhipuAuthCached).toHaveBeenCalledWith({ maxAgeMs: 5_000 });
+  });
+
+  it("is not available when provider ids exist but auth is missing", async () => {
+    authMocks.resolveZhipuAuthCached.mockResolvedValueOnce({ state: "none" });
+
+    const ctx = createProviderAvailabilityContext({ providerIds: ["zhipu"] });
+
+    await expect(zhipuProvider.isAvailable(ctx)).resolves.toBe(false);
+    expect(authMocks.resolveZhipuAuthCached).toHaveBeenCalledWith({ maxAgeMs: 5_000 });
+  });
+
+  it("is not available when provider lookup throws", async () => {
+    const ctx = createProviderAvailabilityContext({ providersError: new Error("boom") });
+
+    await expect(zhipuProvider.isAvailable(ctx)).resolves.toBe(false);
+    expect(authMocks.resolveZhipuAuthCached).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Zhipu** quota provider for the domestic China Zhipu Coding Plan (`bigmodel.cn`), mirroring the existing Z.ai provider (`api.z.ai`).

### What's new
- **New provider: `zhipu`** — queries `https://bigmodel.cn/api/monitor/usage/quota/limit`
- **Auth resolution**: `ZHIPU_API_KEY` / `ZHIPU_CODING_PLAN_API_KEY` env vars → opencode.jsonc provider config (`zhipu`, `zhipu-coding-plan`, `glm-coding-plan`) → auth.json
- **Full feature parity with Z.ai provider**: TUI sidebar, toast notifications, `/quota` command status report
- **Same response format** as Z.ai (5h/weekly token windows + MCP monthly limit)

### Files changed
| File | Change |
|------|--------|
| `src/lib/zhipu.ts` | New — quota fetcher (mirrors `zai.ts`) |
| `src/lib/zhipu-auth.ts` | New — auth resolution (mirrors `zai-auth.ts`) |
| `src/providers/zhipu.ts` | New — provider wrapper (mirrors `zai.ts`) |
| `src/providers/registry.ts` | Register `zhipuProvider` |
| `src/lib/provider-metadata.ts` | Add zhipu canonical ID, labels, synonyms, runtime IDs, shape |
| `src/lib/types.ts` | Add `zhipu-coding-plan` to `AuthData` interface |
| `src/lib/quota-status.ts` | Add zhipu diagnostics section for `/quota` command |

### Usage
Add to `opencode.jsonc`:
```jsonc
{
  "experimental": {
    "quotaToast": {
      "enabledProviders": ["zai", "zhipu", "kimi-code"]
    }
  }
}
```

And configure the provider:
```jsonc
{
  "provider": {
    "zhipu-coding-plan": {
      "name": "Zhipu Coding Plan",
      "options": { "apiKey": "{env:ZHIPU_API_KEY}" },
      // ...models...
    }
  }
}
```

### Testing
- `npm run typecheck` ✅
- `npm run build` ✅
- Published as `@mingxy/opencode-quota@3.6.2` and tested in production

### Why separate provider?
Z.ai (international) and Zhipu (domestic China) use different API endpoints and API keys. They serve different user bases and need independent auth resolution. The domestic endpoint is `bigmodel.cn` (not `api.z.ai`).