### PR TITLE
fix(zhipu): add zhipuai-coding-plan in provider list

### DIFF
--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -98,6 +98,7 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   gemini: "google-gemini-cli",
   "glm-coding-plan": "zhipu",
   "zhipu-coding-plan": "zhipu",
+  "zhipuai-coding-plan": "zhipu",
 };
 
 export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
@@ -119,7 +120,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
     "google",
   ],
   zai: ["zai", "glm", "zai-coding-plan"],
-  zhipu: ["zhipu", "glm-coding-plan", "zhipu-coding-plan"],
+  zhipu: ["zhipu", "glm-coding-plan", "zhipu-coding-plan", "zhipuai-coding-plan"],
   nanogpt: ["nanogpt", "nano-gpt"],
   "minimax-coding-plan": ["minimax-coding-plan", "minimax"],
   "minimax-china-coding-plan": [
@@ -201,7 +202,8 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     authentication: "external_api_key",
     authFallbacks: ["env_api_key", "global_opencode_config"],
     quota: "remote_api",
-    notes: "Requires CROF_API_KEY, CROFAI_API_KEY, or trusted user/global config; not available through OpenCode /connect",
+    notes:
+      "Requires CROF_API_KEY, CROFAI_API_KEY, or trusted user/global config; not available through OpenCode /connect",
   },
   {
     id: "google-antigravity",

--- a/src/lib/zhipu-auth.ts
+++ b/src/lib/zhipu-auth.ts
@@ -11,8 +11,13 @@ import { getAuthPaths, readAuthFileCached } from "./opencode-auth.js";
 import type { AuthData, ZaiAuthData } from "./types.js";
 
 export const DEFAULT_ZHIPU_AUTH_CACHE_MAX_AGE_MS = 5_000;
-const ZHIPU_AUTH_KEYS = ["zhipu-coding-plan"] as const;
-const ZHIPU_PROVIDER_KEYS = ["zhipu", "zhipu-coding-plan", "glm-coding-plan"] as const;
+const ZHIPU_AUTH_KEYS = ["zhipu-coding-plan", "zhipuai-coding-plan"] as const;
+const ZHIPU_PROVIDER_KEYS = [
+  "zhipu",
+  "zhipu-coding-plan",
+  "zhipuai-coding-plan",
+  "glm-coding-plan",
+] as const;
 const ALLOWED_ZHIPU_ENV_VARS = ["ZHIPU_API_KEY", "ZHIPU_CODING_PLAN_API_KEY"] as const;
 
 export type ZhipuKeySource =

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -75,7 +75,8 @@ describe("provider-metadata", () => {
         authentication: "external_api_key",
         authFallbacks: ["env_api_key", "global_opencode_config"],
         quota: "remote_api",
-        notes: "Requires CROF_API_KEY, CROFAI_API_KEY, or trusted user/global config; not available through OpenCode /connect",
+        notes:
+          "Requires CROF_API_KEY, CROFAI_API_KEY, or trusted user/global config; not available through OpenCode /connect",
       },
       {
         id: "google-antigravity",
@@ -187,6 +188,7 @@ describe("provider-metadata", () => {
       "zhipu",
       "glm-coding-plan",
       "zhipu-coding-plan",
+      "zhipuai-coding-plan",
     ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.nanogpt).toEqual(["nanogpt", "nano-gpt"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS["minimax-coding-plan"]).toEqual([
@@ -233,16 +235,15 @@ describe("provider-metadata", () => {
       "zhipu",
       "glm-coding-plan",
       "zhipu-coding-plan",
+      "zhipuai-coding-plan",
     ]);
     expect(getQuotaProviderRuntimeIds("glm-coding-plan")).toEqual([
       "zhipu",
       "glm-coding-plan",
       "zhipu-coding-plan",
+      "zhipuai-coding-plan",
     ]);
-    expect(getQuotaProviderRuntimeIds("minimax")).toEqual([
-      "minimax-coding-plan",
-      "minimax",
-    ]);
+    expect(getQuotaProviderRuntimeIds("minimax")).toEqual(["minimax-coding-plan", "minimax"]);
     expect(getQuotaProviderRuntimeIds("minimax-cn")).toEqual([
       "minimax-china-coding-plan",
       "minimax-cn-coding-plan",


### PR DESCRIPTION
## Summary

OpenCode registers the Zhipu Coding Plan provider with the ID `zhipuai-coding-plan` (generated by `/connect`), but the plugin's runtime ID mapping only included `zhipu`, `glm-coding-plan`, and `zhipu-coding-plan`. Since `zhipuai-coding-plan` was not recognized, `isCanonicalProviderAvailable("zhipu")` always returned false, causing the TUI Sidebar to display "Unavailable (not detected)" even when quota data was successfully fetched via `/quota_status`.

This PR adds `zhipuai-coding-plan` to three locations:

| File | Change |
|---|---|
| `src/lib/provider-metadata.ts` | Added `"zhipuai-coding-plan"` to `QUOTA_PROVIDER_ID_SYNONYMS` and `QUOTA_PROVIDER_RUNTIME_IDS.zhipu` |
| `src/lib/zhipu-auth.ts` | Added `"zhipuai-coding-plan"` to `ZHIPU_AUTH_KEYS` and `ZHIPU_PROVIDER_KEYS` |
| `tests/lib.provider-metadata.test.ts` | Updated snapshot assertions to include the new runtime ID |

## Linked Issue

Fixes #98 

## OpenCode Validation

- Current production released OpenCode version tested: v1.15.6
- Why this version is relevant to the fix: OpenCode `/connect` generates provider ID `zhipuai-coding-plan` which was not in the plugin's mapping.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test`
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [x] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [x] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior

## Screenshot
<img width="386" height="176" alt="screenshot" src="https://github.com/user-attachments/assets/436fb1cd-416a-4705-b32c-98e7b0928001" />
