### PR TITLE
fix: guard against division by zero in cursor provider and deferred refresh race condition

### DIFF
--- a/src/lib/cursor-pricing.ts
+++ b/src/lib/cursor-pricing.ts
@@ -137,7 +137,7 @@ export function getEffectiveCursorIncludedApiUsd(params: {
   plan: CursorQuotaPlan;
   overrideUsd?: number;
 }): number | undefined {
-  if (typeof params.overrideUsd === "number" && Number.isFinite(params.overrideUsd) && params.overrideUsd > 0) {
+  if (typeof params.overrideUsd === "number" && Number.isFinite(params.overrideUsd) && params.overrideUsd >= 0) {
     return params.overrideUsd;
   }
   if (params.plan === "none") return undefined;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1308,7 +1308,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
       }
     } finally {
       const state = deferredQuotaRefreshes.get(sessionID);
-      if (state) {
+      if (state && state === pendingDeferred) {
         state.inFlight = false;
       }
     }

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -92,7 +92,7 @@ export const cursorProvider: QuotaProvider = {
               group,
               label: "API:",
               right: `${fmtUsdAmount(usage.api.costUsd)}/${fmtUsdAmount(includedApiUsd)}`,
-              percentRemaining: 100 - (usage.api.costUsd / includedApiUsd) * 100,
+              percentRemaining: includedApiUsd > 0 ? 100 - (usage.api.costUsd / includedApiUsd) * 100 : 0,
               resetTimeIso: usage.window.resetTimeIso,
             },
       );

--- a/tests/providers.cursor.test.ts
+++ b/tests/providers.cursor.test.ts
@@ -156,6 +156,27 @@ describe("cursor provider", () => {
     expect(out.errors[0]?.message).toContain("Unknown Cursor model ids");
   });
 
+  it("guards against division by zero when includedApiUsd override is zero", async () => {
+    const { getCurrentCursorUsageSummary } = await import("../src/lib/cursor-usage.js");
+    (getCurrentCursorUsageSummary as any).mockResolvedValue({
+      window: { resetTimeIso: "2026-03-01T00:00:00.000Z" },
+      api: { costUsd: 0, tokens: {}, messageCount: 1 },
+      autoComposer: { costUsd: 0, tokens: {}, messageCount: 0 },
+      total: { costUsd: 0, tokens: {}, messageCount: 1 },
+      unknownModels: [],
+    });
+
+    const out = await cursorProvider.fetch({
+      config: { cursorPlan: "pro", cursorIncludedApiUsd: 0 },
+    } as any);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries[0]).toMatchObject({
+      right: "$0.00/$0.00",
+      percentRemaining: 0,
+    });
+  });
+
   it("treats the current Cursor provider id as an availability signal", async () => {
     const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
     const { inspectCursorOpenCodeIntegration } = await import("../src/lib/cursor-detection.js");


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs identified during a code audit:

### 1. Division by zero in Cursor provider (`src/providers/cursor.ts`)

When `includedApiUsd` is `0`, the expression `usage.api.costUsd / includedApiUsd` produces `Infinity` or `NaN`, resulting in `-Infinity%` or `NaN%` displayed in the quota toast.

**Fix:** Added a guard `includedApiUsd > 0 ? ... : 0` to safely return `0` when the budget is zero.

Additionally, `getEffectiveCursorIncludedApiUsd` in `src/lib/cursor-pricing.ts` was rejecting `0` as a valid override (`> 0` instead of `>= 0`). This meant users could not explicitly set a zero API budget. Changed to `>= 0` so `0` is accepted as a valid override value.

### 2. Race condition in deferred quota refresh (`src/plugin.ts`)

In `showQuotaToast`, the `finally` block resets `state.inFlight = false` by looking up the state from the `deferredQuotaRefreshes` Map. However, during the `try` block, `reconcileDeferredQuotaRefresh` may clear the old state and schedule a new one — creating a **new** state object in the Map. The `finally` block would then find this new state and incorrectly set its `inFlight` to `false`, even though it was never set to `true` by the current invocation.

**Fix:** Added an identity check `state === pendingDeferred` in the `finally` block to ensure we only reset `inFlight` on the same state object that was marked at the start of the function.

### Test

Added a test case in `tests/providers.cursor.test.ts` that verifies the cursor provider correctly handles `cursorIncludedApiUsd: 0` without producing `NaN` or `Infinity`.

## Changes

| File | Change |
|------|--------|
| `src/providers/cursor.ts` | Guard `percentRemaining` against division by zero |
| `src/lib/cursor-pricing.ts` | Accept `0` as valid `overrideUsd` (`>= 0`) |
| `src/plugin.ts` | Identity check in `finally` to prevent race condition |
| `tests/providers.cursor.test.ts` | New test for zero-budget scenario |

## Verification

- `pnpm run typecheck` passes
- `pnpm run build` passes
- `pnpm test -- tests/providers.cursor.test.ts tests/lib.cursor-usage.test.ts` — all 14 tests pass
- Tested against OpenCode Go (current production version)