### PR TITLE
feat(ollama-cloud): add Ollama Cloud provider with cookie-based quota scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | Zhipu Coding Plan | Automatic | Remote API |
 | NanoGPT | Usually automatic | Remote API |
 | DeepSeek | Usually automatic | Remote API balance |
+| Ollama Cloud | [Needs setup](#ollama-cloud) | Dashboard scraping |
 | OpenCode Go | [Needs setup](#opencode-go) | Dashboard scraping |
 
 ## Common configuration
@@ -512,6 +513,25 @@ Or put the key in trusted user/global OpenCode config, not repo-local config:
 ```
 
 If you use manual provider selection, include `deepseek` in `enabledProviders`.
+
+</details>
+
+<a id="ollama-cloud"></a>
+<details>
+<summary><strong>Ollama Cloud</strong></summary>
+
+Ollama Cloud quota scrapes the Ollama Cloud settings page and needs a `__Secure-session` cookie:
+
+```bash
+export OLLAMA_USAGE_COOKIE="your-session-cookie-value"
+```
+
+Or use one of these config files (cookie without the `__Secure-session=` prefix, or with — the plugin normalizes it):
+
+- `~/.config/opencode/opencode-quota/ollama-cloud.json`: `{ "cookie": "..." }`
+- `~/.config/ollama-usage/config.yaml`: `cookie: "..."`
+
+To find the cookie, open `ollama.com/settings` in your browser, open Developer Tools → Storage → Cookies, and copy the value of `__Secure-session`.
 
 </details>
 

--- a/src/lib/ollama-cloud-config.ts
+++ b/src/lib/ollama-cloud-config.ts
@@ -1,0 +1,202 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+import { homedir } from "os";
+import { xdgConfig } from "xdg-basedir";
+
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
+
+export interface OllamaCloudConfig {
+  cookie: string;
+}
+
+export type ResolvedOllamaCloudConfig =
+  | { state: "none" }
+  | { state: "configured"; config: OllamaCloudConfig; source: string }
+  | { state: "incomplete"; source: string; missing: string }
+  | { state: "invalid"; source: string; error: string };
+
+export interface OllamaCloudConfigDiagnostics {
+  state: ResolvedOllamaCloudConfig["state"];
+  source: string | null;
+  missing: string | null;
+  error: string | null;
+  checkedPaths: string[];
+}
+
+type ReadConfigFileResult =
+  | { state: "missing" }
+  | { state: "loaded"; config: Partial<OllamaCloudConfig> }
+  | { state: "invalid"; error: string };
+
+function getConfigCandidatePaths(): string[] {
+  const { configDirs } = getOpencodeRuntimeDirCandidates();
+  const paths = configDirs.map((dir) =>
+    join(dir, "opencode-quota", "ollama-cloud.json"),
+  );
+
+  const xdgConfigDir =
+    xdgConfig || join(homedir(), ".config");
+  paths.push(join(xdgConfigDir, "ollama-usage", "config.yaml"));
+
+  const home = homedir();
+  paths.push(join(home, ".ollama-usage", "config.yaml"));
+
+  return paths;
+}
+
+function getOllamaUsageConfigPath(): string {
+  const xdgConfigDir = xdgConfig || join(homedir(), ".config");
+  return join(xdgConfigDir, "ollama-usage", "config.yaml");
+}
+
+function getOllamaUsageLegacyPath(): string {
+  return join(homedir(), ".ollama-usage", "config.yaml");
+}
+
+function getConfigFileError(error: unknown): string {
+  if (error instanceof SyntaxError) {
+    return `Failed to parse config: ${error.message}`;
+  }
+  if (error instanceof Error && error.message) {
+    return `Failed to read config file: ${error.message}`;
+  }
+  return `Failed to read config file: ${String(error)}`;
+}
+
+async function readJsonConfigFile(path: string): Promise<ReadConfigFileResult> {
+  try {
+    const data = await readFile(path, "utf-8");
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { state: "invalid", error: "Config file must contain a JSON object" };
+    }
+    return { state: "loaded", config: parsed as Partial<OllamaCloudConfig> };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return { state: "missing" };
+    }
+    return { state: "invalid", error: getConfigFileError(error) };
+  }
+}
+
+async function readYamlConfigFile(path: string): Promise<ReadConfigFileResult> {
+  try {
+    const data = await readFile(path, "utf-8");
+    const cookieMatch = data.match(/(?:^|\n)\s*cookie\s*:\s*["']?\s*(.+?)\s*["']?\s*(?:\n|$)/);
+    if (cookieMatch && cookieMatch[1]) {
+      return { state: "loaded", config: { cookie: cookieMatch[1].trim() } };
+    }
+    return { state: "missing" };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return { state: "missing" };
+    }
+    return { state: "invalid", error: getConfigFileError(error) };
+  }
+}
+
+export function resolveOllamaCloudConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedOllamaCloudConfig | null {
+  const cookie = env.OLLAMA_USAGE_COOKIE?.trim();
+
+  if (!cookie) return null;
+
+  return {
+    state: "configured",
+    config: { cookie },
+    source: "env",
+  };
+}
+
+export async function resolveOllamaCloudConfig(): Promise<ResolvedOllamaCloudConfig> {
+  const envResult = resolveOllamaCloudConfigFromEnv();
+  if (envResult) return envResult;
+
+  const candidates = getConfigCandidatePaths();
+
+  for (const path of candidates) {
+    const isYaml = path.endsWith(".yaml");
+    const fileResult = isYaml
+      ? await readYamlConfigFile(path)
+      : await readJsonConfigFile(path);
+
+    if (fileResult.state === "missing") continue;
+    if (fileResult.state === "invalid") {
+      return { state: "invalid", source: path, error: fileResult.error };
+    }
+
+    const config = fileResult.config;
+    const cookie = typeof config.cookie === "string" ? config.cookie.trim() : "";
+
+    if (cookie) {
+      return {
+        state: "configured",
+        config: { cookie },
+        source: path,
+      };
+    }
+
+    return { state: "incomplete", source: path, missing: "cookie" };
+  }
+
+  return { state: "none" };
+}
+
+let cachedConfig: ResolvedOllamaCloudConfig | null = null;
+let cachedAt = 0;
+
+const DEFAULT_CACHE_MAX_AGE_MS = 30_000;
+export { DEFAULT_CACHE_MAX_AGE_MS as DEFAULT_OLLAMA_CLOUD_CONFIG_CACHE_MAX_AGE_MS };
+
+export async function resolveOllamaCloudConfigCached(params?: {
+  maxAgeMs?: number;
+}): Promise<ResolvedOllamaCloudConfig> {
+  const maxAgeMs = Math.max(0, params?.maxAgeMs ?? DEFAULT_CACHE_MAX_AGE_MS);
+  const now = Date.now();
+  if (cachedConfig && now - cachedAt < maxAgeMs) {
+    return cachedConfig;
+  }
+  cachedConfig = await resolveOllamaCloudConfig();
+  cachedAt = now;
+  return cachedConfig;
+}
+
+export async function getOllamaCloudConfigDiagnostics(): Promise<OllamaCloudConfigDiagnostics> {
+  const resolved = await resolveOllamaCloudConfig();
+  const checkedPaths = getConfigCandidatePaths();
+
+  if (resolved.state === "none") {
+    return { state: "none", source: null, missing: null, error: null, checkedPaths };
+  }
+
+  if (resolved.state === "incomplete") {
+    return {
+      state: "incomplete",
+      source: resolved.source,
+      missing: resolved.missing,
+      error: null,
+      checkedPaths,
+    };
+  }
+
+  if (resolved.state === "invalid") {
+    return {
+      state: "invalid",
+      source: resolved.source,
+      missing: null,
+      error: resolved.error,
+      checkedPaths,
+    };
+  }
+
+  return {
+    state: "configured",
+    source: resolved.source,
+    missing: null,
+    error: null,
+    checkedPaths,
+  };
+}
+
+export { getOllamaUsageConfigPath, getOllamaUsageLegacyPath };

--- a/src/lib/ollama-cloud.ts
+++ b/src/lib/ollama-cloud.ts
@@ -1,0 +1,185 @@
+/**
+ * Ollama Cloud settings page scraper.
+ *
+ * Fetches the Ollama Cloud settings page and parses the HTML for session
+ * and weekly usage percentages, plan tier, and reset times from the
+ * `data-usage-track` aria-labels, `usage-meter__fill` style attributes,
+ * and `.local-time` data-time attributes.
+ */
+
+import { fetchWithTimeout } from "./http.js";
+import { sanitizeDisplaySnippet, sanitizeSingleLineDisplayText } from "./display-sanitize.js";
+import type { OllamaCloudResult } from "./types.js";
+
+const SETTINGS_URL = "https://ollama.com/settings";
+const USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Gecko/20100101 Firefox/148.0";
+
+const SCRAPE_TIMEOUT_MS = 10_000;
+
+const USAGE_PERCENT_RE = /(\d+(?:\.\d+)?)%\s*used/;
+const WIDTH_PERCENT_RE = /(?:^|;)\s*width\s*:\s*([0-9.]+)%/;
+const DATA_USAGE_TRACK_RE = /data-usage-track[^>]*aria-label="([^"]*)"/gs;
+const LOCAL_TIME_RE = /class="[^"]*local-time[^"]*"[^>]*data-time="([^"]*)"/gs;
+const PLAN_TIER_RE = /class="[^"]*capitalize[^"]*"[^>]*>([^<]*)</;
+
+interface ScrapedUsage {
+  usagePercent: number;
+  resetTimeIso: string;
+}
+
+function extractUsagePercentFromTrack(trackHtml: string): number | null {
+  const ariaMatch = trackHtml.match(USAGE_PERCENT_RE);
+  if (ariaMatch) {
+    const pct = Number(ariaMatch[1]);
+    if (Number.isFinite(pct) && pct >= 0 && pct <= 100) {
+      return pct;
+    }
+  }
+
+  const styleMatch = trackHtml.match(/style="([^"]*)"/);
+  if (styleMatch) {
+    const widthMatch = styleMatch[1].match(WIDTH_PERCENT_RE);
+    if (widthMatch) {
+      const pct = Number(widthMatch[1]);
+      if (Number.isFinite(pct) && pct >= 0 && pct <= 100) {
+        return pct;
+      }
+    }
+  }
+
+  return null;
+}
+
+function extractResetTimes(html: string): string[] {
+  const times: string[] = [];
+  let match: RegExpExecArray | null;
+  const re = new RegExp(LOCAL_TIME_RE.source, LOCAL_TIME_RE.flags);
+  while ((match = re.exec(html)) !== null) {
+    times.push(match[1]);
+  }
+  return times;
+}
+
+function extractPlanTier(html: string): string | null {
+  const match = html.match(PLAN_TIER_RE);
+  return match ? match[1].trim() : null;
+}
+
+function sanitizeMessage(text: string, maxLength = 200): string {
+  const sanitized = sanitizeSingleLineDisplayText(text);
+  return (sanitized || "unknown").slice(0, maxLength);
+}
+
+const COOKIE_NAME_PREFIX = "__Secure-session=";
+
+function normalizeCookie(raw: string): string {
+  let value = raw.trim();
+  if (value.startsWith(COOKIE_NAME_PREFIX)) value = value.slice(COOKIE_NAME_PREFIX.length);
+  return value;
+}
+
+export async function queryOllamaCloudQuota(
+  cookie: string,
+  options: { requestTimeoutMs?: number } = {},
+): Promise<OllamaCloudResult> {
+  if (cookie.includes("\r") || cookie.includes("\n")) {
+    return {
+      success: false,
+      error: "Cookie contains invalid CRLF characters",
+    };
+  }
+
+  try {
+    const response = await fetchWithTimeout(
+      SETTINGS_URL,
+      {
+        method: "GET",
+        headers: {
+          "User-Agent": USER_AGENT,
+          Accept: "text/html",
+          Cookie: `${COOKIE_NAME_PREFIX}${normalizeCookie(cookie)}`,
+        },
+        redirect: "manual",
+      },
+      options.requestTimeoutMs ?? SCRAPE_TIMEOUT_MS,
+    );
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location") || "";
+      return {
+        success: false,
+        error: `Authentication error: redirected to ${sanitizeMessage(location, 80)} — cookie may be expired`,
+      };
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        success: false,
+        error: `Ollama Cloud settings error ${response.status}: ${sanitizeMessage(text)}`,
+      };
+    }
+
+    const html = await response.text();
+
+    const planTier = extractPlanTier(html);
+
+    const tracks: string[] = [];
+    let trackMatch: RegExpExecArray | null;
+    const trackRe = new RegExp(DATA_USAGE_TRACK_RE.source, DATA_USAGE_TRACK_RE.flags);
+    while ((trackMatch = trackRe.exec(html)) !== null) {
+      tracks.push(trackMatch[0]);
+    }
+
+    if (tracks.length < 2) {
+      return {
+        success: false,
+        error: `Could not parse usage tracks from Ollama Cloud settings page (found ${tracks.length}, need at least 2)`,
+      };
+    }
+
+    const sessionPercent = extractUsagePercentFromTrack(tracks[0]);
+    const weeklyPercent = extractUsagePercentFromTrack(tracks[1]);
+
+    if (sessionPercent === null && weeklyPercent === null) {
+      return {
+        success: false,
+        error: "Could not extract any usage percentages from Ollama Cloud settings page",
+      };
+    }
+
+    const resetTimes = extractResetTimes(html);
+    const sessionResetsAt = resetTimes[0] || undefined;
+    const weeklyResetsAt = resetTimes[1] || undefined;
+
+    return {
+      success: true,
+      ...(sessionPercent !== null
+        ? {
+            session: {
+              usagePercent: sessionPercent,
+              percentRemaining: 100 - sessionPercent,
+              resetTimeIso: sessionResetsAt,
+            },
+          }
+        : {}),
+      ...(weeklyPercent !== null
+        ? {
+            weekly: {
+              usagePercent: weeklyPercent,
+              percentRemaining: 100 - weeklyPercent,
+              resetTimeIso: weeklyResetsAt,
+            },
+          }
+        : {}),
+      ...(planTier ? { planTier } : {}),
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: sanitizeMessage(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+export { extractUsagePercentFromTrack as _extractUsagePercentFromTrack, extractResetTimes as _extractResetTimes, extractPlanTier as _extractPlanTier };

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -286,7 +286,7 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
   {
     id: "ollama-cloud",
     autoSetup: "manual_env_config",
-    authentication: "external_api_key",
+    authentication: "state_only",
     quota: "remote_api",
     notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
   },

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -17,7 +17,8 @@ export type CanonicalQuotaProviderId =
   | "minimax-china-coding-plan"
   | "kimi-for-coding"
   | "deepseek"
-  | "opencode-go";
+  | "opencode-go"
+  | "ollama-cloud";
 
 export type QuotaProviderAutoSetup = "yes" | "usually" | "manual_env_config" | "needs_quick_setup";
 
@@ -72,6 +73,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   "kimi-code": "Kimi Code",
   deepseek: "DeepSeek",
   "opencode-go": "OpenCode Go",
+  "ollama-cloud": "Ollama Cloud",
 };
 
 export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
@@ -135,6 +137,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
   deepseek: ["deepseek"],
   "opencode-go": ["opencode-go"],
+  "ollama-cloud": ["ollama-cloud"],
 };
 
 const LIVE_LOCAL_USAGE_PROVIDER_ID_SET = new Set<string>([
@@ -279,6 +282,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     quota: "remote_api",
     quickSetupAnchor: "opencode-go-quick-setup",
     notes: "Scrapes the OpenCode Go dashboard; requires workspaceId and authCookie",
+  },
+  {
+    id: "ollama-cloud",
+    autoSetup: "manual_env_config",
+    authentication: "external_api_key",
+    quota: "remote_api",
+    notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
   },
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -650,6 +650,30 @@ export type SyntheticResult =
   | QuotaError
   | null;
 
+/** Single usage window from Ollama Cloud settings page */
+export interface OllamaCloudWindow {
+  /** Usage percentage [0..100] */
+  usagePercent: number;
+  /** Remaining percentage [0..100] */
+  percentRemaining: number;
+  /** ISO reset timestamp */
+  resetTimeIso?: string;
+}
+
+/** Result from scraping Ollama Cloud settings page */
+export type OllamaCloudResult =
+  | {
+      success: true;
+      /** Session usage window, when present */
+      session?: OllamaCloudWindow;
+      /** Weekly usage window, when present */
+      weekly?: OllamaCloudWindow;
+      /** Plan tier (e.g. "free", "pro") */
+      planTier?: string;
+    }
+  | QuotaError
+  | null;
+
 /** Single usage window from OpenCode Go dashboard */
 export interface OpenCodeGoWindow {
   /** Usage percentage [0..100] */

--- a/src/providers/ollama-cloud.ts
+++ b/src/providers/ollama-cloud.ts
@@ -1,0 +1,119 @@
+/**
+ * Ollama Cloud provider wrapper.
+ *
+ * Scrapes the Ollama Cloud settings page and reports session and weekly
+ * usage as percentage-based quota entries.
+ */
+
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import type { OllamaCloudResult } from "../lib/types.js";
+import {
+  DEFAULT_OLLAMA_CLOUD_CONFIG_CACHE_MAX_AGE_MS,
+  resolveOllamaCloudConfigCached,
+} from "../lib/ollama-cloud-config.js";
+import { queryOllamaCloudQuota } from "../lib/ollama-cloud.js";
+import { normalizeQuotaProviderId } from "../lib/provider-metadata.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+const OLLAMA_CLOUD_PROVIDER_LABEL = "Ollama Cloud";
+
+function buildOllamaCloudEntries(
+  result: Extract<OllamaCloudResult, { success: true }>,
+): QuotaToastEntry[] {
+  const entries: QuotaToastEntry[] = [];
+
+  if (result.session) {
+    entries.push({
+      name: `${OLLAMA_CLOUD_PROVIDER_LABEL} Session`,
+      group: OLLAMA_CLOUD_PROVIDER_LABEL,
+      label: "Session:",
+      percentRemaining: result.session.percentRemaining,
+      resetTimeIso: result.session.resetTimeIso,
+    });
+  }
+
+  if (result.weekly) {
+    entries.push({
+      name: `${OLLAMA_CLOUD_PROVIDER_LABEL} Weekly`,
+      group: OLLAMA_CLOUD_PROVIDER_LABEL,
+      label: "Weekly:",
+      percentRemaining: result.weekly.percentRemaining,
+      resetTimeIso: result.weekly.resetTimeIso,
+    });
+  }
+
+  return entries;
+}
+
+export const ollamaCloudProvider: QuotaProvider = {
+  id: "ollama-cloud",
+
+  async isAvailable(_ctx: QuotaProviderContext): Promise<boolean> {
+    const config = await resolveOllamaCloudConfigCached({
+      maxAgeMs: DEFAULT_OLLAMA_CLOUD_CONFIG_CACHE_MAX_AGE_MS,
+    });
+    return config.state === "configured";
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    const [provider] = model.toLowerCase().split("/", 2);
+    return normalizeQuotaProviderId(provider) === "ollama-cloud";
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const config = await resolveOllamaCloudConfigCached({
+      maxAgeMs: DEFAULT_OLLAMA_CLOUD_CONFIG_CACHE_MAX_AGE_MS,
+    });
+
+    if (config.state === "none") {
+      return notAttemptedResult();
+    }
+
+    if (config.state === "incomplete") {
+      return attemptedErrorResult(
+        OLLAMA_CLOUD_PROVIDER_LABEL,
+        `Missing ${config.missing} (source: ${config.source})`,
+      );
+    }
+
+    if (config.state === "invalid") {
+      return attemptedErrorResult(
+        OLLAMA_CLOUD_PROVIDER_LABEL,
+        `Invalid config (${config.source}): ${config.error}`,
+      );
+    }
+
+    const result = await queryOllamaCloudQuota(config.config.cookie, {
+      requestTimeoutMs: ctx.config?.requestTimeoutMsConfigured
+        ? ctx.config.requestTimeoutMs
+        : undefined,
+    });
+
+    if (!result) {
+      return attemptedErrorResult(
+        OLLAMA_CLOUD_PROVIDER_LABEL,
+        "No response from Ollama Cloud settings page",
+      );
+    }
+
+    if (!result.success) {
+      return attemptedErrorResult(OLLAMA_CLOUD_PROVIDER_LABEL, result.error);
+    }
+
+    const entries = buildOllamaCloudEntries(result);
+
+    if (entries.length === 0) {
+      return attemptedErrorResult(
+        OLLAMA_CLOUD_PROVIDER_LABEL,
+        "No usage data found on Ollama Cloud settings page",
+      );
+    }
+
+    return attemptedResult(entries);
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,6 +26,7 @@ import {
 import { opencodeGoProvider } from "./opencode-go.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
+import { ollamaCloudProvider } from "./ollama-cloud.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
@@ -49,5 +50,6 @@ export function getProviders(): QuotaProvider[] {
     kimiCodeProvider,
     deepseekProvider,
     opencodeGoProvider,
+    ollamaCloudProvider,
   ];
 }

--- a/tests/lib.ollama-cloud-config.test.ts
+++ b/tests/lib.ollama-cloud-config.test.ts
@@ -1,0 +1,183 @@
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimePathMocks = vi.hoisted(() => ({
+  getOpencodeRuntimeDirCandidates: vi.fn(),
+}));
+
+const osMocks = vi.hoisted(() => ({
+  homedir: vi.fn(() => process.env.HOME || ""),
+}));
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: runtimePathMocks.getOpencodeRuntimeDirCandidates,
+}));
+
+vi.mock("os", async () => {
+  const actual = await vi.importActual<typeof import("os")>("os");
+  return {
+    ...actual,
+    homedir: osMocks.homedir,
+  };
+});
+
+const tempRoots: string[] = [];
+const originalEnv = process.env;
+
+async function createConfigRoot(): Promise<{
+  root: string;
+  opencodeConfigDir: string;
+  xdgConfigDir: string;
+  jsonPath: string;
+  yamlPath: string;
+  legacyYamlPath: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "ollama-cloud-config-"));
+  tempRoots.push(root);
+
+  const opencodeConfigDir = join(root, "opencode-config");
+  const xdgConfigDir = join(root, "xdg-config");
+  const jsonPath = join(opencodeConfigDir, "opencode-quota", "ollama-cloud.json");
+  const yamlPath = join(xdgConfigDir, "ollama-usage", "config.yaml");
+  const legacyYamlPath = join(root, ".ollama-usage", "config.yaml");
+
+  await mkdir(join(opencodeConfigDir, "opencode-quota"), { recursive: true });
+  await mkdir(join(xdgConfigDir, "ollama-usage"), { recursive: true });
+  await mkdir(join(root, ".ollama-usage"), { recursive: true });
+
+  return { root, opencodeConfigDir, xdgConfigDir, jsonPath, yamlPath, legacyYamlPath };
+}
+
+async function importConfigModule() {
+  return import("../src/lib/ollama-cloud-config.js");
+}
+
+describe("ollama-cloud config resolution", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    osMocks.homedir.mockReturnValue(originalEnv.HOME || "");
+    delete process.env.OLLAMA_USAGE_COOKIE;
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    for (const root of tempRoots.splice(0, tempRoots.length)) {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves the cookie from OLLAMA_USAGE_COOKIE first", async () => {
+    process.env.OLLAMA_USAGE_COOKIE = "  env-cookie  ";
+
+    const { resolveOllamaCloudConfigFromEnv, resolveOllamaCloudConfig } = await importConfigModule();
+
+    expect(resolveOllamaCloudConfigFromEnv()).toEqual({
+      state: "configured",
+      config: { cookie: "env-cookie" },
+      source: "env",
+    });
+    await expect(resolveOllamaCloudConfig()).resolves.toEqual({
+      state: "configured",
+      config: { cookie: "env-cookie" },
+      source: "env",
+    });
+  });
+
+  it("resolves the cookie from the OpenCode quota JSON config before ollama-usage YAML", async () => {
+    const { opencodeConfigDir, xdgConfigDir, jsonPath, yamlPath } = await createConfigRoot();
+    process.env.XDG_CONFIG_HOME = xdgConfigDir;
+    runtimePathMocks.getOpencodeRuntimeDirCandidates.mockReturnValue({
+      configDirs: [opencodeConfigDir],
+    });
+
+    await writeFile(jsonPath, JSON.stringify({ cookie: "json-cookie" }));
+    await writeFile(yamlPath, 'cookie: "yaml-cookie"\n');
+
+    const { resolveOllamaCloudConfig } = await importConfigModule();
+
+    await expect(resolveOllamaCloudConfig()).resolves.toEqual({
+      state: "configured",
+      config: { cookie: "json-cookie" },
+      source: jsonPath,
+    });
+  });
+
+  it("resolves the cookie from ollama-usage YAML when JSON config is absent", async () => {
+    const { root, opencodeConfigDir, xdgConfigDir, legacyYamlPath } = await createConfigRoot();
+    process.env.HOME = root;
+    osMocks.homedir.mockReturnValue(root);
+    process.env.XDG_CONFIG_HOME = xdgConfigDir;
+    runtimePathMocks.getOpencodeRuntimeDirCandidates.mockReturnValue({
+      configDirs: [opencodeConfigDir],
+    });
+
+    await writeFile(legacyYamlPath, "cookie: __Secure-session=yaml-cookie\n");
+
+    const { resolveOllamaCloudConfig } = await importConfigModule();
+
+    await expect(resolveOllamaCloudConfig()).resolves.toEqual({
+      state: "configured",
+      config: { cookie: "__Secure-session=yaml-cookie" },
+      source: legacyYamlPath,
+    });
+  });
+
+  it("reports incomplete config diagnostics when a present config lacks cookie", async () => {
+    const { root, opencodeConfigDir, xdgConfigDir, jsonPath, legacyYamlPath } = await createConfigRoot();
+    process.env.HOME = root;
+    osMocks.homedir.mockReturnValue(root);
+    process.env.XDG_CONFIG_HOME = xdgConfigDir;
+    runtimePathMocks.getOpencodeRuntimeDirCandidates.mockReturnValue({
+      configDirs: [opencodeConfigDir],
+    });
+
+    await writeFile(jsonPath, JSON.stringify({ cookie: "   " }));
+
+    const { getOllamaCloudConfigDiagnostics, resolveOllamaCloudConfig } = await importConfigModule();
+
+    await expect(resolveOllamaCloudConfig()).resolves.toEqual({
+      state: "incomplete",
+      source: jsonPath,
+      missing: "cookie",
+    });
+    const diagnostics = await getOllamaCloudConfigDiagnostics();
+    expect(diagnostics).toMatchObject({
+      state: "incomplete",
+      source: jsonPath,
+      missing: "cookie",
+      error: null,
+    });
+    expect(diagnostics.checkedPaths).toEqual(expect.arrayContaining([jsonPath, legacyYamlPath]));
+  });
+
+  it("reports invalid config diagnostics and does not fall through", async () => {
+    const { opencodeConfigDir, xdgConfigDir, jsonPath, yamlPath } = await createConfigRoot();
+    process.env.XDG_CONFIG_HOME = xdgConfigDir;
+    runtimePathMocks.getOpencodeRuntimeDirCandidates.mockReturnValue({
+      configDirs: [opencodeConfigDir],
+    });
+
+    await writeFile(jsonPath, "[]");
+    await writeFile(yamlPath, "cookie: yaml-cookie\n");
+
+    const { getOllamaCloudConfigDiagnostics, resolveOllamaCloudConfig } = await importConfigModule();
+
+    await expect(resolveOllamaCloudConfig()).resolves.toEqual({
+      state: "invalid",
+      source: jsonPath,
+      error: "Config file must contain a JSON object",
+    });
+    await expect(getOllamaCloudConfigDiagnostics()).resolves.toMatchObject({
+      state: "invalid",
+      source: jsonPath,
+      missing: null,
+      error: "Config file must contain a JSON object",
+    });
+  });
+});
+

--- a/tests/lib.ollama-cloud.test.ts
+++ b/tests/lib.ollama-cloud.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithTimeout: vi.fn(),
+}));
+
+vi.mock("../src/lib/http.js", () => ({
+  fetchWithTimeout: mocks.fetchWithTimeout,
+}));
+
+import {
+  _extractPlanTier,
+  _extractResetTimes,
+  _extractUsagePercentFromTrack,
+  queryOllamaCloudQuota,
+} from "../src/lib/ollama-cloud.js";
+
+function mockResponse(params: {
+  ok: boolean;
+  status: number;
+  text?: string;
+  headers?: Record<string, string>;
+}) {
+  mocks.fetchWithTimeout.mockResolvedValueOnce({
+    ok: params.ok,
+    status: params.status,
+    headers: {
+      get: (name: string) => params.headers?.[name.toLowerCase()] ?? null,
+    },
+    text: async () => params.text ?? "",
+  });
+}
+
+function buildSettingsHtml(): string {
+  return `
+    <html>
+      <body>
+        <span class="capitalize">pro</span>
+        <div data-usage-track aria-label="25% used"></div>
+        <span class="local-time" data-time="2026-06-14T10:00:00.000Z"></span>
+        <div data-usage-track aria-label="40.5% used"></div>
+        <span class="local-time" data-time="2026-06-21T10:00:00.000Z"></span>
+      </body>
+    </html>
+  `;
+}
+
+describe("queryOllamaCloudQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("normalizes a bare cookie value before sending the settings request", async () => {
+    mockResponse({ ok: true, status: 200, text: buildSettingsHtml() });
+
+    await queryOllamaCloudQuota("raw-cookie");
+
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledWith(
+      "https://ollama.com/settings",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: "__Secure-session=raw-cookie",
+        }),
+        redirect: "manual",
+      }),
+      10_000,
+    );
+  });
+
+  it("does not duplicate the __Secure-session cookie prefix", async () => {
+    mockResponse({ ok: true, status: 200, text: buildSettingsHtml() });
+
+    await queryOllamaCloudQuota("__Secure-session=prefixed-cookie", { requestTimeoutMs: 1234 });
+
+    expect(mocks.fetchWithTimeout).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Cookie: "__Secure-session=prefixed-cookie",
+        }),
+      }),
+      1234,
+    );
+  });
+
+  it("rejects CRLF in cookie values before making a request", async () => {
+    const out = await queryOllamaCloudQuota("bad\r\nCookie: injected");
+
+    expect(out).toEqual({
+      success: false,
+      error: "Cookie contains invalid CRLF characters",
+    });
+    expect(mocks.fetchWithTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns session and weekly usage from a successful settings page scrape", async () => {
+    mockResponse({ ok: true, status: 200, text: buildSettingsHtml() });
+
+    const out = await queryOllamaCloudQuota("cookie");
+
+    expect(out).toEqual({
+      success: true,
+      session: {
+        usagePercent: 25,
+        percentRemaining: 75,
+        resetTimeIso: "2026-06-14T10:00:00.000Z",
+      },
+      weekly: {
+        usagePercent: 40.5,
+        percentRemaining: 59.5,
+        resetTimeIso: "2026-06-21T10:00:00.000Z",
+      },
+      planTier: "pro",
+    });
+  });
+
+  it("reports redirects as expired or invalid cookie authentication errors", async () => {
+    mockResponse({
+      ok: false,
+      status: 302,
+      headers: { location: "https://ollama.com/signin?next=/settings" },
+    });
+
+    const out = await queryOllamaCloudQuota("cookie");
+
+    expect(out && !out.success ? out.error : "").toBe(
+      "Authentication error: redirected to https://ollama.com/signin?next=/settings — cookie may be expired",
+    );
+  });
+
+  it("reports unauthorized settings responses without leaking the cookie", async () => {
+    mockResponse({ ok: false, status: 401, text: "Unauthorized\nPlease sign in" });
+
+    const out = await queryOllamaCloudQuota("secret-cookie");
+
+    expect(out && !out.success ? out.error : "").toBe(
+      "Ollama Cloud settings error 401: Unauthorized Please sign in",
+    );
+    expect(out && !out.success ? out.error : "").not.toContain("secret-cookie");
+  });
+
+  it("returns a clear parse error for non-matching settings HTML", async () => {
+    mockResponse({ ok: true, status: 200, text: "<html><body>No usage data here</body></html>" });
+
+    const out = await queryOllamaCloudQuota("cookie");
+
+    expect(out && !out.success ? out.error : "").toBe(
+      "Could not parse usage tracks from Ollama Cloud settings page (found 0, need at least 2)",
+    );
+  });
+
+  it("returns a clear parse error when usage tracks do not contain percentages", async () => {
+    mockResponse({
+      ok: true,
+      status: 200,
+      text: '<div data-usage-track aria-label="session"></div><div data-usage-track aria-label="weekly"></div>',
+    });
+
+    const out = await queryOllamaCloudQuota("cookie");
+
+    expect(out && !out.success ? out.error : "").toBe(
+      "Could not extract any usage percentages from Ollama Cloud settings page",
+    );
+  });
+});
+
+describe("ollama-cloud HTML parsing helpers", () => {
+  it("extracts usage percentages from aria labels and width styles", () => {
+    expect(_extractUsagePercentFromTrack('data-usage-track aria-label="12.5% used"')).toBe(12.5);
+    expect(
+      _extractUsagePercentFromTrack('data-usage-track style="width: 33%" aria-label="usage"'),
+    ).toBe(33);
+  });
+
+  it("extracts reset times and plan tier", () => {
+    const html = '<span class="local-time" data-time="2026-06-14T10:00:00Z"></span><span class="capitalize">free</span>';
+
+    expect(_extractResetTimes(html)).toEqual(["2026-06-14T10:00:00Z"]);
+    expect(_extractPlanTier(html)).toBe("free");
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -152,7 +152,7 @@ describe("provider-metadata", () => {
       {
         id: "ollama-cloud",
         autoSetup: "manual_env_config",
-        authentication: "external_api_key",
+        authentication: "state_only",
         quota: "remote_api",
         notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
       },

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -149,6 +149,13 @@ describe("provider-metadata", () => {
         quickSetupAnchor: "opencode-go-quick-setup",
         notes: "Scrapes the OpenCode Go dashboard; requires workspaceId and authCookie",
       },
+      {
+        id: "ollama-cloud",
+        autoSetup: "manual_env_config",
+        authentication: "external_api_key",
+        quota: "remote_api",
+        notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
+      },
     ]);
   });
 

--- a/tests/providers.ollama-cloud.test.ts
+++ b/tests/providers.ollama-cloud.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+
+const mocks = vi.hoisted(() => ({
+  queryOllamaCloudQuota: vi.fn(),
+  resolveOllamaCloudConfigCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/ollama-cloud-config.js", () => ({
+  resolveOllamaCloudConfigCached: mocks.resolveOllamaCloudConfigCached,
+  DEFAULT_OLLAMA_CLOUD_CONFIG_CACHE_MAX_AGE_MS: 30_000,
+}));
+
+vi.mock("../src/lib/ollama-cloud.js", () => ({
+  queryOllamaCloudQuota: mocks.queryOllamaCloudQuota,
+}));
+
+import { ollamaCloudProvider } from "../src/providers/ollama-cloud.js";
+
+function mockConfigNone() {
+  mocks.resolveOllamaCloudConfigCached.mockResolvedValueOnce({ state: "none" });
+}
+
+function mockConfigIncomplete(source = "/tmp/ollama-cloud.json", missing = "cookie") {
+  mocks.resolveOllamaCloudConfigCached.mockResolvedValueOnce({
+    state: "incomplete",
+    source,
+    missing,
+  });
+}
+
+function mockConfigInvalid(source = "/tmp/ollama-cloud.json", error = "broken config") {
+  mocks.resolveOllamaCloudConfigCached.mockResolvedValueOnce({
+    state: "invalid",
+    source,
+    error,
+  });
+}
+
+function mockConfigConfigured(cookie = "session-cookie") {
+  mocks.resolveOllamaCloudConfigCached.mockResolvedValueOnce({
+    state: "configured",
+    config: { cookie },
+    source: "env",
+  });
+}
+
+async function runProviderFetch(config: Record<string, unknown> = {}) {
+  return ollamaCloudProvider.fetch({ config } as any);
+}
+
+describe("ollama-cloud provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns attempted:false when config is absent", async () => {
+    mockConfigNone();
+
+    const out = await runProviderFetch();
+
+    expectNotAttempted(out);
+    expect(mocks.queryOllamaCloudQuota).not.toHaveBeenCalled();
+  });
+
+  it("returns a config error when config is incomplete", async () => {
+    mockConfigIncomplete();
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithErrorLabel(out, "Ollama Cloud");
+    expect(out.errors[0]?.message).toContain("Missing cookie");
+    expect(mocks.queryOllamaCloudQuota).not.toHaveBeenCalled();
+  });
+
+  it("returns a config error when config is invalid", async () => {
+    mockConfigInvalid();
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithErrorLabel(out, "Ollama Cloud");
+    expect(out.errors[0]?.message).toContain("Invalid config");
+    expect(out.errors[0]?.message).toContain("/tmp/ollama-cloud.json");
+    expect(mocks.queryOllamaCloudQuota).not.toHaveBeenCalled();
+  });
+
+  it("returns session and weekly entries on successful settings scrape", async () => {
+    mockConfigConfigured();
+    mocks.queryOllamaCloudQuota.mockResolvedValueOnce({
+      success: true,
+      session: {
+        usagePercent: 25,
+        percentRemaining: 75,
+        resetTimeIso: "2026-06-14T10:00:00.000Z",
+      },
+      weekly: {
+        usagePercent: 40,
+        percentRemaining: 60,
+        resetTimeIso: "2026-06-21T10:00:00.000Z",
+      },
+    });
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "Ollama Cloud Session",
+        group: "Ollama Cloud",
+        label: "Session:",
+        percentRemaining: 75,
+        resetTimeIso: "2026-06-14T10:00:00.000Z",
+      },
+      {
+        name: "Ollama Cloud Weekly",
+        group: "Ollama Cloud",
+        label: "Weekly:",
+        percentRemaining: 60,
+        resetTimeIso: "2026-06-21T10:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("passes user-configured requestTimeoutMs to the scraper", async () => {
+    mockConfigConfigured("cookie");
+    mocks.queryOllamaCloudQuota.mockResolvedValueOnce({
+      success: true,
+      weekly: { usagePercent: 10, percentRemaining: 90 },
+    });
+
+    await runProviderFetch({ requestTimeoutMs: 1234, requestTimeoutMsConfigured: true });
+
+    expect(mocks.queryOllamaCloudQuota).toHaveBeenCalledWith("cookie", {
+      requestTimeoutMs: 1234,
+    });
+  });
+
+  it("returns scraper errors with the provider label", async () => {
+    mockConfigConfigured();
+    mocks.queryOllamaCloudQuota.mockResolvedValueOnce({
+      success: false,
+      error: "Authentication error: redirected to /signin — cookie may be expired",
+    });
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithErrorLabel(out, "Ollama Cloud");
+    expect(out.errors[0]?.message).toContain("cookie may be expired");
+  });
+
+  it("returns an error when the scraper succeeds without usage entries", async () => {
+    mockConfigConfigured();
+    mocks.queryOllamaCloudQuota.mockResolvedValueOnce({ success: true });
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithErrorLabel(out, "Ollama Cloud");
+    expect(out.errors[0]?.message).toBe("No usage data found on Ollama Cloud settings page");
+  });
+});
+
+describe("ollama-cloud matchesCurrentModel", () => {
+  it.each([
+    ["ollama-cloud/gpt-oss:20b-cloud", true],
+    ["OLLAMA-CLOUD/gpt-oss:120b-cloud", true],
+    ["ollama/gpt-oss", false],
+    ["openai/gpt-4", false],
+  ])("matchesCurrentModel(%s) -> %s", (model, expected) => {
+    expect(ollamaCloudProvider.matchesCurrentModel?.(model)).toBe(expected);
+  });
+});
+
+describe("ollama-cloud isAvailable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [{ state: "configured", config: { cookie: "ck" }, source: "env" }, true],
+    [{ state: "incomplete", source: "/tmp/ollama-cloud.json", missing: "cookie" }, false],
+    [{ state: "invalid", source: "/tmp/ollama-cloud.json", error: "broken" }, false],
+    [{ state: "none" }, false],
+  ])("returns correct availability for config state %j", async (configState, expected) => {
+    mocks.resolveOllamaCloudConfigCached.mockResolvedValueOnce(configState);
+
+    const available = await ollamaCloudProvider.isAvailable({} as any);
+
+    expect(available).toBe(expected);
+  });
+});


### PR DESCRIPTION
Adds an Ollama Cloud provider that scrapes usage data from ollama.com/settings.

Closes #38

### What it does
- Scrapes session and weekly usage percentages, plan tier, and reset times from the Ollama Cloud settings page
- Supports cookie config via `OLLAMA_USAGE_COOKIE` env var, `~/.config/opencode/opencode-quota/ollama-cloud.json`, or `~/.config/ollama-usage/config.yaml`
- Normalizes `__Secure-session=` cookie prefix if the user includes it in their config

### Files changed
- `src/lib/ollama-cloud.ts` — settings page scraper with HTML parsing
- `src/lib/ollama-cloud-config.ts` — cookie config resolution (env > JSON > YAML)
- `src/providers/ollama-cloud.ts` — QuotaProvider interface implementation
- `src/lib/provider-metadata.ts` — canonical ID, labels, shapes, runtime IDs
- `src/lib/types.ts` — OllamaCloudWindow and OllamaCloudResult types
- `src/providers/registry.ts` — registered in provider list
- `tests/lib.provider-metadata.test.ts` — updated expected shapes
- `README.md` — provider table entry and setup instructions