### PR TITLE
feat: generic OpenAI-compatible gateway quota provider (Refs #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | NanoGPT | Usually automatic | Remote API |
 | DeepSeek | Usually automatic | Remote API balance |
 | OpenCode Go | [Needs setup](#opencode-go) | Dashboard scraping |
+| OpenAI-Compatible Gateway | [Needs setup](#openai-compatible-gateway) | Remote API (configurable) |
 
 ## Common configuration
 
@@ -425,6 +426,7 @@ Existing `experimental.quotaToast` settings still work when no sidecar file exis
 | `cursorPlan` | `"none"` | Cursor included API budget preset: `none`, `pro`, `pro-plus`, `ultra`. |
 | `cursorIncludedApiUsd` | unset | Override Cursor monthly included API budget in USD. |
 | `cursorBillingCycleStartDay` | unset | Local billing-cycle anchor day `1..28`; when unset, Cursor usage resets on the local calendar month. |
+| `openaiCompatibleGateways` | `[]` | List of OpenAI-compatible gateways to poll for remaining quota. Each entry: `providerId` (required; the OpenCode provider id whose `options.baseURL`/`apiKey` are reused), `baseURL` (override), `quotaPath` (default `/quota`), `label`, `mapping` (`"neutral"` default, or `"openrouter"`). See [OpenAI-Compatible Gateway](#openai-compatible-gateway). |
 
 </details>
 
@@ -527,6 +529,35 @@ export OPENCODE_GO_AUTH_COOKIE="your-auth-cookie"
 ```
 
 Use `opencodeGoWindows` to choose **5h**, **Weekly**, and/or **Monthly** windows. Environment variables take precedence over the optional `opencode-go.json` file.
+
+</details>
+
+<a id="openai-compatible-gateway"></a>
+<details>
+<summary><strong>OpenAI-Compatible Gateway</strong></summary>
+
+Generic support for any self-hosted / OpenAI-compatible gateway (LiteLLM proxy, in-house or university gateway, OpenRouter-compatible endpoint, …) that exposes a remaining-quota endpoint. There is no standard quota endpoint, so this consumes a small documented JSON shape and is bound to no product.
+
+List your gateways under `openaiCompatibleGateways`. Each entry names the OpenCode provider id the gateway is already configured as for chat — its `options.baseURL` and API key are reused, so there is no duplicate config:
+
+```jsonc
+{
+  "openaiCompatibleGateways": [
+    { "providerId": "my-gateway", "quotaPath": "/quota" }
+  ]
+}
+```
+
+Per-entry fields: `providerId` (required), `baseURL` (override; default `provider.<id>.options.baseURL`), `quotaPath` (default `/quota`), `label`, and `mapping`.
+
+The API key is resolved like other key-based providers: env `<PROVIDERID>_API_KEY` (e.g. `MY_GATEWAY_API_KEY`), trusted user/global `provider.<id>.options.apiKey`, or OpenCode auth.
+
+**Response shapes (`mapping`):**
+
+- `"neutral"` (default) — `{ key, tokens:{limit,used,remaining,resets_at}, cost:{currency,limit,used,remaining} }`. Token bucket renders as a percent bar with reset; cost renders as a `$used / $limit` value row.
+- `"openrouter"` — the OpenRouter key-info shape `{ data:{ label, usage, limit, limit_remaining } }` (dollars only).
+
+If you use manual provider selection, include `openai-compatible` in `enabledProviders`.
 
 </details>
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,7 @@
 
 import type {
   CursorQuotaPlan,
+  OpenAiCompatibleGateway,
   QuotaToastConfig,
   GoogleModelId,
   PercentDisplayMode,
@@ -61,6 +62,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "tuiCompactStatus.maxWidth",
   "maintainerAnnouncements.enabled",
   "maintainerAnnouncements.home",
+  "openaiCompatibleGateways",
   "layout.maxWidth",
   "layout.narrowAt",
   "layout.tinyAt",
@@ -151,6 +153,7 @@ type ValidatedQuotaToastPatch = {
   tuiSidebarPanel?: TuiSidebarPanelPatch;
   tuiCompactStatus?: TuiCompactStatusPatch;
   maintainerAnnouncements?: MaintainerAnnouncementsPatch;
+  openaiCompatibleGateways?: OpenAiCompatibleGateway[];
   layout?: LayoutPatch;
 };
 
@@ -271,6 +274,7 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
     googleModels: [...config.googleModels],
     opencodeGoWindows: [...config.opencodeGoWindows],
     pricingSnapshot: { ...config.pricingSnapshot },
+    openaiCompatibleGateways: config.openaiCompatibleGateways.map((gateway) => ({ ...gateway })),
     tuiSidebarPanel: { ...config.tuiSidebarPanel },
     tuiCompactStatus: { ...config.tuiCompactStatus },
     maintainerAnnouncements: { ...config.maintainerAnnouncements },
@@ -425,6 +429,39 @@ function extractMaintainerAnnouncementsPatch(value: unknown): MaintainerAnnounce
 
 
   return Object.keys(patch).length > 0 ? patch : undefined;
+}
+
+function extractOpenaiCompatibleGateways(value: unknown): OpenAiCompatibleGateway[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const gateways: OpenAiCompatibleGateway[] = [];
+  for (const entry of value) {
+    if (!isPlainObject(entry)) continue;
+
+    const providerId = normalizeOptionalString(entry.providerId);
+    if (!providerId) continue;
+
+    const gateway: OpenAiCompatibleGateway = { providerId };
+
+    const baseURL = normalizeOptionalString(entry.baseURL);
+    if (baseURL) gateway.baseURL = baseURL;
+
+    const quotaPath = normalizeOptionalString(entry.quotaPath);
+    if (quotaPath) gateway.quotaPath = quotaPath;
+
+    const label = normalizeOptionalString(entry.label);
+    if (label) gateway.label = label;
+
+    if (entry.mapping === "neutral" || entry.mapping === "openrouter") {
+      gateway.mapping = entry.mapping;
+    }
+
+    gateways.push(gateway);
+  }
+
+  return gateways;
 }
 
 function extractLayoutPatch(value: unknown): LayoutPatch | undefined {
@@ -628,6 +665,13 @@ function extractValidatedQuotaToastPatch(
     }
   }
 
+  if (hasOwnKey(quotaToastConfig, "openaiCompatibleGateways")) {
+    const gateways = extractOpenaiCompatibleGateways(quotaToastConfig.openaiCompatibleGateways);
+    if (gateways !== undefined) {
+      patch.openaiCompatibleGateways = gateways;
+    }
+  }
+
   if (hasOwnKey(quotaToastConfig, "layout")) {
     const layout = extractLayoutPatch(quotaToastConfig.layout);
     if (layout) {
@@ -827,6 +871,13 @@ function applyValidatedQuotaToastPatch(
       applySettingSource(settingSources, "maintainerAnnouncements.home", sourcePath);
     }
 
+  }
+
+  if (hasOwnKey(patch, "openaiCompatibleGateways")) {
+    config.openaiCompatibleGateways = patch.openaiCompatibleGateways!.map((gateway) => ({
+      ...gateway,
+    }));
+    applySettingSource(settingSources, "openaiCompatibleGateways", sourcePath);
   }
 
   if (patch.layout) {

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -1,4 +1,4 @@
-import type { CursorQuotaPlan, OpenCodeGoWindowKey } from "./types.js";
+import type { CursorQuotaPlan, OpenAiCompatibleGateway, OpenCodeGoWindowKey } from "./types.js";
 
 /**
  * Normalized quota output model.
@@ -122,6 +122,7 @@ export interface QuotaProviderContext {
     currentModel?: string;
     currentProviderID?: string;
     enabledProviders: string[] | "auto";
+    openaiCompatibleGateways?: OpenAiCompatibleGateway[];
   };
 }
 

--- a/src/lib/openai-compatible-config.ts
+++ b/src/lib/openai-compatible-config.ts
@@ -1,0 +1,92 @@
+/**
+ * Per-gateway auth + base-URL resolution for the generic OpenAI-compatible
+ * gateway provider.
+ *
+ * A gateway is identified by the OpenCode provider id it is registered as
+ * (e.g. "apigee"). The API key is resolved with the shared resolver from the
+ * same trusted sources every other provider uses — env, trusted user/global
+ * OpenCode config (provider.<id>.options.apiKey), and auth.json. The base URL
+ * is taken from an explicit override or read from the same provider's
+ * options.baseURL, so a gateway already configured for chat needs no extra
+ * setup.
+ */
+
+import { readAuthFile } from "./opencode-auth.js";
+import {
+  createProviderApiKeyResolver,
+  getGlobalOpencodeConfigCandidatePaths,
+} from "./api-key-resolver.js";
+import { getEffectiveConfigRoot } from "./config-file-utils.js";
+import { loadConfiguredOpenCodeConfig } from "./opencode-config-providers.js";
+
+export type GatewayKeySource = "env" | "opencode.json" | "opencode.jsonc" | "auth.json";
+
+export interface GatewayApiKeyResult {
+  key: string;
+  source: GatewayKeySource;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Conventional env var for a gateway id: "my-gateway" -> "MY_GATEWAY_API_KEY". */
+export function gatewayEnvVarName(providerId: string): string {
+  const slug = providerId
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return `${slug}_API_KEY`;
+}
+
+function createGatewayApiKeyResolver(providerId: string) {
+  const envName = gatewayEnvVarName(providerId);
+  return createProviderApiKeyResolver<GatewayKeySource>({
+    envVars: [{ name: envName, source: "env" }],
+    providerKeys: [providerId],
+    allowedEnvVars: [envName],
+    configJsonSource: "opencode.json",
+    configJsoncSource: "opencode.jsonc",
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+    auth: {
+      readAuth: readAuthFile,
+      authSource: "auth.json",
+    },
+  });
+}
+
+export async function resolveGatewayApiKey(providerId: string): Promise<GatewayApiKeyResult | null> {
+  if (!providerId.trim()) return null;
+  return createGatewayApiKeyResolver(providerId).resolve();
+}
+
+export async function hasGatewayApiKey(providerId: string): Promise<boolean> {
+  if (!providerId.trim()) return false;
+  return createGatewayApiKeyResolver(providerId).has();
+}
+
+/**
+ * Resolve a gateway's base URL: an explicit override wins, else read
+ * provider.<id>.options.baseURL from the merged OpenCode config (best-effort).
+ */
+export async function resolveGatewayBaseURL(
+  providerId: string,
+  override?: string,
+): Promise<string | null> {
+  if (typeof override === "string" && override.trim()) {
+    return override.trim();
+  }
+  try {
+    const config = await loadConfiguredOpenCodeConfig({
+      configRootDir: getEffectiveConfigRoot(process.cwd()),
+    });
+    const provider = isRecord(config) ? config.provider : undefined;
+    const entry = isRecord(provider) ? provider[providerId] : undefined;
+    const options = isRecord(entry) ? entry.options : undefined;
+    const baseURL = isRecord(options) ? options.baseURL : undefined;
+    return typeof baseURL === "string" && baseURL.trim() ? baseURL.trim() : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/openai-compatible-config.ts
+++ b/src/lib/openai-compatible-config.ts
@@ -66,6 +66,18 @@ export async function hasGatewayApiKey(providerId: string): Promise<boolean> {
   return createGatewayApiKeyResolver(providerId).has();
 }
 
+/** Key-resolution diagnostics for /quota_status (which sources were checked). */
+export async function getGatewayKeyDiagnostics(providerId: string): Promise<{
+  configured: boolean;
+  source: GatewayKeySource | null;
+  checkedPaths: string[];
+}> {
+  if (!providerId.trim()) {
+    return { configured: false, source: null, checkedPaths: [] };
+  }
+  return createGatewayApiKeyResolver(providerId).diagnostics();
+}
+
 /**
  * Resolve a gateway's base URL: an explicit override wins, else read
  * provider.<id>.options.baseURL from the merged OpenCode config (best-effort).

--- a/src/lib/openai-compatible.ts
+++ b/src/lib/openai-compatible.ts
@@ -1,0 +1,171 @@
+/**
+ * OpenAI-compatible gateway quota fetcher.
+ *
+ * Polls a self-hosted / OpenAI-compatible gateway's quota endpoint
+ * (GET <baseURL><quotaPath>, default `/quota`) with a Bearer key and maps the
+ * response into a normalized { tokens, cost } shape. There is no standard
+ * remaining-quota endpoint, so this consumes a small, documented vendor-neutral
+ * contract by default and is NOT bound to any product:
+ *
+ *   neutral: { key, tokens:{limit,used,remaining,resets_at},
+ *              cost:{currency,limit,used,remaining} }
+ *
+ * A built-in `openrouter` preset maps the OpenRouter key-info shape
+ * ({ data:{ label, usage, limit, limit_remaining } }, dollars only) so
+ * OpenRouter-style gateways work too.
+ */
+
+import type { QuotaError } from "./types.js";
+import { fetchWithTimeout } from "./http.js";
+
+export type GatewayMapping = "neutral" | "openrouter";
+
+export interface GatewayTokenWindow {
+  limit: number | null;
+  used: number | null;
+  remaining: number | null;
+  resetTimeIso?: string;
+}
+
+export interface GatewayCostWindow {
+  currency: string;
+  limit: number | null;
+  used: number | null;
+  remaining: number | null;
+}
+
+export type GatewayQuotaResult =
+  | {
+      success: true;
+      label: string;
+      tokens?: GatewayTokenWindow;
+      cost?: GatewayCostWindow;
+    }
+  | QuotaError
+  | null;
+
+export interface QueryGatewayQuotaParams {
+  baseURL: string;
+  apiKey: string;
+  /** Path appended to baseURL; defaults to "/quota". */
+  quotaPath?: string;
+  /** Response shape; defaults to "neutral". */
+  mapping?: GatewayMapping;
+  /** Display label used when the body carries none. */
+  fallbackLabel?: string;
+  requestTimeoutMs?: number;
+}
+
+const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function num(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+type ParsedQuota = { label?: string; tokens?: GatewayTokenWindow; cost?: GatewayCostWindow } | null;
+
+/** Vendor-neutral { key, tokens, cost } contract. */
+function parseNeutral(body: unknown): ParsedQuota {
+  if (!isRecord(body)) return null;
+
+  let tokens: GatewayTokenWindow | undefined;
+  if (isRecord(body.tokens)) {
+    const t = body.tokens;
+    tokens = {
+      limit: num(t.limit),
+      used: num(t.used),
+      remaining: num(t.remaining),
+      resetTimeIso: str(t.resets_at),
+    };
+  }
+
+  let cost: GatewayCostWindow | undefined;
+  if (isRecord(body.cost)) {
+    const c = body.cost;
+    cost = {
+      currency: str(c.currency) ?? "USD",
+      limit: num(c.limit),
+      used: num(c.used),
+      remaining: num(c.remaining),
+    };
+  }
+
+  if (!tokens && !cost) return null;
+  return { label: str(body.key), tokens, cost };
+}
+
+/** OpenRouter key-info preset: { data:{ label, usage, limit, limit_remaining } } (dollars). */
+function parseOpenRouter(body: unknown): ParsedQuota {
+  if (!isRecord(body) || !isRecord(body.data)) return null;
+  const d = body.data;
+  const used = num(d.usage);
+  const limit = num(d.limit);
+  const remaining = num(d.limit_remaining) ?? (limit !== null && used !== null ? limit - used : null);
+  return {
+    label: str(d.label) ?? str(d.name),
+    cost: { currency: "USD", limit, used, remaining },
+  };
+}
+
+export async function queryGatewayQuota(
+  params: QueryGatewayQuotaParams,
+): Promise<GatewayQuotaResult> {
+  if (!params.baseURL || !params.apiKey) return null;
+
+  const url = joinUrl(params.baseURL, params.quotaPath ?? "/quota");
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${params.apiKey}`,
+          "User-Agent": USER_AGENT,
+          Accept: "application/json",
+        },
+      },
+      params.requestTimeoutMs,
+    );
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (!response.ok) {
+    return { success: false, error: `gateway quota error ${response.status}` };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    return { success: false, error: "gateway quota returned non-JSON" };
+  }
+
+  const parsed = (params.mapping ?? "neutral") === "openrouter" ? parseOpenRouter(body) : parseNeutral(body);
+  if (!parsed) {
+    return { success: false, error: "gateway quota returned an unexpected shape" };
+  }
+
+  return {
+    success: true,
+    label: parsed.label ?? params.fallbackLabel ?? "Gateway",
+    tokens: parsed.tokens,
+    cost: parsed.cost,
+  };
+}

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -17,7 +17,8 @@ export type CanonicalQuotaProviderId =
   | "minimax-china-coding-plan"
   | "kimi-for-coding"
   | "deepseek"
