### PR TITLE
fix(Gemini companion): expand resolution to scan packages directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slkiser/opencode-quota",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@slkiser/opencode-quota",
-      "version": "3.8.1",
+      "version": "3.8.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slkiser/opencode-quota",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "OpenCode quota & tokens usage with zero context window pollution. Supports GitHub Copilot, OpenAI (Plus/Pro), Qwen Code, Chutes AI, Synthetic, Google Antigravity, Z.ai coding plan and more.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/lib/google-antigravity-companion.ts
+++ b/src/lib/google-antigravity-companion.ts
@@ -1,4 +1,5 @@
 import { readFile } from "fs/promises";
+import { readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -103,7 +104,24 @@ function normalizeCredential(value: unknown): string {
 }
 
 function getCompanionResolvePaths(): string[] {
-  return getOpencodeRuntimeDirCandidates().cacheDirs;
+  const cacheDirs = getOpencodeRuntimeDirCandidates().cacheDirs;
+  const resolvePaths: string[] = [...cacheDirs];
+
+  for (const cacheDir of cacheDirs) {
+    try {
+      const packagesDir = join(cacheDir, "packages");
+      const entries = readdirSync(packagesDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.startsWith(COMPANION_PACKAGE_NAME)) {
+          resolvePaths.push(join(packagesDir, entry.name));
+        }
+      }
+    } catch {
+      // Ignore if packages dir doesn't exist
+    }
+  }
+
+  return resolvePaths;
 }
 
 function markPackageFoundForExportBlock(

--- a/src/lib/google-gemini-cli-companion.ts
+++ b/src/lib/google-gemini-cli-companion.ts
@@ -1,4 +1,5 @@
 import { readFile } from "fs/promises";
+import { readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -93,7 +94,24 @@ function normalizeCredential(value: unknown): string {
 }
 
 function getCompanionResolvePaths(): string[] {
-  return getOpencodeRuntimeDirCandidates().cacheDirs;
+  const cacheDirs = getOpencodeRuntimeDirCandidates().cacheDirs;
+  const resolvePaths: string[] = [...cacheDirs];
+
+  for (const cacheDir of cacheDirs) {
+    try {
+      const packagesDir = join(cacheDir, "packages");
+      const entries = readdirSync(packagesDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.startsWith(COMPANION_PACKAGE_NAME)) {
+          resolvePaths.push(join(packagesDir, entry.name));
+        }
+      }
+    } catch {
+      // Ignore if packages dir doesn't exist
+    }
+  }
+
+  return resolvePaths;
 }
 
 function resolveCompanionSpecifier(specifier: string): string {


### PR DESCRIPTION
## Summary

Update `getCompanionResolvePaths` to recursively scan the packages subdirectory for installed companion plugins.
This ensures that plugins installed via the package manager are correctly discovered and loaded during runtime resolution.

Current output:
```
> npx @slkiser/opencode-quota show
[Copilot] (personal)
Quota window                        19d
████████████████████░░░░░░░░░░░░░░░░░░░   52% left

Gemini CLI: Unavailable (not detected)
```

With local fix:
```
> node ./dist/bin/opencode-quota.js show           
[Copilot] (personal)
Quota window                        19d
████████████████████░░░░░░░░░░░░░░░░░░░   52% left

[Gemini CLI]
Quota window                         1h
███████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   17% left
Quota window                        18h
███████████████████████████████████████   99% left
Quota window                           
███████████████████████████████████████  100% left

```

Test locally in OpenCode:
```
# Quota (/quota) 15:48 12/05/2026
→ [Copilot] (personal)
  Quota: 143/300     █████████░░░░░░░░░  52% left (resets in 19d)
→ [Gemini CLI]
  Gemini Pro:        ███░░░░░░░░░░░░░░░  17% left (resets in 1h)
  Gemini Flash:      ██████████████████  99% left (resets in 18h)
  Gemini Flash Lite: ██████████████████  100% left (resets in 24h)

# Quota Status (opencode-quota v3.8.2) (/quota_status) 15:49 12/05/2026
...
google_gemini_cli:
- auth_state: present
- auth_source: google
- account_count: 1
- valid_account_count: 1
- companion_package_state: present
- companion_package_path: /home/anthony/.cache/opencode/packages/opencode-gemini-auth@latest/node_modules/opencode-gemini-auth/dist/index.js
- live_probe: success
- live_entry_1: [Gemini CLI] percent_remaining=17 reset_at=2026-05-12T14:59:02Z
...
```

## Linked Issue

https://github.com/slkiser/opencode-quota/issues/85

## OpenCode Validation

- Current production released OpenCode version tested: 1.14.48
- Why this version is relevant to the fix: -

## Quality Checklist

- [X] I ran `npm run typecheck`
- [X] I ran `npm test`
- [X] I ran `npm run build`
- [ ] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [ ] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
