### PR TITLE
feat: integrate Gemini CLI quota merging and Antigravity v2 rate-limit overrides

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -180,7 +180,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Validates and normalizes a Google model ID
  */
 function isValidGoogleModelId(id: unknown): id is GoogleModelId {
-  return typeof id === "string" && ["G3PRO", "G3FLASH", "CLAUDE", "G3IMAGE"].includes(id);
+  return typeof id === "string" && ["G3PRO", "G3FLASH", "CLAUDE", "G3IMAGE", "GPTOSS"].includes(id);
 }
 
 function isValidCursorQuotaPlan(plan: unknown): plan is CursorQuotaPlan {

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -86,6 +86,11 @@ export interface SessionTokensData {
 export interface QuotaProviderPresentation {
   singleWindowDisplayName?: string;
   singleWindowShowRight?: boolean;
+  /**
+   * When set to "preserve", the provider's entries are kept individually
+   * (one per window) even in single-window format styles.
+   */
+  classicStrategy?: "preserve";
 }
 
 export interface QuotaProviderResult {

--- a/src/lib/google-antigravity-companion.ts
+++ b/src/lib/google-antigravity-companion.ts
@@ -104,7 +104,12 @@ function normalizeCredential(value: unknown): string {
 }
 
 function getCompanionResolvePaths(): string[] {
-  const paths = [...getOpencodeRuntimeDirCandidates().cacheDirs];
+  const paths = [
+    ...getOpencodeRuntimeDirCandidates().cacheDirs,
+    "C:\\Users\\gsc\\AppData\\Local\\nvm\\v22.22.1\\node_modules",
+    "C:\\Users\\gsc\\AppData\\Roaming\\npm\\node_modules",
+    "C:\\nvm4w\\nodejs\\node_modules"
+  ];
   return paths;
 }
 

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -46,6 +46,8 @@ import {
 
 const GOOGLE_QUOTA_API_URL = "https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels";
 const USER_AGENT = "antigravity/1.11.9 darwin/arm64";
+const USER_AGENT_GEMINI_CLI = "GeminiCLI/1.0.0/gemini-2.5-pro (win32; x64)";
+const GOOGLE_RETRIEVE_USER_QUOTA_URL = "https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota";
 
 const GOOGLE_TOKEN_REFRESH_URL = "https://oauth2.googleapis.com/token";
 
@@ -455,14 +457,31 @@ async function fetchGoogleQuota(
 }
 
 /**
+ * Map a modelId to its rate-limit family for local override lookup.
+ * Families: "claude", "gemini-flash", "gemini-pro", "gpt-oss"
+ */
+function getRateLimitFamily(
+  _modelId: GoogleModelId,
+  modelConfig: (typeof GOOGLE_MODEL_KEYS)[GoogleModelId],
+): "claude" | "gemini-flash" | "gemini-pro" | "gpt-oss" | null {
+  const key = modelConfig.key.toLowerCase();
+  if (key.includes("claude")) return "claude";
+  if (key.includes("flash")) return "gemini-flash";
+  if (key.includes("pro")) return "gemini-pro";
+  if (key.includes("gpt-oss")) return "gpt-oss";
+  return null;
+}
+
+/**
  * Extract model quotas from API response
  */
 function extractModelQuotas(
   data: GoogleQuotaResponse,
   modelIds: GoogleModelId[],
-  accountEmail?: string,
+  account: AntigravityAccount,
 ): GoogleModelQuota[] {
   const quotas: GoogleModelQuota[] = [];
+  const accountEmail = account.email || "Unknown";
 
   for (const modelId of modelIds) {
     const modelConfig = GOOGLE_MODEL_KEYS[modelId];
@@ -480,12 +499,26 @@ function extractModelQuotas(
     }
 
     if (modelInfo) {
-      const remainingFraction = modelInfo.quotaInfo?.remainingFraction ?? 0;
+      let remainingFraction = modelInfo.quotaInfo?.remainingFraction ?? 0;
+      let resetTimeIso: string | undefined = modelInfo.quotaInfo?.resetTime;
+
+      // Apply local rate limit overrides (rate-limited state from companion plugin)
+      if (account.rateLimitResetTimes) {
+        const family = getRateLimitFamily(modelId, modelConfig);
+        if (family && account.rateLimitResetTimes[family]) {
+          const resetTimestamp = account.rateLimitResetTimes[family];
+          if (resetTimestamp && resetTimestamp > Date.now()) {
+            remainingFraction = 0;
+            resetTimeIso = new Date(resetTimestamp).toISOString();
+          }
+        }
+      }
+
       quotas.push({
         modelId,
         displayName: modelConfig.display,
         percentRemaining: Math.round(remainingFraction * 100),
-        resetTimeIso: modelInfo.quotaInfo?.resetTime,
+        resetTimeIso,
         accountEmail,
       });
     }
@@ -563,7 +596,7 @@ async function fetchAccountQuotaWithAntigravityRefresh(params: {
         throw err;
       }
     }
-    const models = extractModelQuotas(data, params.modelIds, email);
+    const models = extractModelQuotas(data, params.modelIds, params.account);
 
     return { success: true, models, accountEmail: email };
   } catch (err) {
@@ -576,6 +609,129 @@ async function fetchAccountQuotaWithAntigravityRefresh(params: {
       accountEmail: email,
     };
   }
+}
+
+// =============================================================================
+// Gemini CLI Quota Merging (more accurate rate limits)
+// =============================================================================
+
+/** Bucket returned by the Gemini CLI `retrieveUserQuota` endpoint. */
+interface GeminiCliBucket {
+  modelId?: string;
+  remainingFraction?: number;
+  resetTime?: string;
+}
+
+/** Map a `GoogleModelId` to the key expected by Gemini CLI's `retrieveUserQuota`. */
+function modelIdToGemini3Key(modelId: GoogleModelId): string | null {
+  const cfg = GOOGLE_MODEL_KEYS[modelId];
+  if (!cfg) return null;
+  if (cfg.display === "G3Pro") return "gemini-3.1-pro";
+  if (cfg.display === "G3Flash") return "gemini-3-flash";
+  if (cfg.display === "Claude") return "claude-sonnet-4-6";
+  if (cfg.display === "GPT-OSS") return "gpt-oss-120b-medium";
+  return null;
+}
+
+/**
+ * Fetch the Gemini CLI user quota endpoint for the most accurate rate limit info.
+ * Best-effort: never throws, returns `{ buckets: [] }` on any error.
+ */
+async function fetchGeminiCliQuota(
+  accessToken: string,
+  projectId: string,
+): Promise<{ buckets?: GeminiCliBucket[] }> {
+  try {
+    const response = await fetchWithTimeout(
+      GOOGLE_RETRIEVE_USER_QUOTA_URL,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+          "User-Agent": USER_AGENT_GEMINI_CLI,
+        },
+        body: JSON.stringify({ project: projectId }),
+      },
+      GOOGLE_QUOTA_TIMEOUT_MS,
+    );
+    if (response.ok) {
+      return (await response.json()) as { buckets?: GeminiCliBucket[] };
+    }
+    return { buckets: [] };
+  } catch {
+    return { buckets: [] };
+  }
+}
+
+/**
+ * Merge Gemini CLI quota buckets into Antigravity model data.
+ * For each Antigravity model, if the CLI reports a LOWER remaining percentage,
+ * the CLI value wins (CLI is more accurate for active rate limits).
+ */
+function mergeGeminiCliQuota(
+  cliBuckets: GeminiCliBucket[] | undefined,
+  antigravityModels: GoogleModelQuota[],
+): GoogleModelQuota[] {
+  if (!cliBuckets || cliBuckets.length === 0) return antigravityModels;
+
+  const findBucketByDisplay = (display: string): GeminiCliBucket | null => {
+    if (display === "G3Pro") {
+      for (const b of cliBuckets) {
+        if (!b.modelId) continue;
+        if (
+          b.modelId.startsWith("gemini-3.1-pro") ||
+          b.modelId.startsWith("gemini-3-pro") ||
+          b.modelId === "gemini-3.5-pro" ||
+          b.modelId.startsWith("gemini-3.5-pro")
+        ) {
+          return b;
+        }
+      }
+    }
+    if (display === "G3Flash") {
+      for (const b of cliBuckets) {
+        if (!b.modelId) continue;
+        if (
+          b.modelId.startsWith("gemini-3-flash") ||
+          b.modelId.startsWith("gemini-3.5-flash") ||
+          b.modelId.startsWith("gemini-3.1-flash")
+        ) {
+          return b;
+        }
+      }
+    }
+    if (display === "Claude") {
+      for (const b of cliBuckets) {
+        if (!b.modelId) continue;
+        if (b.modelId.startsWith("claude") || b.modelId === "claude-sonnet-4-6") {
+          return b;
+        }
+      }
+    }
+    if (display === "GPT-OSS") {
+      for (const b of cliBuckets) {
+        if (b.modelId && b.modelId.startsWith("gpt-oss")) return b;
+      }
+    }
+    return null;
+  };
+
+  return antigravityModels.map((m) => {
+    const cfg = GOOGLE_MODEL_KEYS[m.modelId];
+    if (!cfg) return m;
+    const cliBucket = findBucketByDisplay(cfg.display);
+    if (!cliBucket || typeof cliBucket.remainingFraction !== "number") return m;
+    const cliPercent = Math.round(cliBucket.remainingFraction * 100);
+    if (cliPercent < m.percentRemaining) {
+      return {
+        ...m,
+        percentRemaining: cliPercent,
+        resetTimeIso: cliBucket.resetTime || m.resetTimeIso,
+      };
+    }
+    return m;
+  });
 }
 
 // =============================================================================
@@ -630,6 +786,35 @@ export async function queryGoogleQuota(
       allModels.push(...result.models);
     } else if (!result.success && result.error && result.accountEmail) {
       errors.push({ email: result.accountEmail, error: result.error });
+    }
+  }
+
+  // Also fetch and merge Gemini CLI quota for more accurate rate limits
+  if (accounts.length > 0 && allModels.length > 0) {
+    try {
+      const firstAccount = accounts[0]!;
+      const projectId = getProjectId(firstAccount);
+      if (projectId) {
+        const tokenResult = await refreshAccessTokenWithCache({
+          refreshToken: firstAccount.refreshToken,
+          projectId,
+          email: firstAccount.email,
+          credentials,
+        });
+        if (!("error" in tokenResult)) {
+          const cliData = await fetchGeminiCliQuota(tokenResult.accessToken, projectId);
+          if (cliData && cliData.buckets) {
+            const mergedModels = mergeGeminiCliQuota(cliData.buckets, allModels);
+            return {
+              success: true,
+              models: mergedModels,
+              errors: errors.length > 0 ? errors : undefined,
+            } as GoogleQuotaResult;
+          }
+        }
+      }
+    } catch {
+      // If Gemini CLI quota fetch fails, fall through to Antigravity-only result
     }
   }
 

--- a/src/lib/grouped-entry-normalization.ts
+++ b/src/lib/grouped-entry-normalization.ts
@@ -29,7 +29,7 @@ function normalizeDurationText(value?: string): string | undefined {
 
 function looksLikeGoogleModel(name: string): boolean {
   const lower = name.toLowerCase();
-  return lower === "claude" || lower === "g3pro" || lower === "g3flash" || lower === "g3image";
+  return lower === "claude" || lower === "g3pro" || lower === "g3flash" || lower === "g3image" || lower === "gpt-oss";
 }
 
 function getGoogleFallbackMeta(name: string): { group: string; label: string } | undefined {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -387,10 +387,14 @@ function normalizeSingleWindowPresentation(
       : typeof legacyPresentation.classicShowRight === "boolean"
         ? legacyPresentation.classicShowRight
         : false;
+  const classicStrategy = legacyPresentation.classicStrategy === "preserve"
+    ? legacyPresentation.classicStrategy
+    : undefined;
 
   return {
     ...(singleWindowDisplayName ? { singleWindowDisplayName } : {}),
     ...(singleWindowShowRight ? { singleWindowShowRight } : {}),
+    ...(classicStrategy ? { classicStrategy } : {}),
   };
 }
 
@@ -421,6 +425,17 @@ function projectProviderResultToStyle(
   }
 
   const presentation = normalizeSingleWindowPresentation(result.presentation);
+  if (presentation?.classicStrategy === "preserve") {
+    return entries.map((entry) =>
+      renameSingleWindowEntry(
+        stripSingleWindowEntryMeta(entry, presentation?.singleWindowShowRight ?? false),
+        buildSingleWindowName({
+          entry,
+          singleWindowDisplayName: entry.group || entry.name,
+        }),
+      ),
+    );
+  }
   const selectedEntry = selectSingleWindowEntry(entries);
   if (!selectedEntry) {
     return [];

--- a/src/lib/toast-format-grouped.ts
+++ b/src/lib/toast-format-grouped.ts
@@ -51,7 +51,7 @@ function resolveGroupedRowLabel(entry: QuotaToastEntry): string {
   const fromName = extractWindowLabel(entry.name);
   if (fromName) return `${fromName} window`;
 
-  return "Quota window";
+  return normalizeLabelText(entry.group) || "Quota window";
 }
 
 export function formatQuotaRowsGrouped(params: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ import { DEFAULT_QUOTA_FORMAT_STYLE } from "./quota-format-style.js";
 // =============================================================================
 
 /** Google model identifiers */
-export type GoogleModelId = "G3PRO" | "G3FLASH" | "CLAUDE" | "G3IMAGE";
+export type GoogleModelId = "G3PRO" | "G3FLASH" | "CLAUDE" | "G3IMAGE" | "GPTOSS";
 export type GeminiCliAuthSourceKey =
   | "google-gemini-cli"
   | "gemini-cli"
@@ -693,14 +693,23 @@ export const GOOGLE_MODEL_KEYS: Record<
 > = {
   G3PRO: {
     key: "gemini-3.1-pro",
-    altKey: "gemini-3.1-pro-high|gemini-3.1-pro-low|gemini-3-pro-high|gemini-3-pro-low",
+    altKey: "gemini-3.1-pro-high|gemini-3.1-pro-low|gemini-3-pro-high|gemini-3-pro-low|gemini-3.5-pro-high|gemini-3.5-pro-low",
     display: "G3Pro",
   },
-  G3FLASH: { key: "gemini-3-flash", display: "G3Flash" },
+  G3FLASH: {
+    key: "gemini-3-flash",
+    altKey: "gemini-3-flash-medium|gemini-3-flash-high|gemini-3-flash-low|gemini-3-5-flash-medium|gemini-3-5-flash-high|gemini-3-5-flash-low|gemini-3.5-flash-medium|gemini-3.5-flash-high|gemini-3.5-flash-low",
+    display: "G3Flash",
+  },
   CLAUDE: {
     key: "claude-opus-4-6-thinking",
-    altKey: "claude-opus-4-5-thinking|claude-opus-4-5",
+    altKey: "claude-opus-4-5-thinking|claude-opus-4-5|claude-sonnet-4-6|claude-sonnet-4-6-thinking|claude-opus-4-6|gemini-claude-sonnet-4-6|gemini-claude-opus-4-6-thinking",
     display: "Claude",
   },
   G3IMAGE: { key: "gemini-3-pro-image", display: "G3Image" },
+  GPTOSS: {
+    key: "gpt-oss-120b-medium",
+    altKey: "gpt-oss-120b-high|gpt-oss-120b-low|gpt-oss-120b",
+    display: "GPT-OSS",
+  },
 };

--- a/src/providers/google-antigravity.ts
+++ b/src/providers/google-antigravity.ts
@@ -51,6 +51,8 @@ export const googleAntigravityProvider: QuotaProvider = {
       const emailLabel = formatGoogleAccountLabel(m.accountEmail, "fixedGmailHint") || "Antigravity";
       return {
         name: `${m.displayName} (${emailLabel})`,
+        group: m.displayName,
+        label: `${m.displayName}:`,
         percentRemaining: m.percentRemaining,
         resetTimeIso: m.resetTimeIso,
       };
@@ -59,6 +61,7 @@ export const googleAntigravityProvider: QuotaProvider = {
     return attemptedResult(
       entries,
       formatGoogleAccountErrors(result.errors, "fixedGmailHint"),
+      { classicStrategy: "preserve" },
     );
   },
 };

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -286,7 +286,7 @@ describe("formatQuotaRows", () => {
       entries: [{ name: "Unlabeled Provider", group: "Unlabeled Provider", percentRemaining: 75 }],
     });
 
-    expect(out).toContain("Quota window");
+    expect(out).toContain("[Unlabeled Provider]");
   });
 
   it("shares single-window provider/window display labels with classic formatting", () => {
@@ -550,7 +550,7 @@ describe("formatQuotaRows", () => {
 
     expect(out).toContain("[Google Antigravity] (acct)");
     expect(out).toContain("\nClaude ");
-    expect(out).toContain("Quota window");
+    expect(out).toContain("\nGoogle Antigravity (acct)");
     expect(out).not.toContain("[Claude] (acct)");
     expect(out).not.toContain("[G3Pro] (acct)");
   });

--- a/tests/lib.google.multi-account-refresh.test.ts
+++ b/tests/lib.google.multi-account-refresh.test.ts
@@ -79,7 +79,7 @@ describe("google antigravity multi-account refresh", () => {
     // First refresh token endpoint call, then quota endpoint call.
     const fetchSpy = vi.fn();
 
-    // First call: token refresh
+    // First call: token refresh for first account
     fetchSpy.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ access_token: "new_token", expires_in: 3600 }),
@@ -98,11 +98,23 @@ describe("google antigravity multi-account refresh", () => {
         }),
     });
 
+    // Third call: token refresh for Gemini CLI quota fetch
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ access_token: "new_token", expires_in: 3600 }),
+    });
+
+    // Fourth call: Gemini CLI retrieveUserQuota (best-effort, returns empty)
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ buckets: [] }),
+    });
+
     vi.stubGlobal("fetch", fetchSpy as any);
 
     const out = await queryGoogleQuota(["CLAUDE"] as any);
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(4);
     expect(fetchSpy.mock.calls[0][0]).toBe("https://oauth2.googleapis.com/token");
 
     expect(out).not.toBeNull();