-  | "opencode-go";
+  | "opencode-go"
+  | "openai-compatible";
 
 export type QuotaProviderAutoSetup = "yes" | "usually" | "manual_env_config" | "needs_quick_setup";
 
@@ -72,6 +73,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   "kimi-code": "Kimi Code",
   deepseek: "DeepSeek",
   "opencode-go": "OpenCode Go",
+  "openai-compatible": "OpenAI-Compatible Gateway",
 };
 
 export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
@@ -135,6 +137,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
   deepseek: ["deepseek"],
   "opencode-go": ["opencode-go"],
+  "openai-compatible": ["openai-compatible"],
 };
 
 const LIVE_LOCAL_USAGE_PROVIDER_ID_SET = new Set<string>([
@@ -279,6 +282,15 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     quota: "remote_api",
     quickSetupAnchor: "opencode-go-quick-setup",
     notes: "Scrapes the OpenCode Go dashboard; requires workspaceId and authCookie",
+  },
+  {
+    id: "openai-compatible",
+    autoSetup: "manual_env_config",
+    authentication: "opencode_auth_api_key",
+    authFallbacks: ["env_api_key", "global_opencode_config"],
+    quota: "remote_api",
+    notes:
+      "Generic: polls one or more configured OpenAI-compatible gateways' quota endpoints (experimental.quotaToast.openaiCompatibleGateways)",
   },
 ];
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -13,6 +13,8 @@ import { getCrofKeyDiagnostics } from "./crof.js";
 import { getNanoGptKeyDiagnostics, queryNanoGptQuota } from "./nanogpt.js";
 import { getDeepSeekKeyDiagnostics } from "./deepseek.js";
 import { getSyntheticKeyDiagnostics } from "./synthetic.js";
