### PR TITLE
fix(gemini-cli): Surface specific missing companion error instead of generic unavailable status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slkiser/opencode-quota",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@slkiser/opencode-quota",
-      "version": "3.8.3",
+      "version": "3.8.4",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slkiser/opencode-quota",
-  "version": "3.8.3",
+  "version": "3.8.4",
   "description": "OpenCode quota & tokens usage with zero context window pollution. Supports GitHub Copilot, OpenAI (Plus/Pro), Qwen Code, Chutes AI, Synthetic, Google Antigravity, Z.ai coding plan and more.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/lib/google-gemini-cli.ts
+++ b/src/lib/google-gemini-cli.ts
@@ -7,7 +7,6 @@ import {
 } from "./google-token-cache.js";
 import {
   clearGeminiCliCompanionCacheForTests as clearGeminiCliCompanionResolutionCacheForTests,
-  inspectGeminiCliCompanionPresence,
   resolveGeminiCliClientCredentials,
   type GeminiCliConfiguredCredentials,
 } from "./google-gemini-cli-companion.js";
@@ -265,15 +264,11 @@ export async function inspectGeminiCliAuthPresence(client?: ConfigClient): Promi
 }
 
 export async function hasGeminiCliQuotaRuntimeAvailable(client?: ConfigClient): Promise<boolean> {
-  const [authPresence, companionPresence] = await Promise.all([
-    inspectGeminiCliAuthPresence(client),
-    inspectGeminiCliCompanionPresence(),
-  ]);
+  const authPresence = await inspectGeminiCliAuthPresence(client);
 
   return (
     authPresence.state === "present" &&
-    authPresence.validAccountCount > 0 &&
-    companionPresence.state === "present"
+    authPresence.validAccountCount > 0
   );
 }
 


### PR DESCRIPTION
## Summary
Fix an issue where a missing `opencode-gemini-auth` companion package resulted in a generic `Gemini CLI: Unavailable (not detected)` status message instead of the intended actionable error.

## Details
**Why:**
In version 3.8.3, changes to how the companion package is resolved led to a regression in error reporting. The `hasGeminiCliQuotaRuntimeAvailable()` function was checking for both the presence of valid OAuth configuration *and* the companion package.
When the companion package was missing, it returned `false`, which caused the entire provider to be marked as unavailable.
This early exit bypassed the `fetch` phase (`queryGeminiCliQuota()`) where the specific and actionable error (`Install opencode-gemini-auth separately to enable Gemini CLI quota`) is actually generated and returned to the user.

**How:**
- Removed `inspectGeminiCliCompanionPresence` from `hasGeminiCliQuotaRuntimeAvailable()`.
- The availability check now only verifies that Gemini CLI auth configuration is present.
- Companion validation is now correctly delegated to the `fetch` phase (`queryGeminiCliQuota()`), which properly captures the companion state and surfaces the appropriate error message to the user if it's missing or incompatible.

## Linked Issue

Current version : 
```
> node ./dist/bin/opencode-quota.js show

[Copilot] (personal)
Quota                                          16d
████████████████████░░░░░░░░░░░░░░░░░░░   52% left

Gemini CLI: Unavailable (not detected)
```

Fix version:
```
> node ./dist/bin/opencode-quota.js show        

[Copilot] (personal)
Quota                                          16d
████████████████████░░░░░░░░░░░░░░░░░░░   52% left

[Gemini CLI]
Gemini Pro                                     24h
███████████████████████░░░░░░░░░░░░░░░░   59% left
Gemini Flash                                 23.5h
███████████████████████████████████████   99% left
Gemini Flash Lite                                 
███████████████████████████████████████  100% left
```

## OpenCode Validation

- Current production released OpenCode version tested: 1.15.0
- Why this version is relevant to the fix: -

## Quality Checklist

- [x] I ran `npm run typecheck`
- [x] I ran `npm test`
- [x] I ran `npm run build`
- [ ] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [ ] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