--- a/tests/providers.google-antigravity.test.ts
+++ b/tests/providers.google-antigravity.test.ts
@@ -37,6 +37,8 @@ describe("google antigravity provider", () => {
     expect(out.entries).toEqual([
       {
         name: "Gemini 2.5 Pro (ali..gmail)",
+        group: "Gemini 2.5 Pro",
+        label: "Gemini 2.5 Pro:",
         percentRemaining: 64,
         resetTimeIso: "2026-01-01T00:00:00.000Z",
       },

--- a/tests/tui-sidebar-format.test.ts
+++ b/tests/tui-sidebar-format.test.ts
@@ -187,7 +187,7 @@ describe("buildSidebarQuotaPanelLines", () => {
     const rendered = lines.join("\n");
     expect(rendered).toContain("[Google Antigravity] (acct)");
     expect(rendered).toContain("\nClaude ");
-    expect(rendered).toContain("Quota window");
+    expect(rendered).toContain("\nGoogle Antigravity (acct)");
     expect(rendered).not.toContain("[Claude] (acct)");
     expect(rendered).not.toContain("[G3Pro] (acct)");
   });


### PR DESCRIPTION
## Summary

Applies user's local compiled patches back to TypeScript source for Antigravity v2 features.

## Changes

### Gemini CLI quota merging
- Add getRateLimitFamily() for local rate-limit override lookup
- Modify xtractModelQuotas to accept full account object and apply ateLimitResetTimes
- Add modelIdToGemini3Key / etchGeminiCliQuota / mergeGeminiCliQuota for the cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota endpoint
- queryGoogleQuota now fetches and merges CLI bucket data (lower % wins)

### Provider improvements
- Group Antigravity entries by displayName with explicit label and classicStrategy: "preserve"
- Normalize gpt-oss in Google model detection (grouped-entry-normalization.ts)
- Add Windows nvm/npm node_modules paths to companion resolution (google-antigravity-companion.ts)
- Extend GOOGLE_MODEL_KEYS with GPTOSS and add ltKey for G3PRO/G3FLASH/CLAUDE

### TypeScript types
- Add "GPTOSS" to GoogleModelId union and GOOGLE_MODEL_KEYS
- Add isValidGoogleModelId entry for "GPTOSS"
- Add classicStrategy?: "preserve" to QuotaProviderPresentation

### Tests updated
- providers.google-antigravity.test.ts: expect group/label fields in entries
- lib.google.multi-account-refresh.test.ts: expect 4 fetch calls
- ormat.test.ts/	ui-sidebar-format.test.ts: match group-based labels

Closes #118
