### PR TITLE
fix: respect percentDisplayMode in /quota command

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Existing `experimental.quotaToast` settings still work when no sidecar file exis
 | `minIntervalMs` | `300000` | Minimum fetch interval between provider updates. |
 | `requestTimeoutMs` | `5000` | Remote provider request timeout in milliseconds. |
 | `formatStyle` | `singleWindow` | Shared quota reset-period display for popup toasts and the Sidebar panel: `singleWindow` shows one reset period per provider; `allWindows` shows all reset periods per provider. Legacy `classic`/`grouped` aliases are still accepted. |
-| `percentDisplayMode` | `remaining` | Shared quota percentage meaning for popup toasts and the Sidebar panel: `remaining` shows quota left; `used` shows quota consumed. `/quota` keeps its existing remaining-percent output. |
+| `percentDisplayMode` | `remaining` | Shared quota percentage meaning for popup toasts, the Sidebar panel, and `/quota`: `remaining` shows quota left; `used` shows quota consumed. |
 | `onlyCurrentModel` | `false` | Filter quota rows to the current model/provider when that session selection can be resolved. |
 | `showSessionTokens` | `true` | Show the `Session input/output tokens` section when session token data is available. When cached input is present, the section keeps the legacy `in/out` layout and appends cached input in parentheses next to the input amount. |
 | `pricingSnapshot.source` | `"auto"` | Token pricing snapshot selection for `/tokens_*`: `auto`, `bundled`, or `runtime`. |

--- a/src/lib/quota-command-format.ts
+++ b/src/lib/quota-command-format.ts
@@ -8,8 +8,9 @@
  */
 
 import type { QuotaToastEntry, QuotaToastError, SessionTokensData } from "./entries.js";
+import type { PercentDisplayMode } from "./types.js";
 import { isValueEntry } from "./entries.js";
-import { bar, clampInt, padRight } from "./format-utils.js";
+import { bar, clampInt, formatDisplayedPercentLabel, padRight } from "./format-utils.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { groupQuotaEntries } from "./grouped-entry-normalization.js";
 import { renderPlainTextReport, type ReportDocument, type ReportSection } from "./report-document.js";