+import { getGatewayKeyDiagnostics } from "./openai-compatible-config.js";
+import type { OpenAiCompatibleGateway } from "./types.js";
 import { getCopilotQuotaAuthDiagnostics } from "./copilot.js";
 import {
   computeAlibabaCodingPlanQuota,
@@ -633,6 +635,7 @@ export async function buildQuotaStatusReport(params: {
   cursorIncludedApiUsd?: number;
   cursorBillingCycleStartDay?: number;
   opencodeGoWindows?: OpenCodeGoWindowKey[];
+  openaiCompatibleGateways?: OpenAiCompatibleGateway[];
   pricingSnapshotSource: PricingSnapshotSource;
   onlyCurrentModel: boolean;
   currentModel?: string;
@@ -1359,6 +1362,26 @@ export async function buildQuotaStatusReport(params: {
   ];
   appendProviderCompactLiveProbeRows(deepSeekRows, "deepseek", params.providerLiveProbes);
   sections.push(createKvSection("deepseek", "deepseek:", deepSeekRows));
+
+  // === openai-compatible gateways (config-driven; one section per gateway) ===
+  for (const gateway of params.openaiCompatibleGateways ?? []) {
+    const diag = await getGatewayKeyDiagnostics(gateway.providerId);
+    const rows: ReportKvRow[] = [
+      { key: "provider_id", value: gateway.providerId },
+      { key: "quota_path", value: gateway.quotaPath ?? "/quota" },
+      { key: "api_key_configured", value: diag.configured ? "true" : "false" },
+      { key: "api_key_source", value: diag.source ?? "(none)" },
+      { key: "api_key_checked_paths", value: joinOrNone(diag.checkedPaths) },
+    ];
+    appendProviderCompactLiveProbeRows(rows, "openai-compatible", params.providerLiveProbes);
+    sections.push(
+      createKvSection(
+        `openai-compatible:${gateway.providerId}`,
+        `openai-compatible (${gateway.label ?? gateway.providerId}):`,
+        rows,
+      ),
+    );
+  }
 
   // === nanogpt ===
   const nanoGptDiag = await readApiKeyDiagnosticsWithAuthPaths(getNanoGptKeyDiagnostics);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -132,6 +132,13 @@ export interface QuotaToastConfig {
   /** Bundled-only maintainer announcement surfaces. */
   maintainerAnnouncements: MaintainerAnnouncementsConfig;
 
+  /**
+   * Generic OpenAI-compatible gateways to poll for remaining quota/budget.
+   * Each entry names an OpenCode provider id (its baseURL + apiKey are reused)
+   * and the gateway's quota endpoint. Drives the `openai-compatible` provider.
+   */
+  openaiCompatibleGateways: OpenAiCompatibleGateway[];
+
   /** Responsive toast layout breakpoints (not used by the fixed-width TUI sidebar). */
   layout: {
     /** Default max width target for toast formatting */
@@ -191,12 +198,33 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
     enabled: true,
     home: true,
   },
+  openaiCompatibleGateways: [],
   layout: {
     maxWidth: 50,
     narrowAt: 42,
     tinyAt: 32,
   },
 };
+
+/**
+ * One OpenAI-compatible gateway that exposes a remaining-quota endpoint.
+ *
+ * `providerId` is the OpenCode provider id the gateway is registered as; its
+ * `options.baseURL`/`options.apiKey` are reused (no duplicate config). There is
+ * no standard quota endpoint, so `mapping` selects the response shape.
+ */
+export interface OpenAiCompatibleGateway {
+  /** OpenCode provider id (e.g. "apigee"); drives key/baseURL lookup + matching. */
+  providerId: string;
+  /** Override the base URL (default: provider.<id>.options.baseURL). */
+  baseURL?: string;
+  /** Quota endpoint path appended to the base URL (default "/quota"). */
+  quotaPath?: string;
+  /** Display label (default: the provider id). */
+  label?: string;
+  /** Response shape: "neutral" (default) or "openrouter". */
+  mapping?: "neutral" | "openrouter";
+}
 
 // =============================================================================
 // Auth Data Types (from ~/.local/share/opencode/auth.json)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1485,6 +1485,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       cursorIncludedApiUsd: runtimeConfig.cursorIncludedApiUsd,
       cursorBillingCycleStartDay: runtimeConfig.cursorBillingCycleStartDay,
       opencodeGoWindows: runtimeConfig.opencodeGoWindows,
+      openaiCompatibleGateways: runtimeConfig.openaiCompatibleGateways,
       pricingSnapshotSource: runtimeConfig.pricingSnapshot.source,
       onlyCurrentModel: runtimeConfig.onlyCurrentModel,
       currentModel,

--- a/src/providers/openai-compatible.ts
+++ b/src/providers/openai-compatible.ts
@@ -1,0 +1,156 @@
+/**
+ * Generic OpenAI-compatible gateway provider.
+ *
+ * Unlike the vendor providers, this one is config-driven: it reads
+ * `experimental.quotaToast.openaiCompatibleGateways` and polls each gateway's
+ * quota endpoint (see src/lib/openai-compatible.ts). One provider covers any
+ * number of self-hosted / OpenAI-compatible gateways. Bound to no product.
+ */
+
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+  QuotaToastError,
+} from "../lib/entries.js";
+import type { OpenAiCompatibleGateway } from "../lib/types.js";
+import {
+  hasGatewayApiKey,
+  resolveGatewayApiKey,
+  resolveGatewayBaseURL,
+} from "../lib/openai-compatible-config.js";
+import {
+  queryGatewayQuota,
+  type GatewayQuotaResult,
+} from "../lib/openai-compatible.js";
+import { clampPercent, fmtUsdAmount, formatTokenCount } from "../lib/format-utils.js";
+import { attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+// `matchesCurrentModel` can't see ctx.config, so cache the configured gateway
+// provider ids at availability/fetch time. onlyCurrentModel (default off) then
+// matches `<providerId>/...` models against them.
+let knownGatewayProviderIds: string[] = [];
+
+function rememberGateways(gateways: OpenAiCompatibleGateway[]): void {
+  knownGatewayProviderIds = gateways.map((gateway) => gateway.providerId);
+}
+
+function getGateways(ctx: QuotaProviderContext): OpenAiCompatibleGateway[] {
+  return ctx.config?.openaiCompatibleGateways ?? [];
+}
+
+function tokenCount(value: number | null): string {
+  return value === null ? "?" : formatTokenCount(value);
+}
+
+type GatewaySuccess = Extract<NonNullable<GatewayQuotaResult>, { success: true }>;
+
+function buildGatewayEntries(label: string, result: GatewaySuccess): QuotaToastEntry[] {
+  const entries: QuotaToastEntry[] = [];
+
+  const tokens = result.tokens;
+  if (tokens && tokens.limit !== null && tokens.limit > 0 && tokens.remaining !== null) {
+    entries.push({
+      name: `${label} tokens`,
+      group: label,
+      label: "Tokens:",
+      percentRemaining: clampPercent((tokens.remaining / tokens.limit) * 100),
+      right: `${tokenCount(tokens.used)}/${tokenCount(tokens.limit)}`,
+      resetTimeIso: tokens.resetTimeIso,
+    });
+  }
+
+  const cost = result.cost;
+  if (cost && (cost.limit !== null || cost.used !== null)) {
+    const used = cost.used ?? 0;
+    const value =
+      cost.limit !== null ? `${fmtUsdAmount(used)} / ${fmtUsdAmount(cost.limit)}` : fmtUsdAmount(used);
+    entries.push({
+      kind: "value",
+      name: `${label} cost`,
+      group: label,
+      label: "Budget:",
+      value,
+    });
+  }
+
+  if (entries.length === 0) {
+    entries.push({ kind: "value", name: label, group: label, label: "Status:", value: "no quota data" });
+  }
+
+  return entries;
+}
+
+export const openaiCompatibleProvider: QuotaProvider = {
+  id: "openai-compatible",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const gateways = getGateways(ctx);
+    rememberGateways(gateways);
+    for (const gateway of gateways) {
+      if (await hasGatewayApiKey(gateway.providerId)) return true;
+    }
+    return false;
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    const prefix = model.split("/")[0];
+    return prefix.length > 0 && knownGatewayProviderIds.includes(prefix);
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const gateways = getGateways(ctx);
+    rememberGateways(gateways);
+    if (gateways.length === 0) {
+      return notAttemptedResult();
+    }
+
+    const entries: QuotaToastEntry[] = [];
+    const errors: QuotaToastError[] = [];
+    let attempted = false;
+
+    for (const gateway of gateways) {
+      const apiKey = await resolveGatewayApiKey(gateway.providerId);
+      if (!apiKey) {
+        // Not configured for this gateway; skip without marking attempted.
+        continue;
+      }
+
+      const label = gateway.label ?? gateway.providerId;
+      const baseURL = await resolveGatewayBaseURL(gateway.providerId, gateway.baseURL);
+      attempted = true;
+
+      if (!baseURL) {
+        errors.push({
+          label,
+          message: `no base URL (set provider.${gateway.providerId}.options.baseURL or gateway.baseURL)`,
+        });
+        continue;
+      }
+
+      const result = await queryGatewayQuota({
+        baseURL,
+        apiKey: apiKey.key,
+        quotaPath: gateway.quotaPath,
+        mapping: gateway.mapping,
+        fallbackLabel: label,
+        requestTimeoutMs: ctx.config?.requestTimeoutMs,
+      });
+
+      if (!result) continue;
+      if (!result.success) {
+        errors.push({ label, message: result.error });
+        continue;
+      }
+
+      entries.push(...buildGatewayEntries(label, result));
+    }
+
+    if (!attempted) {
+      return notAttemptedResult();
+    }
+
+    return attemptedResult(entries, errors);
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,6 +26,7 @@ import {
 import { opencodeGoProvider } from "./opencode-go.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
+import { openaiCompatibleProvider } from "./openai-compatible.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
@@ -49,5 +50,6 @@ export function getProviders(): QuotaProvider[] {
     kimiCodeProvider,
     deepseekProvider,
     opencodeGoProvider,
+    openaiCompatibleProvider,
   ];
 }

--- a/tests/lib.openai-compatible-config.test.ts
+++ b/tests/lib.openai-compatible-config.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  gatewayEnvVarName,
+  hasGatewayApiKey,
+  resolveGatewayApiKey,
+  resolveGatewayBaseURL,
+} from "../src/lib/openai-compatible-config.js";
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFile: vi.fn(),
+  getAuthPaths: vi.fn(() => []),
+}));
+
+describe("openai-compatible gateway config", () => {
+  const originalEnv = process.env;
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "oq-gw-"));
+    process.env = { ...originalEnv, XDG_CONFIG_HOME: tempDir };
+    process.chdir(tempDir);
+    delete process.env.APIGEE_API_KEY;
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+    (readAuthFile as any).mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("derives a conventional env var name from the provider id", () => {
+    expect(gatewayEnvVarName("apigee")).toBe("APIGEE_API_KEY");
+    expect(gatewayEnvVarName("my-gateway")).toBe("MY_GATEWAY_API_KEY");
+    expect(gatewayEnvVarName("acme.llm")).toBe("ACME_LLM_API_KEY");
+  });
+
+  it("resolves the key from the gateway env var", async () => {
+    process.env.APIGEE_API_KEY = "env-key";
+    await expect(resolveGatewayApiKey("apigee")).resolves.toEqual({ key: "env-key", source: "env" });
+  });
+
+  it("resolves the key from trusted global OpenCode config", async () => {
+    mkdirSync(join(tempDir, "opencode"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "opencode", "opencode.json"),
+      JSON.stringify({ provider: { apigee: { options: { apiKey: "config-key" } } } }),
+    );
+    await expect(resolveGatewayApiKey("apigee")).resolves.toEqual({
+      key: "config-key",
+      source: "opencode.json",
+    });
+  });
+
+  it("returns no key when nothing is configured", async () => {
+    await expect(hasGatewayApiKey("apigee")).resolves.toBe(false);
+    await expect(resolveGatewayApiKey("apigee")).resolves.toBeNull();
+  });
+
+  it("baseURL: explicit override wins", async () => {
+    await expect(resolveGatewayBaseURL("apigee", "https://gw/llm/v1")).resolves.toBe(
+      "https://gw/llm/v1",
+    );
+  });
+
+  it("baseURL: falls back to provider.<id>.options.baseURL from global config", async () => {
+    mkdirSync(join(tempDir, "opencode"), { recursive: true });
+    writeFileSync(
+      join(tempDir, "opencode", "opencode.json"),
+      JSON.stringify({ provider: { apigee: { options: { baseURL: "https://gw/llm/v1" } } } }),
+    );
+    await expect(resolveGatewayBaseURL("apigee")).resolves.toBe("https://gw/llm/v1");
+  });
+
+  it("baseURL: null when neither override nor config is present", async () => {
+    await expect(resolveGatewayBaseURL("apigee")).resolves.toBeNull();
+  });
+});

