### PR TITLE
fix(tui): stub missing @opentui/core .js siblings on install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
       },
       "peerDependencies": {
         "@opencode-ai/plugin": "^1.4.3"
-      }
+      },
+      "hasInstallScript": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -28,11 +28,13 @@
   ],
   "files": [
     "dist",
+    "scripts/shim-opentui-core.mjs",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node scripts/copy-data.mjs && node scripts/prepare-tui-dist.mjs",
+    "build": "tsc && node scripts/copy-data.mjs && node scripts/prepare-tui-dist.mjs && node scripts/shim-opentui-core.mjs",
+    "postinstall": "node scripts/shim-opentui-core.mjs",
     "build:check": "npm run build && npm pack --dry-run",
     "pricing:refresh": "node scripts/refresh-modelsdev-pricing.mjs",
     "pricing:refresh:if-stale": "node scripts/refresh-modelsdev-pricing-if-stale.mjs",

--- a/scripts/shim-opentui-core.mjs
+++ b/scripts/shim-opentui-core.mjs
@@ -1,0 +1,102 @@
+// Workaround for @opentui/core@0.2.x publishing *.d.ts without matching *.js
+// siblings. When OpenCode's Bun-based TUI host loads `dist/tui.tsx`, it walks
+// the type-import graph through `@opentui/core/index.d.ts` (which contains
+// `export * from "./types.js"` and similar) and aborts with ENOENT on the
+// missing runtime files. Bundled runtime symbols are re-exported from
+// `index.js`, so empty stubs are sufficient to unblock resolution.
+//
+// Tracking: https://github.com/slkiser/opencode-quota/issues/87
+//
+// This script is safe to run repeatedly: it only writes `.js` files that do
+// not already exist next to a `.d.ts`.
+
+import { readdir, stat, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const SHIM_BANNER = '// Auto-generated stub for missing .js sibling of .d.ts in @opentui/core.\n' +
+  '// See scripts/shim-opentui-core.mjs in @slkiser/opencode-quota.\n' +
+  'export {};\n'
+
+async function findOpentuiCoreDirs(startDir) {
+  const results = []
+  let current = path.resolve(startDir)
+  // Walk up looking for any node_modules/@opentui/core that contains this package.
+  // The plugin is typically installed under <opencode cache>/node_modules/@slkiser/opencode-quota,
+  // with @opentui/core as a sibling under the same node_modules root.
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(current, 'node_modules', '@opentui', 'core')
+    if (existsSync(candidate)) results.push(candidate)
+    const parent = path.dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return results
+}
+
+async function shimDir(coreDir) {
+  let created = 0
+  const entries = await readdir(coreDir, { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isFile()) continue
+    if (!entry.name.endsWith('.d.ts')) continue
+    if (entry.name.endsWith('.d.ts.map')) continue
+    const base = entry.name.slice(0, -'.d.ts'.length)
+    const jsPath = path.join(coreDir, `${base}.js`)
+    const tsxPath = path.join(coreDir, `${base}.tsx`)
+    const dirPath = path.join(coreDir, base)
+    if (existsSync(jsPath) || existsSync(tsxPath)) continue
+    try {
+      const st = await stat(dirPath)
+      if (st.isDirectory()) continue
+    } catch {
+      // not a directory, proceed
+    }
+    await writeFile(jsPath, SHIM_BANNER, 'utf-8')
+    created++
+  }
+  return created
+}
+
+async function main() {
+  // Two entry points: when run from this repo's `scripts/` during `npm run build`,
+  // and when run as a postinstall hook from the installed package.
+  // INIT_CWD is set by npm to the directory where install was invoked.
+  const searchRoots = new Set()
+  if (process.env.INIT_CWD) searchRoots.add(process.env.INIT_CWD)
+  searchRoots.add(path.resolve(__dirname, '..'))
+  searchRoots.add(process.cwd())
+
+  const visited = new Set()
+  let totalCreated = 0
+  let dirsTouched = 0
+  for (const root of searchRoots) {
+    for (const coreDir of await findOpentuiCoreDirs(root)) {
+      if (visited.has(coreDir)) continue
+      visited.add(coreDir)
+      try {
+        const created = await shimDir(coreDir)
+        if (created > 0) {
+          dirsTouched++
+          totalCreated += created
+        }
+      } catch {
+        // best-effort; never fail install if shimming cannot run
+      }
+    }
+  }
+
+  if (totalCreated > 0) {
+    console.log(
+      `[opencode-quota] Added ${totalCreated} runtime stub(s) for @opentui/core .d.ts files in ${dirsTouched} location(s).`,
+    )
+  }
+}
+
+main().catch(() => {
+  // Never fail install on shim errors.
+  process.exit(0)
+})

--- a/tests/opentui-core-shim.test.ts
+++ b/tests/opentui-core-shim.test.ts
@@ -1,0 +1,39 @@
+import { access, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const repoRoot = path.dirname(fileURLToPath(new URL("../package.json", import.meta.url)));
+const coreDir = path.join(repoRoot, "node_modules", "@opentui", "core");
+
+describe("@opentui/core runtime stubs (postinstall shim)", () => {
+  it("has a .js sibling for every .d.ts file in @opentui/core", async () => {
+    if (!(await exists(coreDir))) return;
+
+    const entries = await readdir(coreDir, { withFileTypes: true });
+    const missing: string[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".d.ts")) continue;
+      if (entry.name.endsWith(".d.ts.map")) continue;
+      const base = entry.name.slice(0, -".d.ts".length);
+      const jsPath = path.join(coreDir, `${base}.js`);
+      const tsxPath = path.join(coreDir, `${base}.tsx`);
+      if (!(await exists(jsPath)) && !(await exists(tsxPath))) {
+        missing.push(entry.name);
+      }
+    }
+
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `postinstall` script that creates empty `export {}` runtime stubs for any `.d.ts` in `@opentui/core` that lacks a matching `.js`/`.tsx` sibling. Without these stubs, OpenCode's Bun-based TUI host fails to load `dist/tui.tsx` with `ENOENT: ... @opentui/core/types.js`, and the sidebar panel and compact status line silently never register.

`@opentui/core@0.2.x` publishes `types.d.ts` etc. but not the matching `types.js`. Bun walks `import type` chains during tsx transpile (through `@opentui/core/index.d.ts` → `export * from "./types.js"`) and aborts. Runtime symbols are actually re-exported from the bundled `index.js`, so empty stubs unblock resolution without affecting behavior. Verified locally: sidebar and compact status now render against OpenCode `1.14.48`.

## Linked Issue

Fixes #87

## OpenCode Validation

- Current production released OpenCode version tested: `1.14.48`
- Why this version is relevant to the fix: This is where the report originates and where the ENOENT failure was reproduced and verified.

Repro log line before the fix:

```
ERROR service=tui.plugin path=@slkiser/opencode-quota@3.8.2
  target=file:///.../@slkiser/opencode-quota@3.8.2/node_modules/@slkiser/opencode-quota/dist/tui.tsx
  error: ENOENT: no such file or directory, open
  '.../node_modules/@opentui/core/types.js'
```

After the fix: TUI plugin loads, sidebar + compact status appear.

## Changes

- `scripts/shim-opentui-core.mjs` — finds `@opentui/core` directories under `node_modules` (walking up from `INIT_CWD`, the repo, and `cwd`) and writes empty stubs for every missing `.js` sibling. Idempotent; never fails install.
- `package.json` — adds `postinstall` hook (runs on consumer install), chains the script into `build`, and includes `scripts/shim-opentui-core.mjs` in `files` so the npm tarball ships it.
- `package-lock.json` — single field update (`hasInstallScript: true`) reflecting the new postinstall.
- `tests/opentui-core-shim.test.ts` — regression test: every `.d.ts` in `@opentui/core` must have a runtime sibling.

## Quality Checklist

- [x] I ran `npm run typecheck`
- [x] I ran `npm test` (106 files, 922 tests passed)
- [x] I ran `npm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and added a boundary test
- [ ] I updated docs for user-facing workflow/command/config changes — not applicable; no user-facing surface changes
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply — N/A, no provider change
- [ ] For provider setup/auth wording changes — N/A