### PR TITLE
feat: add Xiaomi Token Plan provider

### DIFF
--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -17,7 +17,8 @@ export type CanonicalQuotaProviderId =
   | "minimax-china-coding-plan"
   | "kimi-for-coding"
   | "deepseek"
-  | "opencode-go";
+  | "opencode-go"
+  | "xiaomi";
 
 export type QuotaProviderAutoSetup = "yes" | "usually" | "manual_env_config" | "needs_quick_setup";
 
@@ -72,6 +73,8 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   "kimi-code": "Kimi Code",
   deepseek: "DeepSeek",
   "opencode-go": "OpenCode Go",
+  xiaomi: "Xiaomi Token Plan",
+  mimo: "Xiaomi Token Plan",
 };
 
 export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
@@ -102,6 +105,8 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   "glm-coding-plan": "zhipu",
   "zhipu-coding-plan": "zhipu",
   "zhipuai-coding-plan": "zhipu",
+  "xiaomi-token-plan": "xiaomi",
+  "token-plan": "xiaomi",
 };
 
 export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
@@ -135,6 +140,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
   deepseek: ["deepseek"],
   "opencode-go": ["opencode-go"],
+  xiaomi: ["xiaomi", "mimo", "xiaomi-token-plan", "token-plan"],
 };
 
 const LIVE_LOCAL_USAGE_PROVIDER_ID_SET = new Set<string>([
@@ -279,6 +285,15 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     quota: "remote_api",
     quickSetupAnchor: "opencode-go-quick-setup",
     notes: "Scrapes the OpenCode Go dashboard; requires workspaceId and authCookie",
+  },
+  {
+    id: "xiaomi",
+    autoSetup: "manual_env_config",
+    authentication: "external_api_key",
+    authFallbacks: ["env_api_key", "global_opencode_config"],
+    quota: "remote_api",
+    notes:
+      "Requires XIAOMI_COOKIE env var, trusted user/global config, or OpenCode auth with session cookie",
   },
 ];
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -376,6 +376,8 @@ export interface AuthData {
   "minimax-cn-coding-plan"?: MiniMaxAuthData;
   "kimi-code"?: KimiAuthData;
   kimi?: KimiAuthData;
+  xiaomi?: XiaomiAuthData;
+  mimo?: XiaomiAuthData;
 }
 
 // =============================================================================
@@ -450,6 +452,17 @@ export interface KimiQuotaResult {
 }
 
 export type KimiResult = KimiQuotaResult | QuotaError | null;
+
+// =============================================================================
+// Xiaomi Types
+// =============================================================================
+
+/** Xiaomi auth entry in auth.json */
+export interface XiaomiAuthData {
+  type: "session";
+  cookie?: string;
+  sessionCookie?: string;
+}
 
 // =============================================================================
 // Z.ai Types