--- a/tests/lib.openai-compatible-config.test.ts
+++ b/tests/lib.openai-compatible-config.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 
 import {
   gatewayEnvVarName,
+  getGatewayKeyDiagnostics,
   hasGatewayApiKey,
   resolveGatewayApiKey,
   resolveGatewayBaseURL,
@@ -80,5 +81,18 @@ describe("openai-compatible gateway config", () => {
 
   it("baseURL: null when neither override nor config is present", async () => {
     await expect(resolveGatewayBaseURL("apigee")).resolves.toBeNull();
+  });
+
+  it("diagnostics: reports configured + source when a key resolves", async () => {
+    process.env.APIGEE_API_KEY = "env-key";
+    const diag = await getGatewayKeyDiagnostics("apigee");
+    expect(diag.configured).toBe(true);
+    expect(diag.source).toBe("env");
+  });
+
+  it("diagnostics: reports not-configured when no key is present", async () => {
+    const diag = await getGatewayKeyDiagnostics("apigee");
+    expect(diag.configured).toBe(false);
+    expect(diag.source).toBeNull();
   });
 });

--- a/tests/lib.openai-compatible.test.ts
+++ b/tests/lib.openai-compatible.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { queryGatewayQuota } from "../src/lib/openai-compatible.js";
+
+function mockFetchOnce(body: unknown, status = 200): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(
+      async () =>
+        new Response(typeof body === "string" ? body : JSON.stringify(body), { status }),
+    ) as any,
+  );
+}
+
+describe("queryGatewayQuota", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when baseURL or apiKey is missing", async () => {
+    await expect(queryGatewayQuota({ baseURL: "", apiKey: "k" })).resolves.toBeNull();
+    await expect(queryGatewayQuota({ baseURL: "https://gw/llm/v1", apiKey: "" })).resolves.toBeNull();
+  });
+
+  it("parses the vendor-neutral shape (tokens + cost)", async () => {
+    mockFetchOnce({
+      key: "course-comp318-fall26",
+      tokens: { limit: 5000000, used: 250000, remaining: 4750000, resets_at: "2026-05-31T00:00:00Z" },
+      cost: { currency: "USD", limit: 5.0, used: 0.42, remaining: 4.58 },
+    });
+
+    const out = await queryGatewayQuota({ baseURL: "https://gw/llm/v1", apiKey: "k" });
+    expect(out && out.success).toBe(true);
+    if (out && out.success) {
+      expect(out.label).toBe("course-comp318-fall26");
+      expect(out.tokens).toEqual({
+        limit: 5000000,
+        used: 250000,
+        remaining: 4750000,
+        resetTimeIso: "2026-05-31T00:00:00Z",
+      });
+      expect(out.cost).toEqual({ currency: "USD", limit: 5.0, used: 0.42, remaining: 4.58 });
+    }
+  });
+
+  it("hits <baseURL><quotaPath> with a Bearer header", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ cost: { limit: 1, used: 0, remaining: 1 } }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock as any);
+
+    await queryGatewayQuota({ baseURL: "https://gw/llm/v1/", apiKey: "secret", quotaPath: "/quota" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://gw/llm/v1/quota");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer secret");
+  });
+
+  it("parses the openrouter preset (dollars; derives remaining)", async () => {
+    mockFetchOnce({ data: { label: "or-key", usage: 0.45, limit: 10.0 } });
+
+    const out = await queryGatewayQuota({
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: "k",
+      quotaPath: "/key",
+      mapping: "openrouter",
+    });
+    expect(out && out.success).toBe(true);
+    if (out && out.success) {
+      expect(out.label).toBe("or-key");
+      expect(out.tokens).toBeUndefined();
+      expect(out.cost).toEqual({ currency: "USD", limit: 10.0, used: 0.45, remaining: 9.55 });
+    }
+  });
+
+  it("reports a 5xx/4xx as an error", async () => {
+    mockFetchOnce("Unauthorized", 401);
+    const out = await queryGatewayQuota({ baseURL: "https://gw/llm/v1", apiKey: "k" });
+    expect(out && out.success).toBe(false);
+    if (out && !out.success) expect(out.error).toContain("401");
+  });
+
+  it("reports non-JSON as an error", async () => {
+    mockFetchOnce("<html>not json</html>", 200);
+    const out = await queryGatewayQuota({ baseURL: "https://gw/llm/v1", apiKey: "k" });
+    expect(out && out.success).toBe(false);
+    if (out && !out.success) expect(out.error).toContain("non-JSON");
+  });
+
+  it("reports an unrecognized shape as an error", async () => {
+    mockFetchOnce({ something: "else" });
+    const out = await queryGatewayQuota({ baseURL: "https://gw/llm/v1", apiKey: "k" });
+    expect(out && out.success).toBe(false);
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -149,6 +149,15 @@ describe("provider-metadata", () => {
         quickSetupAnchor: "opencode-go-quick-setup",
         notes: "Scrapes the OpenCode Go dashboard; requires workspaceId and authCookie",
       },
+      {
+        id: "openai-compatible",
+        autoSetup: "manual_env_config",
+        authentication: "opencode_auth_api_key",
+        authFallbacks: ["env_api_key", "global_opencode_config"],
+        quota: "remote_api",
+        notes:
+          "Generic: polls one or more configured OpenAI-compatible gateways' quota endpoints (experimental.quotaToast.openaiCompatibleGateways)",
+      },
     ]);
   });
 