@@ -46,6 +47,7 @@ function buildQuotaCommandDocument(params: {
   errors: QuotaToastError[];
   sessionTokens?: SessionTokensData;
   generatedAtMs?: number;
+  percentDisplayMode?: PercentDisplayMode;
 }): ReportDocument {
   const groups = groupQuotaEntries(params.entries, "quota");
   const normalizedEntries = groups.flatMap((group) => group.entries);
@@ -72,7 +74,8 @@ function buildQuotaCommandDocument(params: {
       }
 
       const pct = clampInt(row.percentRemaining, 0, 100);
-      lines.push(`  ${labelCol} ${bar(pct, barWidth)}  ${pct}% left${suffix}`);
+      const pctLabel = formatDisplayedPercentLabel(row.percentRemaining, params.percentDisplayMode);
+      lines.push(`  ${labelCol} ${bar(pct, barWidth)}  ${pctLabel}${suffix}`);
     }
     return {
       id: `group-${index}`,
@@ -116,6 +119,7 @@ export function formatQuotaCommand(params: {
   errors: QuotaToastError[];
   sessionTokens?: SessionTokensData;
   generatedAtMs?: number;
+  percentDisplayMode?: PercentDisplayMode;
 }): string {
   return renderPlainTextReport(buildQuotaCommandDocument(params));
 }

--- a/src/lib/quota-command-format.ts
+++ b/src/lib/quota-command-format.ts
@@ -10,7 +10,7 @@
 import type { QuotaToastEntry, QuotaToastError, SessionTokensData } from "./entries.js";
 import type { PercentDisplayMode } from "./types.js";
 import { isValueEntry } from "./entries.js";
-import { bar, clampInt, formatDisplayedPercentLabel, padRight } from "./format-utils.js";
+import { bar, formatDisplayedPercentLabel, padRight, resolveDisplayedPercent } from "./format-utils.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { groupQuotaEntries } from "./grouped-entry-normalization.js";
 import { renderPlainTextReport, type ReportDocument, type ReportSection } from "./report-document.js";
@@ -73,7 +73,7 @@ function buildQuotaCommandDocument(params: {
         continue;
       }
 
-      const pct = clampInt(row.percentRemaining, 0, 100);
+      const pct = resolveDisplayedPercent(row.percentRemaining, params.percentDisplayMode);
       const pctLabel = formatDisplayedPercentLabel(row.percentRemaining, params.percentDisplayMode);
       lines.push(`  ${labelCol} ${bar(pct, barWidth)}  ${pctLabel}${suffix}`);
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1626,6 +1626,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       formatQuotaCommand({
         ...reportData,
         generatedAtMs,
+        percentDisplayMode: runtime.config.percentDisplayMode,
       }),
     );
   }

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -320,8 +320,8 @@ describe("/quota command behavior", () => {
 
     expect(client.session.prompt).toHaveBeenCalledTimes(1);
     const injected = getPromptText(client);
-    expect(injected).toContain("81% left");
-    expect(injected).not.toContain("19% left");
+    expect(injected).toContain("19% used");
+    expect(injected).not.toContain("81% left");
   });
 
   it("rewrites default_agent only when one zero-width-normalized key matches", async () => {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -285,7 +285,7 @@ describe("/quota command behavior", () => {
     expect(message).not.toContain("81% left");
   });
 
-  it("keeps /quota remaining-oriented when percentDisplayMode is used", async () => {
+  it("honors percentDisplayMode for /quota output", async () => {
     mocks.loadConfig.mockResolvedValueOnce({
       ...DEFAULT_CONFIG,
       enabled: true,

--- a/tests/quota-command-format.test.ts
+++ b/tests/quota-command-format.test.ts
@@ -159,6 +159,39 @@ describe("formatQuotaCommand", () => {
     expect(out.indexOf("5h:")).toBeLessThan(out.indexOf("Weekly:"));
   });
 
+  it("honors used percent display mode in /quota percent rows", () => {
+    const out = formatQuotaCommand({
+      entries: [
+        {
+          name: "OpenAI Pro",
+          percentRemaining: 81,
+        },
+      ],
+      errors: [],
+      percentDisplayMode: "used",
+    });
+
+    expect(out).toContain("19% used");
+    expect(out).not.toContain("81% left");
+    expect(out).toContain("███░░░░░░░░░░░░░░░");
+  });
+
+  it("renders over-quota used percentages with a full /quota bar", () => {
+    const out = formatQuotaCommand({
+      entries: [
+        {
+          name: "OpenAI Pro",
+          percentRemaining: -25,
+        },
+      ],
+      errors: [],
+      percentDisplayMode: "used",
+    });
+
+    expect(out).toContain("125% used");
+    expect(out).toContain("██████████████████");
+  });
+
   it("keeps /quota reset formatting independent from compact toast resets", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));


### PR DESCRIPTION
## Summary

The `/quota` slash command hardcodes `% left` regardless of the `percentDisplayMode` config setting. This makes it inconsistent with the sidebar and compact status, which correctly respect the setting.

## Problem

1. Set `percentDisplayMode: "used"` in config
2. Sidebar shows `XX% used` (correct)
3. `/quota` shows `XX% left` (wrong — ignores config)

## Root Cause

`src/lib/quota-command-format.ts:75` hardcodes:
```ts
lines.push(`  ${labelCol} ${bar(pct, barWidth)}  ${pct}% left${suffix}`);
```

While sidebar/compact use `formatDisplayedPercentLabel()` which respects `percentDisplayMode`.

## Fix

- Import `formatDisplayedPercentLabel` in `quota-command-format.ts`
- Replace hardcoded `% left` with `formatDisplayedPercentLabel(row.percentRemaining, params.percentDisplayMode)`
- Pass `percentDisplayMode` from `runtime.config` through `handleQuotaSlashCommand`
- Update test to verify new behavior

## Testing

- All 26 tests in `tests/plugin.quota-command.test.ts` pass
- TypeScript typecheck passes

Closes #116