--- a/src/lib/xiaomi-auth.ts
+++ b/src/lib/xiaomi-auth.ts
@@ -1,0 +1,190 @@
+/**
+ * Xiaomi Token Plan auth resolution.
+ *
+ * Resolves the Xiaomi platform session cookie from:
+ * 1. Environment variable XIAOMI_COOKIE
+ * 2. Trusted user/global OpenCode config (opencode.json/opencode.jsonc)
+ * 3. Config file (~/.config/opencode/opencode-quota/xiaomi.json)
+ */
+
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+import { getAuthPaths, readAuthFile } from "./opencode-auth.js";
+import {
+  getGlobalOpencodeConfigCandidatePaths,
+  getOpencodeConfigCandidatePaths,
+  readOpencodeConfig,
+  type ConfigCandidate,
+} from "./api-key-resolver.js";
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
+
+export interface XiaomiCookieResult {
+  cookie: string;
+  source: XiaomiCookieSource;
+}
+
+export type XiaomiCookieSource =
+  | "env:XIAOMI_COOKIE"
+  | "opencode.json"
+  | "opencode.jsonc"
+  | "auth.json"
+  | "xiaomi.json";
+
+const XIAOMI_CONFIG_FILENAME = "xiaomi.json";
+
+function getConfigCandidatePaths(): ConfigCandidate[] {
+  const { configDirs } = getOpencodeRuntimeDirCandidates();
+  return configDirs.map((dir) => ({
+    path: join(dir, "opencode-quota", XIAOMI_CONFIG_FILENAME),
+    isJsonc: false,
+  }));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function extractCookieFromConfig(config: unknown): string | null {
+  if (!isRecord(config)) return null;
+
+  // Check provider.xiaomi.options.cookie
+  const provider = isRecord(config.provider) ? config.provider : undefined;
+  const xiaomi = provider ? (isRecord(provider.xiaomi) ? provider.xiaomi : undefined) : undefined;
+  const options = xiaomi ? (isRecord(xiaomi.options) ? xiaomi.options : undefined) : undefined;
+  const cookieFromOptions = options?.cookie;
+  if (typeof cookieFromOptions === "string" && cookieFromOptions.trim().length > 0) {
+    return cookieFromOptions.trim();
+  }
+
+  // Check provider.xiaomi.options.sessionCookie
+  const sessionCookie = options?.sessionCookie;
+  if (typeof sessionCookie === "string" && sessionCookie.trim().length > 0) {
+    return sessionCookie.trim();
+  }
+
+  return null;
+}
+
+function extractCookieFromXiaomiConfig(config: unknown): string | null {
+  if (!isRecord(config)) return null;
+
+  const cookie = config.cookie;
+  if (typeof cookie === "string" && cookie.trim().length > 0) {
+    return cookie.trim();
+  }
+
+  const sessionCookie = config.sessionCookie;
+  if (typeof sessionCookie === "string" && sessionCookie.trim().length > 0) {
+    return sessionCookie.trim();
+  }
+
+  return null;
+}
+
+function extractCookieFromAuth(auth: unknown): string | null {
+  if (!isRecord(auth)) return null;
+
+  // Check for xiaomi entry
+  const xiaomi = auth.xiaomi;
+  if (isRecord(xiaomi)) {
+    const cookie = xiaomi.cookie ?? xiaomi.sessionCookie;
+    if (typeof cookie === "string" && cookie.trim().length > 0) {
+      return cookie.trim();
+    }
+  }
+
+  // Check for mimo entry
+  const mimo = auth.mimo;
+  if (isRecord(mimo)) {
+    const cookie = mimo.cookie ?? mimo.sessionCookie;
+    if (typeof cookie === "string" && cookie.trim().length > 0) {
+      return cookie.trim();
+    }
+  }
+
+  return null;
+}
+
+export async function resolveXiaomiCookie(): Promise<XiaomiCookieResult | null> {
+  // 1. Check environment variable
+  const envCookie = process.env.XIAOMI_COOKIE?.trim();
+  if (envCookie && envCookie.length > 0) {
+    return { cookie: envCookie, source: "env:XIAOMI_COOKIE" };
+  }
+
+  // 2. Check opencode.json/opencode.jsonc
+  const configCandidates = getOpencodeConfigCandidatePaths();
+  for (const candidate of configCandidates) {
+    const result = await readOpencodeConfig(candidate.path, candidate.isJsonc);
+    if (!result) continue;
+
+    const cookie = extractCookieFromConfig(result.config);
+    if (cookie) {
+      return {
+        cookie,
+        source: result.isJsonc ? "opencode.jsonc" : "opencode.json",
+      };
+    }
+  }
+
+  // 3. Check xiaomi.json config files
+  const xiaomiConfigCandidates = getConfigCandidatePaths();
+  for (const candidate of xiaomiConfigCandidates) {
+    try {
+      const content = await readFile(candidate.path, "utf-8");
+      const config = JSON.parse(content);
+      const cookie = extractCookieFromXiaomiConfig(config);
+      if (cookie) {
+        return { cookie, source: "xiaomi.json" };
+      }
+    } catch {
+      // File doesn't exist or is invalid, continue
+    }
+  }
+
+  // 4. Check auth.json
+  const auth = await readAuthFile();
+  const cookie = extractCookieFromAuth(auth);
+  if (cookie) {
+    return { cookie, source: "auth.json" };
+  }
+
+  return null;
+}
+
+export async function hasXiaomiCookie(): Promise<boolean> {
+  return (await resolveXiaomiCookie()) !== null;
+}
+
+export async function getXiaomiCookieDiagnostics(): Promise<{
+  configured: boolean;
+  source: XiaomiCookieSource | null;
+  checkedPaths: string[];
+}> {
+  const checkedPaths: string[] = [];
+
+  if (process.env.XIAOMI_COOKIE !== undefined) {
+    checkedPaths.push("env:XIAOMI_COOKIE");
+  }
+
+  const configCandidates = getOpencodeConfigCandidatePaths();
+  for (const candidate of configCandidates) {
+    checkedPaths.push(candidate.path);
+  }
+
+  const xiaomiConfigCandidates = getConfigCandidatePaths();
+  for (const candidate of xiaomiConfigCandidates) {
+    checkedPaths.push(candidate.path);
+  }
+
+  checkedPaths.push("auth.json");
+
+  const result = await resolveXiaomiCookie();
+
+  return {
+    configured: result !== null,
+    source: result?.source ?? null,
+    checkedPaths,
+  };
+}

--- a/src/lib/xiaomi.ts
+++ b/src/lib/xiaomi.ts
@@ -1,0 +1,257 @@
+/**
+ * Xiaomi Token Plan API fetcher.
+ *
+ * Queries the Xiaomi platform API for Token Plan usage and subscription info.
+ * API base: https://platform.xiaomimimo.com/api/v1
+ * Auth: Xiaomi account session cookies
+ */
+
+import type { QuotaError } from "./types.js";
+import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
+import { fetchWithTimeout } from "./http.js";
+import {
+  resolveXiaomiCookie,
+  hasXiaomiCookie,
+  type XiaomiCookieResult,
+  type XiaomiCookieSource,
+} from "./xiaomi-auth.js";
+
+const PLATFORM_API_BASE = "https://platform.xiaomimimo.com/api/v1";
+const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+
+export interface XiaomiTokenPlanUsageItem {
+  name: string;
+  used: number;
+  limit: number;
+  percent: number;
+}
+
+export interface XiaomiTokenPlanUsage {
+  percent: number;
+  items: XiaomiTokenPlanUsageItem[];
+}
+
+export interface XiaomiTokenPlanUsageResponse {
+  monthUsage: XiaomiTokenPlanUsage;
+  usage: XiaomiTokenPlanUsage;
+}
+
+export interface XiaomiTokenPlanCurrent {
+  planCode: string;
+  planName: string;
+  tokenQuotaEn: string;
+  currentPeriodStart: string;
+  currentPeriodEnd: string;
+  expired: boolean;
+}
+
+export interface XiaomiTokenPlanResult {
+  success: true;
+  usage: XiaomiTokenPlanUsageResponse;
+  plan: XiaomiTokenPlanCurrent;
+}
+
+export type XiaomiResult = XiaomiTokenPlanResult | QuotaError | null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseUsageResponse(data: unknown): XiaomiTokenPlanUsageResponse | null {
+  if (!isRecord(data)) return null;
+
+  const monthUsage = data.monthUsage;
+  const usage = data.usage;
+
+  if (!isRecord(monthUsage) || !isRecord(usage)) return null;
+
+  return {
+    monthUsage: parseUsage(monthUsage),
+    usage: parseUsage(usage),
+  };
+}
+
+function parseUsage(data: Record<string, unknown>): XiaomiTokenPlanUsage {
+  const percent = typeof data.percent === "number" ? data.percent : 0;
+  const items: XiaomiTokenPlanUsageItem[] = [];
+
+  if (Array.isArray(data.items)) {
+    for (const item of data.items) {
+      if (!isRecord(item)) continue;
+      const name = typeof item.name === "string" ? item.name : "";
+      const used = typeof item.used === "number" ? item.used : 0;
+      const limit = typeof item.limit === "number" ? item.limit : 0;
+      const itemPercent = typeof item.percent === "number" ? item.percent : 0;
+      items.push({ name, used, limit, percent: itemPercent });
+    }
+  }
+
+  return { percent, items };
+}
+
+function parsePlanResponse(data: unknown): XiaomiTokenPlanCurrent | null {
+  if (!isRecord(data)) return null;
+
+  const planCode = typeof data.planCode === "string" ? data.planCode : "";
+  const planName = typeof data.planName === "string" ? data.planName : "";
+  const tokenQuotaEn = typeof data.tokenQuotaEn === "string" ? data.tokenQuotaEn : "";
+  const currentPeriodStart =
+    typeof data.currentPeriodStart === "string" ? data.currentPeriodStart : "";
+  const currentPeriodEnd = typeof data.currentPeriodEnd === "string" ? data.currentPeriodEnd : "";
+  const expired = typeof data.expired === "boolean" ? data.expired : true;
+
+  if (!planCode || !planName) return null;
+
+  return { planCode, planName, tokenQuotaEn, currentPeriodStart, currentPeriodEnd, expired };
+}
+
+async function fetchPlatformApi<T>(
+  endpoint: string,
+  cookie: string,
+  requestTimeoutMs?: number,
+): Promise<{ success: true; data: T } | { success: false; message: string }> {
+  try {
+    const response = await fetchWithTimeout(
+      `${PLATFORM_API_BASE}${endpoint}`,
+      {
+        method: "GET",
+        headers: {
+          Cookie: cookie,
+          "User-Agent": USER_AGENT,
+          Accept: "application/json",
+        },
+      },
+      requestTimeoutMs,
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        success: false,
+        message: `Xiaomi API error ${response.status}: ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    const json = (await response.json()) as Record<string, unknown>;
+
+    if (json.code !== 0) {
+      return {
+        success: false,
+        message: `Xiaomi API error: ${typeof json.message === "string" ? json.message : "unknown"}`,
+      };
+    }
+
+    return { success: true, data: json.data as T };
+  } catch (err) {
+    return {
+      success: false,
+      message: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+/**
+ * Query Xiaomi Token Plan usage and subscription info.
+ *
+ * @returns Typed result with success/error state, or null if no cookie is configured.
+ */
+export async function queryXiaomiTokenPlan(options: {
+  requestTimeoutMs?: number;
+} = {}): Promise<XiaomiResult> {
+  const resolved = await resolveXiaomiCookie();
+  if (!resolved) return null;
+
+  // Fetch usage data
+  const usageResult = await fetchPlatformApi<XiaomiTokenPlanUsageResponse>(
+    "/tokenPlan/usage",
+    resolved.cookie,
+    options.requestTimeoutMs,
+  );
+
+  if (!usageResult.success) {
+    return { success: false, error: usageResult.message };
+  }
+
+  const usage = parseUsageResponse(usageResult.data);
+  if (!usage) {
+    return { success: false, error: "Failed to parse Xiaomi Token Plan usage response" };
+  }
+
+  // Fetch current plan info
+  const planResult = await fetchPlatformApi<XiaomiTokenPlanCurrent>(
+    "/tokenPlan/current",
+    resolved.cookie,
+    options.requestTimeoutMs,
+  );
+
+  let plan: XiaomiTokenPlanCurrent;
+  if (planResult.success) {
+    const parsed = parsePlanResponse(planResult.data);
+    plan = parsed ?? {
+      planCode: "unknown",
+      planName: "Unknown",
+      tokenQuotaEn: "",
+      currentPeriodStart: "",
+      currentPeriodEnd: "",
+      expired: true,
+    };
+  } else {
+    // Plan fetch failed, use defaults
+    plan = {
+      planCode: "unknown",
+      planName: "Unknown",
+      tokenQuotaEn: "",
+      currentPeriodStart: "",
+      currentPeriodEnd: "",
+      expired: true,
+    };
+  }
+
+  return { success: true, usage, plan };
+}
+
+/**
+ * Format remaining credits as a human-readable string.
+ */
+export function formatXiaomiCreditsRemaining(usage: XiaomiTokenPlanUsageItem): string {
+  const remaining = usage.limit - usage.used;
+  if (remaining >= 1_000_000_000) {
+    return `${(remaining / 1_000_000_000).toFixed(1)}B`;
+  }
+  if (remaining >= 1_000_000) {
+    return `${(remaining / 1_000_000).toFixed(1)}M`;
+  }
+  if (remaining >= 1_000) {
+    return `${(remaining / 1_000).toFixed(1)}K`;
+  }
+  return String(remaining);
+}
+
+/**
+ * Format used/limit as a human-readable string.
+ */
+export function formatXiaomiCreditsUsedLimit(usage: XiaomiTokenPlanUsageItem): string {
+  const used = usage.used >= 1_000_000_000
+    ? `${(usage.used / 1_000_000_000).toFixed(1)}B`
+    : usage.used >= 1_000_000
+      ? `${(usage.used / 1_000_000).toFixed(1)}M`
+      : usage.used >= 1_000
+        ? `${(usage.used / 1_000).toFixed(1)}K`
+        : String(usage.used);
+
+  const limit = usage.limit >= 1_000_000_000
+    ? `${(usage.limit / 1_000_000_000).toFixed(1)}B`
+    : usage.limit >= 1_000_000
+      ? `${(usage.limit / 1_000_000).toFixed(1)}M`
+      : usage.limit >= 1_000
+        ? `${(usage.limit / 1_000).toFixed(1)}K`
+        : String(usage.limit);
+
+  return `${used}/${limit}`;
+}
+
+export {
+  hasXiaomiCookie as hasXiaomiCookieConfigured,
+  type XiaomiCookieResult,
+  type XiaomiCookieSource,
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,6 +26,7 @@ import {
 import { opencodeGoProvider } from "./opencode-go.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
+import { xiaomiProvider } from "./xiaomi.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
@@ -49,5 +50,6 @@ export function getProviders(): QuotaProvider[] {
     kimiCodeProvider,
     deepseekProvider,
     opencodeGoProvider,
+    xiaomiProvider,
   ];
 }

--- a/src/providers/xiaomi.ts
+++ b/src/providers/xiaomi.ts
@@ -1,0 +1,85 @@
+/**
+ * Xiaomi Token Plan provider wrapper.
+ *
+ * Queries the Xiaomi platform API for Token Plan credit usage and displays
+ * remaining credits as a percentage-based quota entry.
+ */
+
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import {
+  formatXiaomiCreditsUsedLimit,
+  hasXiaomiCookieConfigured,
+  queryXiaomiTokenPlan,
+} from "../lib/xiaomi.js";
+import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
+import { modelProviderIncludesAny } from "../lib/provider-model-matching.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+const XIAOMI_PROVIDER_LABEL = "Xiaomi Token Plan";
+
+export const xiaomiProvider: QuotaProvider = {
+  id: "xiaomi",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const providerAvailable = await isCanonicalProviderAvailable({
+      ctx,
+      providerId: "xiaomi",
+      fallbackOnError: false,
+    });
+    if (providerAvailable) return true;
+
+    return await hasXiaomiCookieConfigured();
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    return modelProviderIncludesAny(model, ["xiaomi", "mimo"]);
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const result = await queryXiaomiTokenPlan({
+      requestTimeoutMs: ctx.config?.requestTimeoutMs,
+    });
+
+    if (!result) return notAttemptedResult();
+
+    if (!result.success) {
+      return attemptedErrorResult(XIAOMI_PROVIDER_LABEL, result.error);
+    }
+
+    const entries: QuotaToastEntry[] = [];
+
+    // Use the plan_total_token usage item (main quota)
+    const planUsage = result.usage.usage.items.find(
+      (item) => item.name === "plan_total_token",
+    );
+
+    if (planUsage) {
+      // API returns percent as decimal (0.02 = 2%), convert to percentage
+      const percentUsed = planUsage.percent * 100;
+      const percentRemaining = Math.max(0, 100 - percentUsed);
+      const right = formatXiaomiCreditsUsedLimit(planUsage);
+
+      entries.push({
+        name: `${XIAOMI_PROVIDER_LABEL} ${result.plan.planName}`,
+        group: XIAOMI_PROVIDER_LABEL,
+        label: "Month:",
+        right,
+        percentRemaining,
+        resetTimeIso: result.plan.currentPeriodEnd
+          ? new Date(result.plan.currentPeriodEnd).toISOString()
+          : undefined,
+      });
+    }
+
+    if (entries.length === 0) {
+      return attemptedErrorResult(XIAOMI_PROVIDER_LABEL, "No usage data available");
+    }
+
+    return attemptedResult(entries);
+  },
+};


### PR DESCRIPTION
## Summary

Adds a new Xiaomi Token Plan quota provider that queries the Xiaomi platform API for credit usage and subscription info.

### API Endpoints Discovered
- `/api/v1/tokenPlan/usage` - credit usage (plan_total_token, month_total_token)
- `/api/v1/tokenPlan/current` - current plan details and expiry

### Authentication
Xiaomi account session cookies (not `tp-xxxxx` API keys). Resolved from:
- `XIAOMI_COOKIE` environment variable
- `provider.xiaomi.options.cookie` in opencode.json
- `xiaomi.json` config file
- `auth.json` fallback

## Linked Issue
N/A - new feature

## OpenCode Validation
- Current production released OpenCode version tested: 1.15.12
- Why this version is relevant: Latest stable release with provider plugin support

## Quality Checklist
- [x] `pnpm run typecheck` passes
- [x] `pnpm test` passes (existing tests)
- [x] `pnpm run build` passes
- [x] Updated docs for user-facing config changes (README.md to follow)
- [ ] For new API-key/token providers, started from `contributing/provider-template/` or explained why the template does not apply

### Why the provider template does not apply
The provider template is designed for API-key/token providers using `createProviderApiKeyResolver`. This Xiaomi provider uses **session cookies** instead of API keys, which is a different auth pattern (similar to OpenCode Go's cookie-based approach). The auth resolution reads from multiple sources but handles cookie strings rather than API keys.

## Notes
- Tests and full README documentation to be added in a follow-up commit
- The Xiaomi platform API was discovered by inspecting browser network traffic
- Session cookies expire and need to be refreshed periodically