--- a/tests/providers.openai-compatible.test.ts
+++ b/tests/providers.openai-compatible.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+import { openaiCompatibleProvider } from "../src/providers/openai-compatible.js";
+
+vi.mock("../src/lib/openai-compatible.js", () => ({
+  queryGatewayQuota: vi.fn(),
+}));
+
+vi.mock("../src/lib/openai-compatible-config.js", () => ({
+  resolveGatewayApiKey: vi.fn(),
+  hasGatewayApiKey: vi.fn(),
+  resolveGatewayBaseURL: vi.fn(),
+}));
+
+function ctxWith(gateways: unknown): any {
+  return { config: { openaiCompatibleGateways: gateways } };
+}
+
+describe("openai-compatible provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns attempted:false when no gateways are configured", async () => {
+    const out = await openaiCompatibleProvider.fetch(ctxWith([]));
+    expectNotAttempted(out);
+  });
+
+  it("returns attempted:false when configured gateways have no key", async () => {
+    const { resolveGatewayApiKey } = await import("../src/lib/openai-compatible-config.js");
+    (resolveGatewayApiKey as any).mockResolvedValue(null);
+
+    const out = await openaiCompatibleProvider.fetch(ctxWith([{ providerId: "apigee" }]));
+    expectNotAttempted(out);
+  });
+
+  it("maps a neutral gateway response into token + cost entries", async () => {
+    const { resolveGatewayApiKey, resolveGatewayBaseURL } = await import(
+      "../src/lib/openai-compatible-config.js"
+    );
+    const { queryGatewayQuota } = await import("../src/lib/openai-compatible.js");
+    (resolveGatewayApiKey as any).mockResolvedValue({ key: "k", source: "env" });
+    (resolveGatewayBaseURL as any).mockResolvedValue("https://gw/llm/v1");
+    (queryGatewayQuota as any).mockResolvedValue({
+      success: true,
+      label: "COMP 318",
+      tokens: { limit: 5000000, used: 250000, remaining: 4750000, resetTimeIso: "2026-05-31T00:00:00Z" },
+      cost: { currency: "USD", limit: 5, used: 0.42, remaining: 4.58 },
+    });
+
+    const out = await openaiCompatibleProvider.fetch(ctxWith([{ providerId: "apigee", label: "COMP 318" }]));
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(2);
+
+    const tokenEntry = out.entries[0] as any;
+    expect(tokenEntry.label).toBe("Tokens:");
+    expect(tokenEntry.percentRemaining).toBe(95);
+    expect(tokenEntry.resetTimeIso).toBe("2026-05-31T00:00:00Z");
+
+    const costEntry = out.entries[1] as any;
+    expect(costEntry.kind).toBe("value");
+    expect(costEntry.value).toContain("/");
+  });
+
+  it("maps a gateway error into a quota error", async () => {
+    const { resolveGatewayApiKey, resolveGatewayBaseURL } = await import(
+      "../src/lib/openai-compatible-config.js"
+    );
+    const { queryGatewayQuota } = await import("../src/lib/openai-compatible.js");
+    (resolveGatewayApiKey as any).mockResolvedValue({ key: "k", source: "env" });
+    (resolveGatewayBaseURL as any).mockResolvedValue("https://gw/llm/v1");
+    (queryGatewayQuota as any).mockResolvedValue({ success: false, error: "gateway quota error 401" });
+
+    const out = await openaiCompatibleProvider.fetch(ctxWith([{ providerId: "apigee", label: "COMP 318" }]));
+    expectAttemptedWithErrorLabel(out, "COMP 318");
+  });
+
+  it("flags a missing base URL", async () => {
+    const { resolveGatewayApiKey, resolveGatewayBaseURL } = await import(
+      "../src/lib/openai-compatible-config.js"
+    );
+    (resolveGatewayApiKey as any).mockResolvedValue({ key: "k", source: "env" });
+    (resolveGatewayBaseURL as any).mockResolvedValue(null);
+
+    const out = await openaiCompatibleProvider.fetch(ctxWith([{ providerId: "apigee" }]));
+    expectAttemptedWithErrorLabel(out, "apigee");
+  });
+
+  it("is available when a configured gateway has a key", async () => {
+    const { hasGatewayApiKey } = await import("../src/lib/openai-compatible-config.js");
+    (hasGatewayApiKey as any).mockResolvedValue(true);
+
+    await expect(openaiCompatibleProvider.isAvailable(ctxWith([{ providerId: "apigee" }]))).resolves.toBe(
+      true,
+    );
+  });
+
+  it("matches the current model by configured gateway provider id", async () => {
+    const { hasGatewayApiKey } = await import("../src/lib/openai-compatible-config.js");
+    (hasGatewayApiKey as any).mockResolvedValue(false);
+
+    // Populate the provider-id cache via isAvailable, then match.
+    await openaiCompatibleProvider.isAvailable(ctxWith([{ providerId: "apigee" }]));
+    expect(openaiCompatibleProvider.matchesCurrentModel!("apigee/google/gemini-2.5-flash")).toBe(true);
+    expect(openaiCompatibleProvider.matchesCurrentModel!("openai/gpt-4")).toBe(false);
+  });
+});


### PR DESCRIPTION
Refs #109

### Summary

Adds a generic, config-driven `openai-compatible` provider for any self-hosted /
OpenAI-compatible gateway (LiteLLM, in-house/university gateways,
OpenRouter-compatible endpoints) that exposes a remaining-quota endpoint. No
vendor URL is hardcoded — the base URL is configurable — and it is bound to no
product (there is no standard quota endpoint, so it consumes a small documented
shape with an OpenRouter preset).

### What changed

- **`src/lib/openai-compatible.ts`** — `queryGatewayQuota` (GET `<baseURL><quotaPath>`,
  Bearer) → normalized `{tokens, cost}`; default vendor-neutral shape
  (`{key, tokens:{limit,used,remaining,resets_at}, cost:{currency,limit,used,remaining}}`)
  plus an `openrouter` preset (`{data:{usage,limit,limit_remaining}}`).
- **`src/lib/openai-compatible-config.ts`** — per-gateway API key via the shared
  `createProviderApiKeyResolver` (env `<ID>_API_KEY` / trusted global config
  `provider.<id>.options.apiKey` / auth.json) + base URL (override or
  `provider.<id>.options.baseURL`).
- **`src/providers/openai-compatible.ts`** — config-driven over
  `experimental.quotaToast.openaiCompatibleGateways`; one provider, N gateways.
- Config schema (`types.ts`, `config.ts`, `entries.ts`), registry +
  provider-metadata registration (canonical id `openai-compatible`), README
  (Providers table row, provider-specific setting, setup-notes section).

### Design decisions (open to feedback — see #109)

1. Config under `experimental.quotaToast.openaiCompatibleGateways`.
2. `matchesCurrentModel` uses a fetch-time cache of the configured provider ids,
   since its `(model, context)` signature can't see `ctx.config`.
3. Canonical id `openai-compatible` in `enabledProviders`; per-gateway ids are
   config, not metadata.

### Checklist

- [x] Started from `contributing/provider-template/`
- [x] `pnpm run typecheck` ✓ · `pnpm test` ✓ (1040 passed) · `pnpm run build` ✓
- [x] Tests for each auth source (env / trusted global config / auth.json) +
  fetch mappings (neutral + openrouter) + provider wrapper
- [x] Updated docs (`README.md`)
- [x] `/quota_status` auth-source diagnostics for this provider

Tested against OpenCode 1.15.12 (config schema + plugin API).
