### PR TITLE
feat: implement Google Agy quota provider and companion auth integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | Chutes AI | API key/config | Remote API | Usage/quota |
 | Synthetic | Automatic | Remote API | Quota |
 | Google Antigravity | [Needs setup](#google-antigravity) | Remote API | Usage/quota |
+| Google AGY | [Needs setup](#google-agy-quick-setup) | Remote API | Usage/quota |
 | Gemini CLI | [Needs setup](#gemini-cli) | Remote API | Usage/quota |
 | Z.ai Coding Plan | OpenCode config | Remote API | Usage/quota |
 | Zhipu Coding Plan | OpenCode config | Remote API | Usage/quota |
@@ -476,6 +477,40 @@ Use companion plugin [`opencode-antigravity-auth`](https://github.com/NoeFabris/
 
 </details>
 
+<a id="google-agy-quick-setup"></a>
+<details>
+<summary><strong>Google AGY</strong></summary>
+
+Use companion plugin [`@anthonyhaussman/opencode-agy-auth`](https://www.npmjs.com/package/@anthonyhaussman/opencode-agy-auth). Add it before `@slkiser/opencode-quota` in `opencode.json`, then authenticate Google once:
+
+```bash
+opencode auth login --provider google-agy
+```
+
+If you use manual provider selection, include `google-agy` in `enabledProviders`.
+
+```jsonc
+{
+  "enabledProviders": ["google-agy"],
+}
+```
+
+If the AGY auth entry does not include a project id, set `OPENCODE_AGY_PROJECT_ID` or `provider.google-agy.options.projectId`.
+
+```jsonc
+{
+  "provider": {
+    "google-agy": {
+      "options": {
+        "projectId": "your-google-cloud-project"
+      }
+    }
+  }
+}
+```
+
+</details>
+
 <a id="gemini-cli"></a>
 <details>
 <summary><strong>Gemini CLI</strong></summary>
@@ -695,6 +730,21 @@ Run `/quota_status` and check the `google_antigravity` section.
 | Companion missing | Put `opencode-antigravity-auth` before `@slkiser/opencode-quota` in `opencode.json`. |
 | Accounts not found | Check the selected `antigravity-accounts.json` path shown by `/quota_status`. |
 | Refresh tokens invalid | Re-authenticate with the companion plugin. |
+| Provider returns no rows | Check `live_probe`, `live_entry_*`, and `live_error_*` in `/quota_status`. |
+
+</details>
+
+<details>
+<summary><strong>Google AGY</strong></summary>
+
+Run `/quota_status` and check the `google_agy` section.
+
+| Symptom | Fix |
+| --- | --- |
+| Companion missing | Put `@anthonyhaussman/opencode-agy-auth` before `@slkiser/opencode-quota` in `opencode.json`. |
+| Provider not enabled in manual mode | Include `google-agy` in `enabledProviders` in `opencode-quota/quota-toast.json`. |
+| Auth missing | Run `opencode auth login --provider google-agy`. |
+| Project missing | Set `OPENCODE_AGY_PROJECT_ID` or `provider.google-agy.options.projectId`. |
 | Provider returns no rows | Check `live_probe`, `live_entry_*`, and `live_error_*` in `/quota_status`. |
 
 </details>

--- a/src/lib/google-agy-companion.ts
+++ b/src/lib/google-agy-companion.ts
@@ -1,0 +1,391 @@
+import { readFile } from "fs/promises";
+import { readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
+
+const require = createRequire(import.meta.url);
+
+const COMPANION_PACKAGE_NAME = "@anthonyhaussman/opencode-agy-auth";
+const COMPANION_JS_IMPORT_SPECIFIERS = [
+  `${COMPANION_PACKAGE_NAME}/dist/src/constants.js`,
+  `${COMPANION_PACKAGE_NAME}/src/constants.js`,
+] as const;
+const COMPANION_SOURCE_IMPORT_SPECIFIER = `${COMPANION_PACKAGE_NAME}/src/constants.ts`;
+const COMPANION_PACKAGE_JSON_SPECIFIER = `${COMPANION_PACKAGE_NAME}/package.json`;
+const COMPANION_DIRECT_CANDIDATE_PATHS = [
+  ["src", "constants.ts"],
+  ["src", "constants.js"],
+  ["dist", "src", "constants.js"],
+  ["dist", "index.js"],
+] as const;
+const COMPANION_MISSING_ERROR = `Install ${COMPANION_PACKAGE_NAME} separately to enable Google Agy quota`;
+const COMPANION_INVALID_ERROR = `Installed ${COMPANION_PACKAGE_NAME} package is incompatible`;
+
+export type AgyCompanionPresence =
+  | {
+      state: "present";
+      importSpecifier: string;
+      resolvedPath: string;
+    }
+  | {
+      state: "missing";
+      importSpecifier: string;
+      error: string;
+    }
+  | {
+      state: "invalid";
+      importSpecifier: string;
+      error: string;
+      resolvedPath?: string;
+    };
+
+export type AgyConfiguredCredentials = {
+  state: "configured";
+  clientId: string;
+  clientSecret: string;
+  resolvedPath: string;
+};
+
+export type AgyClientCredentials =
+  | AgyConfiguredCredentials
+  | {
+      state: "missing" | "invalid";
+      error: string;
+      resolvedPath?: string;
+    };
+
+type ResolvedCompanionState = {
+  presence: AgyCompanionPresence;
+  credentials: AgyClientCredentials;
+};
+
+type CompanionModule = {
+  AGY_CLIENT_ID?: unknown;
+  AGY_CLIENT_SECRET?: unknown;
+};
+
+type CompanionResolutionContext = {
+  packageFound: boolean;
+};
+
+let resolvedCompanionStatePromise: Promise<ResolvedCompanionState> | null = null;
+
+function isModuleNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = "code" in error ? error.code : undefined;
+  if (code === "MODULE_NOT_FOUND") {
+    return true;
+  }
+
+  const message = error instanceof Error ? error.message : "";
+  return message.includes("Cannot find module");
+}
+
+function isPackagePathNotExportedError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  return "code" in error && error.code === "ERR_PACKAGE_PATH_NOT_EXPORTED";
+}
+
+function isFallthroughResolutionError(error: unknown): boolean {
+  return isModuleNotFoundError(error) || isPackagePathNotExportedError(error);
+}
+
+function normalizeCredential(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function getCompanionResolvePaths(): string[] {
+  const paths = [...getOpencodeRuntimeDirCandidates().cacheDirs];
+  return paths;
+}
+
+function getRuntimePackageRoots(): string[] {
+  const cacheDirs = getOpencodeRuntimeDirCandidates().cacheDirs;
+  const packageRoots = cacheDirs.map((cacheDir) =>
+    join(cacheDir, "node_modules", COMPANION_PACKAGE_NAME),
+  );
+
+  for (const cacheDir of cacheDirs) {
+    try {
+      const packagesDir = join(cacheDir, "packages");
+      if (COMPANION_PACKAGE_NAME.startsWith("@")) {
+        const [scope, name] = COMPANION_PACKAGE_NAME.split("/");
+        const scopeDir = join(packagesDir, scope);
+        const entries = readdirSync(scopeDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && entry.name.startsWith(name)) {
+            const packagePath = join(scopeDir, entry.name);
+            packageRoots.push(packagePath);
+            packageRoots.push(join(packagePath, "node_modules", COMPANION_PACKAGE_NAME));
+          }
+        }
+      } else {
+        const entries = readdirSync(packagesDir, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory() && entry.name.startsWith(COMPANION_PACKAGE_NAME)) {
+            packageRoots.push(join(packagesDir, entry.name));
+            packageRoots.push(join(packagesDir, entry.name, "node_modules", COMPANION_PACKAGE_NAME));
+          }
+        }
+      }
+    } catch {
+      // Ignore if packages dir doesn't exist
+    }
+  }
+
+  return packageRoots;
+}
+
+function markPackageFoundForExportBlock(error: unknown, context: CompanionResolutionContext): void {
+  if (isPackagePathNotExportedError(error)) {
+    context.packageFound = true;
+  }
+}
+
+function resolveCompanionSpecifier(specifier: string, context: CompanionResolutionContext): string {
+  try {
+    return require.resolve(specifier);
+  } catch (error) {
+    markPackageFoundForExportBlock(error, context);
+    if (!isFallthroughResolutionError(error)) {
+      throw error;
+    }
+
+    try {
+      return require.resolve(specifier, { paths: getCompanionResolvePaths() });
+    } catch (resolvePathsError) {
+      markPackageFoundForExportBlock(resolvePathsError, context);
+      throw resolvePathsError;
+    }
+  }
+}
+
+function buildConfiguredState(params: {
+  importSpecifier: string;
+  resolvedPath: string;
+  clientId: string;
+  clientSecret: string;
+}): ResolvedCompanionState {
+  return {
+    presence: {
+      state: "present",
+      importSpecifier: params.importSpecifier,
+      resolvedPath: params.resolvedPath,
+    },
+    credentials: {
+      state: "configured",
+      clientId: params.clientId,
+      clientSecret: params.clientSecret,
+      resolvedPath: params.resolvedPath,
+    },
+  };
+}
+
+function buildInvalidState(importSpecifier: string, resolvedPath?: string): ResolvedCompanionState {
+  return {
+    presence: {
+      state: "invalid",
+      importSpecifier,
+      ...(resolvedPath ? { resolvedPath } : {}),
+      error: COMPANION_INVALID_ERROR,
+    },
+    credentials: {
+      state: "invalid",
+      ...(resolvedPath ? { resolvedPath } : {}),
+      error: COMPANION_INVALID_ERROR,
+    },
+  };
+}
+
+function parseSourceCredentials(
+  content: string,
+): { clientId: string; clientSecret: string } | null {
+  const clientId =
+    content
+      .match(/(?:export\s+const|const|var)\s+AGY_CLIENT_ID\s*=\s*["']([^"']+)["']/)?.[1]
+      ?.trim() ?? "";
+  const clientSecret =
+    content
+      .match(/(?:export\s+const|const|var)\s+AGY_CLIENT_SECRET\s*=\s*["']([^"']+)["']/)?.[1]
+      ?.trim() ?? "";
+
+  return clientId && clientSecret ? { clientId, clientSecret } : null;
+}
+
+function getPackageCredentialPaths(packageRoot: string): string[] {
+  return COMPANION_DIRECT_CANDIDATE_PATHS.map((parts) => join(packageRoot, ...parts));
+}
+
+function getRuntimeSourceConstantPaths(): string[] {
+  return getRuntimePackageRoots().flatMap((packageRoot) => getPackageCredentialPaths(packageRoot));
+}
+
+async function tryReadSourceConstantsPath(
+  resolvedPath: string,
+): Promise<ResolvedCompanionState | null> {
+  try {
+    const content = await readFile(resolvedPath, "utf8");
+    const credentials = parseSourceCredentials(content);
+    if (!credentials) {
+      return buildInvalidState(COMPANION_SOURCE_IMPORT_SPECIFIER, resolvedPath);
+    }
+    return buildConfiguredState({
+      importSpecifier: COMPANION_SOURCE_IMPORT_SPECIFIER,
+      resolvedPath,
+      clientId: credentials.clientId,
+      clientSecret: credentials.clientSecret,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function tryResolveJsConstants(
+  importSpecifier: string,
+  context: CompanionResolutionContext,
+): Promise<ResolvedCompanionState | null> {
+  let resolvedPath: string;
+  try {
+    resolvedPath = resolveCompanionSpecifier(importSpecifier, context);
+  } catch (error) {
+    if (isFallthroughResolutionError(error)) {
+      return null;
+    }
+    return buildInvalidState(importSpecifier);
+  }
+
+  let companionModule: CompanionModule;
+  try {
+    companionModule = (await import(pathToFileURL(resolvedPath).href)) as CompanionModule;
+  } catch {
+    return buildInvalidState(importSpecifier, resolvedPath);
+  }
+
+  const clientId = normalizeCredential(companionModule.AGY_CLIENT_ID);
+  const clientSecret = normalizeCredential(companionModule.AGY_CLIENT_SECRET);
+  if (!clientId || !clientSecret) {
+    return buildInvalidState(importSpecifier, resolvedPath);
+  }
+
+  return buildConfiguredState({ importSpecifier, resolvedPath, clientId, clientSecret });
+}
+
+async function tryResolvePackageEntry(
+  context: CompanionResolutionContext,
+): Promise<ResolvedCompanionState | null> {
+  try {
+    const packageEntryPath = resolveCompanionSpecifier(COMPANION_PACKAGE_NAME, context);
+    const packageEntryResolved = await tryReadSourceConstantsPath(packageEntryPath);
+    return packageEntryResolved ?? buildInvalidState(COMPANION_PACKAGE_NAME, packageEntryPath);
+  } catch (error) {
+    return isFallthroughResolutionError(error) ? null : buildInvalidState(COMPANION_PACKAGE_NAME);
+  }
+}
+
+async function tryResolveSourceConstants(
+  context: CompanionResolutionContext,
+): Promise<ResolvedCompanionState | null> {
+  let resolvedPath: string;
+  try {
+    resolvedPath = require.resolve(COMPANION_SOURCE_IMPORT_SPECIFIER);
+  } catch (error) {
+    if (!isFallthroughResolutionError(error)) {
+      return buildInvalidState(COMPANION_SOURCE_IMPORT_SPECIFIER);
+    }
+
+    for (const candidatePath of getRuntimeSourceConstantPaths()) {
+      const runtimeResolved = await tryReadSourceConstantsPath(candidatePath);
+      if (runtimeResolved) {
+        return runtimeResolved;
+      }
+    }
+
+    try {
+      const packageJsonPath = resolveCompanionSpecifier(COMPANION_PACKAGE_JSON_SPECIFIER, context);
+      const packageRoot = dirname(packageJsonPath);
+      for (const candidatePath of [
+        join(packageRoot, "src", "constants.ts"),
+        join(packageRoot, "dist", "index.js"),
+      ]) {
+        const packageResolved = await tryReadSourceConstantsPath(candidatePath);
+        if (packageResolved) {
+          return packageResolved;
+        }
+      }
+      resolvedPath = join(packageRoot, "src", "constants.ts");
+    } catch (packageError) {
+      if (isFallthroughResolutionError(packageError)) {
+        return tryResolvePackageEntry(context);
+      }
+
+      return buildInvalidState(COMPANION_SOURCE_IMPORT_SPECIFIER);
+    }
+  }
+
+  return (
+    (await tryReadSourceConstantsPath(resolvedPath)) ??
+    buildInvalidState(COMPANION_SOURCE_IMPORT_SPECIFIER, resolvedPath)
+  );
+}
+
+async function resolveCompanionState(): Promise<ResolvedCompanionState> {
+  const context: CompanionResolutionContext = { packageFound: false };
+
+  for (const importSpecifier of COMPANION_JS_IMPORT_SPECIFIERS) {
+    const resolved = await tryResolveJsConstants(importSpecifier, context);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  const sourceResolved = await tryResolveSourceConstants(context);
+  if (sourceResolved) {
+    return sourceResolved;
+  }
+
+  if (context.packageFound) {
+    return buildInvalidState(COMPANION_PACKAGE_NAME);
+  }
+
+  return {
+    presence: {
+      state: "missing",
+      importSpecifier: COMPANION_SOURCE_IMPORT_SPECIFIER,
+      error: COMPANION_MISSING_ERROR,
+    },
+    credentials: {
+      state: "missing",
+      error: COMPANION_MISSING_ERROR,
+    },
+  };
+}
+
+async function getResolvedCompanionState(): Promise<ResolvedCompanionState> {
+  if (!resolvedCompanionStatePromise) {
+    resolvedCompanionStatePromise = resolveCompanionState();
+  }
+  return resolvedCompanionStatePromise;
+}
+
+export async function inspectAgyCompanionPresence(): Promise<AgyCompanionPresence> {
+  const resolved = await getResolvedCompanionState();
+  return resolved.presence;
+}
+
+export async function resolveAgyClientCredentials(): Promise<AgyClientCredentials> {
+  const resolved = await getResolvedCompanionState();
+  return resolved.credentials;
+}
+
+export function clearAgyCompanionCacheForTests(): void {
+  resolvedCompanionStatePromise = null;
+}

--- a/src/lib/google-agy-companion.ts
+++ b/src/lib/google-agy-companion.ts
@@ -21,7 +21,7 @@ const COMPANION_DIRECT_CANDIDATE_PATHS = [
   ["dist", "src", "constants.js"],
   ["dist", "index.js"],
 ] as const;
-const COMPANION_MISSING_ERROR = `Install ${COMPANION_PACKAGE_NAME} separately to enable Google Agy quota`;
+const COMPANION_MISSING_ERROR = `Install ${COMPANION_PACKAGE_NAME} separately to enable Google AGY quota`;
 const COMPANION_INVALID_ERROR = `Installed ${COMPANION_PACKAGE_NAME} package is incompatible`;
 
 export type AgyCompanionPresence =

--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { readAuthFileCached } from "./opencode-auth.js";
 import { fetchWithTimeout } from "./http.js";
 import {
@@ -35,7 +36,11 @@ const AGY_TOKEN_REFRESH_URL = "https://oauth2.googleapis.com/token";
 const AGY_TOKEN_TIMEOUT_MS = 8_000;
 const AGY_QUOTA_TIMEOUT_MS = 6_000;
 const AGY_ACCOUNTS_CONCURRENCY = 3;
-const AGY_USER_AGENT = `AgyCLI/opencode-quota (${process.platform}; ${process.arch})`;
+const AGY_USER_AGENT = "antigravity/cli/1.0.3 darwin/amd64";
+
+function createAgyActivityRequestId(): string {
+  return crypto.randomUUID();
+}
 
 type RefreshParts = {
   refreshToken: string;
@@ -131,12 +136,12 @@ export function resolveAgyAccounts(
     }
 
     const projectId =
-      normalizeString(entry.projectId) ??
-      normalizeString(entry.projectID) ??
       normalizeString(entry.managedProjectId) ??
       normalizeString(entry.quotaProjectId) ??
-      parts.projectId ??
       parts.managedProjectId ??
+      normalizeString(entry.projectId) ??
+      normalizeString(entry.projectID) ??
+      parts.projectId ??
       normalizeString(configuredProjectId);
 
     if (!projectId) {
@@ -384,6 +389,7 @@ async function retrieveGoogleAgyQuota(
         "Content-Type": "application/json",
         Authorization: `Bearer ${accessToken}`,
         "User-Agent": AGY_USER_AGENT,
+        "x-activity-request-id": createAgyActivityRequestId(),
       },
       body: JSON.stringify({ project: projectId }),
     },
@@ -403,6 +409,26 @@ async function retrieveGoogleAgyQuota(
 export function formatDisplayName(modelId: string): string {
   // Replace all underscores with hyphens
   let cleaned = modelId.replace(/_/g, "-").trim();
+
+  // Special cases for well-known prefixes
+  if (cleaned.toLowerCase().startsWith("claude-")) {
+    // Handle versions like claude-3-5-sonnet -> Claude 3.5 Sonnet
+    return cleaned
+      .split("-")
+      .map((part, i) => {
+        if (i === 0) return "Claude";
+        if (/^\d+$/.test(part) && /^\d+$/.test(cleaned.split("-")[i + 1] || "")) {
+          return part + "." + cleaned.split("-")[i + 1];
+        }
+        if (/^\d+$/.test(part) && /^\d+$/.test(cleaned.split("-")[i - 1] || "")) {
+          return ""; // Skip second part of version
+        }
+        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+      })
+      .filter(Boolean)
+      .join(" ");
+  }
+
   // Replace gpt-oss (case-insensitive) with a temporary placeholder
   cleaned = cleaned.replace(/gpt-oss/gi, "GPT_OSS");
   // Replace digit-digit with digit.digit (e.g. 4-6 to 4.6)
@@ -463,10 +489,19 @@ function mapQuotaBuckets(
     .map((bucket) => {
       const modelId = normalizeString(bucket.modelId)!;
       const remainingFraction = bucket.remainingFraction;
-      const percentRemaining =
-        typeof remainingFraction === "number" && Number.isFinite(remainingFraction)
-          ? Math.round(remainingFraction * 100)
-          : 0;
+
+      let percentRemaining: number;
+      if (typeof remainingFraction === "number" && Number.isFinite(remainingFraction)) {
+        percentRemaining = Math.round(remainingFraction * 100);
+      } else if (
+        normalizeString(bucket.remainingAmount) &&
+        bucket.remainingAmount?.toLowerCase().includes("unlimited")
+      ) {
+        percentRemaining = 100;
+      } else {
+        percentRemaining = 0;
+      }
+
       return {
         modelId,
         displayName: formatDisplayName(modelId),

--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -1,0 +1,609 @@
+import { readAuthFileCached } from "./opencode-auth.js";
+import { fetchWithTimeout } from "./http.js";
+import {
+  getCachedAccessToken,
+  makeAccountCacheKey,
+  setCachedAccessToken,
+} from "./google-token-cache.js";
+import {
+  clearAgyCompanionCacheForTests,
+  inspectAgyCompanionPresence,
+  resolveAgyClientCredentials,
+  type AgyConfiguredCredentials,
+} from "./google-agy-companion.js";
+import type {
+  AuthData,
+  GoogleAgyAuthSourceKey,
+  GoogleAgyQuotaBucket,
+  GoogleAgyResult,
+  GoogleAccountError,
+  GeminiCliOAuthAuthData,
+} from "./types.js";
+
+export const DEFAULT_AGY_AUTH_CACHE_MAX_AGE_MS = 5_000;
+
+export const AGY_AUTH_KEYS = [
+  "google-agy",
+  "opencode-agy-auth",
+  "google-agy-auth",
+] as const satisfies readonly GoogleAgyAuthSourceKey[];
+
+const AGY_CODE_ASSIST_ENDPOINT =
+  process.env.OPENCODE_AGY_ENDPOINT || "https://daily-cloudcode-pa.googleapis.com";
+const AGY_QUOTA_API_URL = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal:retrieveUserQuota`;
+const AGY_TOKEN_REFRESH_URL = "https://oauth2.googleapis.com/token";
+const AGY_TOKEN_TIMEOUT_MS = 8_000;
+const AGY_QUOTA_TIMEOUT_MS = 6_000;
+const AGY_ACCOUNTS_CONCURRENCY = 3;
+const AGY_USER_AGENT = `AgyCLI/opencode-quota (${process.platform}; ${process.arch})`;
+
+type RefreshParts = {
+  refreshToken: string;
+  projectId?: string;
+  managedProjectId?: string;
+};
+
+export type AgyAccount = {
+  sourceKey: GoogleAgyAuthSourceKey;
+  refreshToken: string;
+  projectId: string;
+  email?: string;
+  accessToken?: string;
+  expiresAt?: number;
+};
+
+export type AgyAuthPresence =
+  | {
+      state: "missing";
+      sourceKey?: undefined;
+      accountCount: 0;
+      validAccountCount: 0;
+    }
+  | {
+      state: "present";
+      sourceKey: GoogleAgyAuthSourceKey;
+      accountCount: number;
+      validAccountCount: number;
+    }
+  | {
+      state: "invalid";
+      sourceKey?: GoogleAgyAuthSourceKey;
+      accountCount: number;
+      validAccountCount: number;
+      error: string;
+    };
+
+type RetrieveUserQuotaBucket = {
+  remainingAmount?: string;
+  remainingFraction?: number;
+  resetTime?: string;
+  tokenType?: string;
+  modelId?: string;
+};
+
+type RetrieveUserQuotaResponse = {
+  buckets?: RetrieveUserQuotaBucket[];
+};
+
+type ConfigClient = {
+  config?: {
+    get?: () => Promise<{ data?: unknown }>;
+  };
+};
+
+function normalizeString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+export function parseAgyRefreshParts(refresh: string | undefined): RefreshParts {
+  const [refreshToken = "", projectId = "", managedProjectId = ""] = (refresh ?? "").split("|");
+  return {
+    refreshToken: refreshToken.trim(),
+    ...(normalizeString(projectId) ? { projectId: projectId.trim() } : {}),
+    ...(normalizeString(managedProjectId) ? { managedProjectId: managedProjectId.trim() } : {}),
+  };
+}
+
+export function resolveAgyAccounts(
+  auth: AuthData | null | undefined,
+  configuredProjectId?: string,
+): AgyAccount[] {
+  if (!auth) {
+    return [];
+  }
+
+  const accounts: AgyAccount[] = [];
+  const seen = new Set<string>();
+
+  for (const sourceKey of AGY_AUTH_KEYS) {
+    const entry = auth[sourceKey] as GeminiCliOAuthAuthData | undefined;
+    if (!entry || entry.type !== "oauth") {
+      continue;
+    }
+
+    const parts = parseAgyRefreshParts(entry.refresh);
+    if (!parts.refreshToken) {
+      continue;
+    }
+
+    const projectId =
+      normalizeString(entry.projectId) ??
+      normalizeString(entry.projectID) ??
+      normalizeString(entry.managedProjectId) ??
+      normalizeString(entry.quotaProjectId) ??
+      parts.projectId ??
+      parts.managedProjectId ??
+      normalizeString(configuredProjectId);
+
+    if (!projectId) {
+      continue;
+    }
+
+    const email =
+      normalizeString(entry.email) ??
+      normalizeString(entry.accountEmail) ??
+      normalizeString(entry.login);
+
+    const key = `${parts.refreshToken}\n${projectId}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    accounts.push({
+      sourceKey,
+      refreshToken: parts.refreshToken,
+      projectId,
+      ...(email ? { email } : {}),
+      ...(normalizeString(entry.access) ? { accessToken: entry.access!.trim() } : {}),
+      ...(typeof entry.expires === "number" ? { expiresAt: entry.expires } : {}),
+    });
+  }
+
+  return accounts;
+}
+
+export async function resolveAgyConfiguredProjectId(
+  client?: ConfigClient,
+): Promise<string | undefined> {
+  const explicitEnvProjectId = normalizeString(process.env.OPENCODE_AGY_PROJECT_ID);
+  if (explicitEnvProjectId) {
+    return explicitEnvProjectId;
+  }
+
+  if (client?.config?.get) {
+    try {
+      const result = await client.config.get();
+      const data = result?.data as { provider?: Record<string, { options?: Record<string, unknown> }> };
+      const configProjectId = normalizeString(data?.provider?.["google-agy"]?.options?.projectId);
+      if (configProjectId) {
+        return configProjectId;
+      }
+    } catch {
+      // ignore and fall back
+    }
+  }
+
+  return (
+    normalizeString(process.env.GOOGLE_CLOUD_PROJECT) ??
+    normalizeString(process.env.GOOGLE_CLOUD_PROJECT_ID)
+  );
+}
+
+export async function inspectAgyAuthPresence(client?: ConfigClient): Promise<AgyAuthPresence> {
+  const [auth, configuredProjectId] = await Promise.all([
+    readAuthFileCached({ maxAgeMs: DEFAULT_AGY_AUTH_CACHE_MAX_AGE_MS }),
+    resolveAgyConfiguredProjectId(client),
+  ]);
+
+  let accountCount = 0;
+  if (auth) {
+    for (const sourceKey of AGY_AUTH_KEYS) {
+      const entry = auth[sourceKey];
+      if (entry && entry.type === "oauth") {
+        accountCount++;
+      }
+    }
+  }
+
+  if (accountCount === 0) {
+    return { state: "missing", accountCount: 0, validAccountCount: 0 };
+  }
+
+  const accounts = resolveAgyAccounts(auth, configuredProjectId);
+  const sourceKey = accounts[0]?.sourceKey ?? AGY_AUTH_KEYS.find((key) => auth?.[key]?.type === "oauth");
+
+  if (accounts.length === 0) {
+    return {
+      state: "invalid",
+      ...(sourceKey ? { sourceKey } : {}),
+      accountCount,
+      validAccountCount: 0,
+      error: "Google Agy OAuth auth is missing a refresh token or project id",
+    };
+  }
+
+  return {
+    state: "present",
+    sourceKey: accounts[0]!.sourceKey,
+    accountCount,
+    validAccountCount: accounts.length,
+  };
+}
+
+export async function hasAgyQuotaRuntimeAvailable(client?: ConfigClient): Promise<boolean> {
+  const [authPresence, companionPresence] = await Promise.all([
+    inspectAgyAuthPresence(client),
+    inspectAgyCompanionPresence(),
+  ]);
+
+  return (
+    authPresence.state === "present" &&
+    authPresence.validAccountCount > 0 &&
+    companionPresence.state === "present"
+  );
+}
+
+async function mapWithConcurrency<T, R>(params: {
+  items: T[];
+  concurrency: number;
+  fn: (item: T, index: number) => Promise<R>;
+}): Promise<R[]> {
+  const n = Math.max(1, Math.trunc(params.concurrency));
+  const results = new Array<R>(params.items.length);
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: Math.min(n, params.items.length) }, async () => {
+    while (true) {
+      const idx = nextIndex++;
+      if (idx >= params.items.length) return;
+      results[idx] = await params.fn(params.items[idx]!, idx);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+async function refreshAccessToken(params: {
+  refreshToken: string;
+  clientId: string;
+  clientSecret: string;
+  timeoutMs?: number;
+}): Promise<{ accessToken: string; expiresIn: number } | { error: string }> {
+  try {
+    const response = await fetchWithTimeout(
+      AGY_TOKEN_REFRESH_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          client_id: params.clientId,
+          client_secret: params.clientSecret,
+          refresh_token: params.refreshToken,
+          grant_type: "refresh_token",
+        }),
+      },
+      params.timeoutMs ?? AGY_TOKEN_TIMEOUT_MS,
+    );
+
+    if (!response.ok) {
+      try {
+        const errorData = (await response.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        if (errorData.error === "invalid_grant") {
+          return { error: "Token revoked" };
+        }
+        return { error: errorData.error_description || `HTTP ${response.status}` };
+      } catch {
+        return { error: `HTTP ${response.status}` };
+      }
+    }
+
+    const data = (await response.json()) as {
+      access_token: string;
+      expires_in: number;
+    };
+
+    return {
+      accessToken: data.access_token,
+      expiresIn: data.expires_in,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("timeout")) {
+      return { error: "Token refresh timeout" };
+    }
+    return { error: "Token refresh failed" };
+  }
+}
+
+async function refreshAgyAccessTokenWithCache(params: {
+  account: AgyAccount;
+  credentials: AgyConfiguredCredentials;
+  skewMs?: number;
+  force?: boolean;
+  timeoutMs?: number;
+}): Promise<{ accessToken: string } | { error: string }> {
+  const skewMs = params.skewMs ?? 2 * 60_000;
+  const key = makeAccountCacheKey({
+    refreshToken: params.account.refreshToken,
+    projectId: params.account.projectId,
+    email: params.account.email,
+  });
+
+  if (!params.force) {
+    const cached = await getCachedAccessToken({ key, skewMs });
+    if (cached) return { accessToken: cached.accessToken };
+
+    if (
+      params.account.accessToken &&
+      typeof params.account.expiresAt === "number" &&
+      params.account.expiresAt > Date.now() + skewMs
+    ) {
+      return { accessToken: params.account.accessToken };
+    }
+  }
+
+  const refreshed = await refreshAccessToken({
+    refreshToken: params.account.refreshToken,
+    clientId: params.credentials.clientId,
+    clientSecret: params.credentials.clientSecret,
+    timeoutMs: params.timeoutMs,
+  });
+  if ("error" in refreshed) return refreshed;
+
+  await setCachedAccessToken({
+    key,
+    entry: {
+      accessToken: refreshed.accessToken,
+      expiresAt: Date.now() + Math.max(1, refreshed.expiresIn) * 1000,
+      projectId: params.account.projectId,
+      email: params.account.email,
+    },
+  });
+
+  return { accessToken: refreshed.accessToken };
+}
+
+async function retrieveGoogleAgyQuota(
+  accessToken: string,
+  projectId: string,
+  timeoutMs: number = AGY_QUOTA_TIMEOUT_MS,
+): Promise<RetrieveUserQuotaResponse> {
+  const response = await fetchWithTimeout(
+    AGY_QUOTA_API_URL,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+        "User-Agent": AGY_USER_AGENT,
+      },
+      body: JSON.stringify({ project: projectId }),
+    },
+    timeoutMs,
+  );
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error(`Google Agy quota auth error: ${response.status}`);
+    }
+    throw new Error(`Google Agy quota API error: ${response.status}`);
+  }
+
+  return response.json() as Promise<RetrieveUserQuotaResponse>;
+}
+
+export function formatDisplayName(modelId: string): string {
+  // Replace all underscores with hyphens
+  let cleaned = modelId.replace(/_/g, "-").trim();
+  // Replace gpt-oss (case-insensitive) with a temporary placeholder
+  cleaned = cleaned.replace(/gpt-oss/gi, "GPT_OSS");
+  // Replace digit-digit with digit.digit (e.g. 4-6 to 4.6)
+  cleaned = cleaned.replace(/(\d+)-(\d+)/g, "$1.$2");
+
+  let suffix = "";
+  if (cleaned.toLowerCase().endsWith("-medium")) {
+    suffix = " (Medium)";
+    cleaned = cleaned.slice(0, -7);
+  } else if (cleaned.toLowerCase().endsWith("-large")) {
+    suffix = " (Large)";
+    cleaned = cleaned.slice(0, -6);
+  }
+
+  const parts = cleaned.split("-").filter(Boolean);
+  const formattedParts = parts.map((part) => {
+    if (part === "GPT_OSS") {
+      return "GPT-OSS";
+    }
+    const lower = part.toLowerCase();
+    if (lower === "gpt") return "GPT";
+    if (lower === "oss") return "OSS";
+    // If it's a size like 120b, capitalize it to 120B
+    if (/^\d+[a-zA-Z]+$/.test(part)) {
+      return part.toUpperCase();
+    }
+    // If it's a version number like 3.5 or 4.6, keep as-is
+    if (/^[0-9]+(?:\.[0-9]+)*$/.test(part)) {
+      return part;
+    }
+    return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
+  });
+
+  return formattedParts.join(" ") + suffix;
+}
+
+function aggregateAgyBuckets(buckets: GoogleAgyQuotaBucket[]): GoogleAgyQuotaBucket[] {
+  const grouped = new Map<string, GoogleAgyQuotaBucket>();
+  for (const bucket of buckets) {
+    const existing = grouped.get(bucket.modelId);
+    if (!existing || bucket.percentRemaining < existing.percentRemaining) {
+      grouped.set(bucket.modelId, bucket);
+    }
+  }
+  return Array.from(grouped.values());
+}
+
+function mapQuotaBuckets(
+  buckets: RetrieveUserQuotaBucket[] | undefined,
+  account: AgyAccount,
+): GoogleAgyQuotaBucket[] {
+  if (!buckets) {
+    return [];
+  }
+
+  const normalizedBuckets = buckets
+    .filter((bucket) => normalizeString(bucket.modelId))
+    .map((bucket) => {
+      const modelId = normalizeString(bucket.modelId)!;
+      const remainingFraction = bucket.remainingFraction;
+      const percentRemaining =
+        typeof remainingFraction === "number" && Number.isFinite(remainingFraction)
+          ? Math.round(remainingFraction * 100)
+          : 0;
+      return {
+        modelId,
+        displayName: formatDisplayName(modelId),
+        percentRemaining,
+        ...(normalizeString(bucket.resetTime) ? { resetTimeIso: bucket.resetTime!.trim() } : {}),
+        ...(normalizeString(bucket.remainingAmount)
+          ? { remainingAmount: bucket.remainingAmount!.trim() }
+          : {}),
+        ...(normalizeString(bucket.tokenType) ? { tokenType: bucket.tokenType!.trim() } : {}),
+        ...(account.email ? { accountEmail: account.email } : {}),
+        sourceKey: account.sourceKey,
+      };
+    });
+
+  return aggregateAgyBuckets(normalizedBuckets);
+}
+
+async function fetchAccountQuota(params: {
+  account: AgyAccount;
+  credentials: AgyConfiguredCredentials;
+  timeoutMs?: number;
+}): Promise<{
+  success: boolean;
+  buckets?: GoogleAgyQuotaBucket[];
+  error?: string;
+  accountEmail?: string;
+}> {
+  const accountEmail = params.account.email || params.account.sourceKey;
+
+  try {
+    const tokenResult = await refreshAgyAccessTokenWithCache({
+      account: params.account,
+      credentials: params.credentials,
+      timeoutMs: params.timeoutMs,
+    });
+    if ("error" in tokenResult) {
+      return { success: false, error: tokenResult.error, accountEmail };
+    }
+
+    let quota: RetrieveUserQuotaResponse;
+    try {
+      quota = await retrieveGoogleAgyQuota(
+        tokenResult.accessToken,
+        params.account.projectId,
+        params.timeoutMs,
+      );
+    } catch (err) {
+      if (err instanceof Error && err.message.includes("auth error")) {
+        const retryToken = await refreshAgyAccessTokenWithCache({
+          account: params.account,
+          credentials: params.credentials,
+          force: true,
+          timeoutMs: params.timeoutMs,
+        });
+        if ("error" in retryToken) {
+          return { success: false, error: retryToken.error, accountEmail };
+        }
+        quota = await retrieveGoogleAgyQuota(
+          retryToken.accessToken,
+          params.account.projectId,
+          params.timeoutMs,
+        );
+      } else {
+        throw err;
+      }
+    }
+
+    return {
+      success: true,
+      buckets: mapQuotaBuckets(quota.buckets, params.account),
+      accountEmail,
+    };
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("timeout")) {
+      return { success: false, error: "API timeout", accountEmail };
+    }
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+      accountEmail,
+    };
+  }
+}
+
+export async function queryGoogleAgyQuota(
+  client?: ConfigClient,
+  options: { requestTimeoutMs?: number } = {},
+): Promise<GoogleAgyResult> {
+  const [auth, configuredProjectId] = await Promise.all([
+    readAuthFileCached({ maxAgeMs: DEFAULT_AGY_AUTH_CACHE_MAX_AGE_MS }),
+    resolveAgyConfiguredProjectId(client),
+  ]);
+  const accounts = resolveAgyAccounts(auth, configuredProjectId);
+  if (accounts.length === 0) {
+    return null;
+  }
+
+  const credentials = await resolveAgyClientCredentials();
+  if (credentials.state !== "configured") {
+    return {
+      success: false,
+      error: credentials.error || "Google Agy companion auth plugin not found",
+    };
+  }
+
+  const results = await mapWithConcurrency({
+    items: accounts,
+    concurrency: AGY_ACCOUNTS_CONCURRENCY,
+    fn: async (account) =>
+      fetchAccountQuota({ account, credentials, timeoutMs: options.requestTimeoutMs }),
+  });
+
+  const allBuckets: GoogleAgyQuotaBucket[] = [];
+  const errors: GoogleAccountError[] = [];
+
+  for (const result of results) {
+    if (result.success && result.buckets && result.buckets.length > 0) {
+      allBuckets.push(...result.buckets);
+    } else if (!result.success && result.error && result.accountEmail) {
+      errors.push({ email: result.accountEmail, error: result.error });
+    }
+  }
+
+  if (allBuckets.length === 0 && errors.length === 0) {
+    return {
+      success: false,
+      error: "No Google Agy quota data available",
+    };
+  }
+
+  return {
+    success: true,
+    buckets: allBuckets,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+export function clearAgyRuntimeCacheForTests(): void {
+  clearAgyCompanionCacheForTests();
+}

--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -228,7 +228,7 @@ export async function inspectAgyAuthPresence(client?: ConfigClient): Promise<Agy
       ...(sourceKey ? { sourceKey } : {}),
       accountCount,
       validAccountCount: 0,
-      error: "Google Agy OAuth auth is missing a refresh token or project id",
+      error: "Google AGY OAuth auth is missing a refresh token or project id",
     };
   }
 
@@ -398,9 +398,9 @@ async function retrieveGoogleAgyQuota(
 
   if (!response.ok) {
     if (response.status === 401 || response.status === 403) {
-      throw new Error(`Google Agy quota auth error: ${response.status}`);
+      throw new Error(`Google AGY quota auth error: ${response.status}`);
     }
-    throw new Error(`Google Agy quota API error: ${response.status}`);
+    throw new Error(`Google AGY quota API error: ${response.status}`);
   }
 
   return response.json() as Promise<RetrieveUserQuotaResponse>;
@@ -603,7 +603,7 @@ export async function queryGoogleAgyQuota(
   if (credentials.state !== "configured") {
     return {
       success: false,
-      error: credentials.error || "Google Agy companion auth plugin not found",
+      error: credentials.error || "Google AGY companion auth plugin not found",
     };
   }
 
@@ -628,7 +628,7 @@ export async function queryGoogleAgyQuota(
   if (allBuckets.length === 0 && errors.length === 0) {
     return {
       success: false,
-      error: "No Google Agy quota data available",
+      error: "No Google AGY quota data available",
     };
   }
 

--- a/src/lib/google-gemini-cli.ts
+++ b/src/lib/google-gemini-cli.ts
@@ -126,12 +126,12 @@ function resolveProjectId(
   configuredProjectId?: string,
 ): string | undefined {
   return (
-    normalizeString(entry.projectId) ??
-    normalizeString(entry.projectID) ??
     normalizeString(entry.managedProjectId) ??
     normalizeString(entry.quotaProjectId) ??
-    parts.projectId ??
     parts.managedProjectId ??
+    normalizeString(entry.projectId) ??
+    normalizeString(entry.projectID) ??
+    parts.projectId ??
     normalizeString(configuredProjectId)
   );
 }

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -498,7 +498,7 @@ function extractModelQuotas(
  * Fetch quota for a single account
  */
 function getProjectId(account: AntigravityAccount): string | undefined {
-  return account.projectId || account.projectID || account.managedProjectId;
+  return account.managedProjectId || (account as any).quotaProjectId || account.projectId || account.projectID;
 }
 
 // NOTE: This plugin treats Google Antigravity as truly multi-account.

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -9,6 +9,7 @@ export type CanonicalQuotaProviderId =
   | "chutes"
   | "google-antigravity"
   | "google-gemini-cli"
+  | "google-agy"
   | "zai"
   | "zhipu"
   | "nanogpt"
@@ -56,6 +57,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   copilot: "Copilot",
   "google-antigravity": "Google",
   "google-gemini-cli": "Gemini CLI",
+  "google-agy": "Google Agy",
   synthetic: "Synthetic",
   chutes: "Chutes",
   cursor: "Cursor",
@@ -99,6 +101,8 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   "google-gemini": "google-gemini-cli",
   "opencode-gemini-auth": "google-gemini-cli",
   gemini: "google-gemini-cli",
+  "opencode-agy-auth": "google-agy",
+  "google-agy-auth": "google-agy",
   "glm-coding-plan": "zhipu",
   "zhipu-coding-plan": "zhipu",
   "zhipuai-coding-plan": "zhipu",
@@ -120,6 +124,11 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
     "gemini",
     "opencode-gemini-auth",
     "google",
+  ],
+  "google-agy": [
+    "google-agy",
+    "opencode-agy-auth",
+    "google-agy-auth",
   ],
   zai: ["zai", "glm", "zai-coding-plan"],
   zhipu: ["zhipu", "glm-coding-plan", "zhipu-coding-plan", "zhipuai-coding-plan"],
@@ -213,6 +222,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     authentication: "companion_auth_oauth_token",
     quota: "remote_api",
     quickSetupAnchor: "gemini-cli",
+  },
+  {
+    id: "google-agy",
+    autoSetup: "needs_quick_setup",
+    authentication: "companion_auth_oauth_token",
+    quota: "remote_api",
+    quickSetupAnchor: "google-agy-quick-setup",
   },
   {
     id: "zai",

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -57,7 +57,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   copilot: "Copilot",
   "google-antigravity": "Google",
   "google-gemini-cli": "Gemini CLI",
-  "google-agy": "Google Agy",
+  "google-agy": "Google AGY",
   synthetic: "Synthetic",
   chutes: "Chutes",
   cursor: "Cursor",

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -7,6 +7,8 @@ import { inspectAntigravityCompanionPresence } from "./google-antigravity-compan
 import { inspectGeminiCliCompanionPresence } from "./google-gemini-cli-companion.js";
 import { inspectGeminiCliAuthPresence } from "./google-gemini-cli.js";
 import { inspectAntigravityAccountsPresence } from "./google.js";
+import { inspectAgyCompanionPresence } from "./google-agy-companion.js";
+import { inspectAgyAuthPresence } from "./google-agy.js";
 import { getAnthropicDiagnostics } from "./anthropic.js";
 import { getChutesKeyDiagnostics } from "./chutes.js";
 import { getNanoGptKeyDiagnostics, queryNanoGptQuota } from "./nanogpt.js";
@@ -636,6 +638,7 @@ export async function buildQuotaStatusReport(params: {
     summary: MaintainerAnnouncementsSummary;
   };
   geminiCliClient?: ConfigClient;
+  agyClient?: ConfigClient;
   generatedAtMs?: number;
 }): Promise<string> {
   const version = await getPackageVersion();
@@ -1555,6 +1558,35 @@ export async function buildQuotaStatusReport(params: {
   }
   appendProviderCompactLiveProbeRows(geminiCliRows, "google-gemini-cli", params.providerLiveProbes);
   sections.push(createKvSection("google_gemini_cli", "google_gemini_cli:", geminiCliRows));
+
+  // Google Agy
+  const agyAuthPresence = await inspectAgyAuthPresence(params.agyClient);
+  const agyCompanionPresence = await inspectAgyCompanionPresence();
+  const agyRows: ReportKvRow[] = [
+    { key: "auth_state", value: agyAuthPresence.state },
+    { key: "auth_source", value: agyAuthPresence.sourceKey ?? "auth.json" },
+    { key: "account_count", value: String(agyAuthPresence.accountCount) },
+    { key: "valid_account_count", value: String(agyAuthPresence.validAccountCount) },
+    { key: "companion_package_state", value: agyCompanionPresence.state },
+    {
+      key: "companion_package_path",
+      value:
+        agyCompanionPresence.state === "present" || agyCompanionPresence.state === "invalid"
+          ? agyCompanionPresence.resolvedPath ?? "(none)"
+          : "(none)",
+    },
+  ];
+  if (agyAuthPresence.state === "invalid") {
+    agyRows.push({ key: "auth_error", value: sanitizeDisplayText(agyAuthPresence.error) });
+  }
+  if (agyCompanionPresence.state !== "present") {
+    agyRows.push({
+      key: "companion_error",
+      value: sanitizeDisplayText(agyCompanionPresence.error),
+    });
+  }
+  appendProviderCompactLiveProbeRows(agyRows, "google-agy", params.providerLiveProbes);
+  sections.push(createKvSection("google_agy", "google_agy:", agyRows));
 
   if (params.googleRefresh?.attempted) {
     const googleRefreshRows: ReportKvRow[] = [];

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -1559,7 +1559,7 @@ export async function buildQuotaStatusReport(params: {
   appendProviderCompactLiveProbeRows(geminiCliRows, "google-gemini-cli", params.providerLiveProbes);
   sections.push(createKvSection("google_gemini_cli", "google_gemini_cli:", geminiCliRows));
 
-  // Google Agy
+  // Google AGY
   const agyAuthPresence = await inspectAgyAuthPresence(params.agyClient);
   const agyCompanionPresence = await inspectAgyCompanionPresence();
   const agyRows: ReportKvRow[] = [

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,10 @@ export type GeminiCliAuthSourceKey =
   | "opencode-gemini-auth"
   | "gemini"
   | "google";
+export type GoogleAgyAuthSourceKey =
+  | "google-agy"
+  | "opencode-agy-auth"
+  | "google-agy-auth";
 export type CursorQuotaPlan = "none" | "pro" | "pro-plus" | "ultra";
 export type PricingSnapshotSource = "auto" | "bundled" | "runtime";
 export type PercentDisplayMode = "remaining" | "used";
@@ -341,6 +345,9 @@ export interface AuthData {
   "gemini-cli"?: GeminiCliOAuthAuthData;
   "opencode-gemini-auth"?: GeminiCliOAuthAuthData;
   gemini?: GeminiCliOAuthAuthData;
+  "google-agy"?: GeminiCliOAuthAuthData;
+  "opencode-agy-auth"?: GeminiCliOAuthAuthData;
+  "google-agy-auth"?: GeminiCliOAuthAuthData;
   openai?: OpenAIOAuthData;
   // Some OpenCode installs store ChatGPT auth under "codex".
   codex?: OpenAIOAuthData;
@@ -574,6 +581,25 @@ export interface GeminiCliQuotaResult {
   buckets: GeminiCliQuotaBucket[];
   errors?: GoogleAccountError[];
 }
+
+export interface GoogleAgyQuotaBucket {
+  modelId: string;
+  displayName: string;
+  percentRemaining: number;
+  resetTimeIso?: string;
+  remainingAmount?: string;
+  tokenType?: string;
+  accountEmail?: string;
+  sourceKey?: GoogleAgyAuthSourceKey;
+}
+
+export interface GoogleAgyQuotaResult {
+  success: true;
+  buckets: GoogleAgyQuotaBucket[];
+  errors?: GoogleAccountError[];
+}
+
+export type GoogleAgyResult = GoogleAgyQuotaResult | QuotaError | null;
 
 /** Result from fetching Google quota */
 export interface GoogleQuotaResult {

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -52,14 +52,10 @@ export const googleAgyProvider: QuotaProvider = {
       let groupName: string | undefined;
       const name = bucket.displayName;
 
-      if (name.startsWith("Gemini 2.5")) {
-        groupName = "Gemini 2.5";
-      } else if (name.startsWith("Gemini 3 ") || name.startsWith("Gemini 3.1")) {
-        groupName = "Gemini 3 & 3.1";
-      } else if (name.startsWith("Gemini 3.5")) {
-        groupName = "Gemini 3.5";
-      } else if (name.includes("Claude") && name.includes("4.6")) {
-        groupName = "Claude 4.6";
+      if (name.includes("Gemini")) {
+        groupName = "Gemini Models";
+      } else if (name.includes("Claude") || name.includes("GPT")) {
+        groupName = "Claude and GPT models";
       }
 
       if (!groupName) continue;

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -46,7 +46,37 @@ export const googleAgyProvider: QuotaProvider = {
       return attemptedErrorResult("Google Agy", result.error);
     }
 
-    const entries = result.buckets.map((bucket) => {
+    const groupedBuckets = new Map<string, typeof result.buckets[0]>();
+
+    for (const bucket of result.buckets) {
+      let groupName: string | undefined;
+      const name = bucket.displayName;
+
+      if (name.startsWith("Gemini 2.5")) {
+        groupName = "Gemini 2.5";
+      } else if (name.startsWith("Gemini 3 ") || name.startsWith("Gemini 3.1")) {
+        groupName = "Gemini 3 & 3.1";
+      } else if (name.startsWith("Gemini 3.5")) {
+        groupName = "Gemini 3.5";
+      } else if (name.includes("Claude") && name.includes("4.6")) {
+        groupName = "Claude 4.6";
+      }
+
+      if (!groupName) continue;
+
+      const key = `${bucket.accountEmail || ""}::${groupName}`;
+      const existing = groupedBuckets.get(key);
+
+      if (!existing || bucket.percentRemaining < existing.percentRemaining) {
+        groupedBuckets.set(key, { ...bucket, displayName: groupName });
+      }
+    }
+
+    const finalBuckets = Array.from(groupedBuckets.values()).sort((a, b) => 
+      a.displayName.localeCompare(b.displayName)
+    );
+
+    const entries = finalBuckets.map((bucket) => {
       const emailLabel = formatGoogleAccountLabel(bucket.accountEmail, "domainHint");
       const parsedRemaining = bucket.remainingAmount
         ? Number.parseInt(bucket.remainingAmount, 10)

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -43,7 +43,7 @@ export const googleAgyProvider: QuotaProvider = {
     }
 
     if (!result.success) {
-      return attemptedErrorResult("Google Agy", result.error);
+      return attemptedErrorResult("Google AGY", result.error);
     }
 
     const groupedBuckets = new Map<string, typeof result.buckets[0]>();
@@ -87,7 +87,7 @@ export const googleAgyProvider: QuotaProvider = {
 
       return {
         name: `${bucket.displayName} (${emailLabel})`,
-        group: "Google Agy",
+        group: "Google AGY",
         label: `${bucket.displayName}:`,
         ...(right ? { right } : {}),
         percentRemaining: bucket.percentRemaining,
@@ -96,7 +96,7 @@ export const googleAgyProvider: QuotaProvider = {
     });
 
     return attemptedResult(entries, formatGoogleAccountErrors(result.errors, "domainHint"), {
-      singleWindowDisplayName: "Google Agy",
+      singleWindowDisplayName: "Google AGY",
       singleWindowShowRight: true,
     });
   },

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -1,0 +1,77 @@
+import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import { hasAgyQuotaRuntimeAvailable, queryGoogleAgyQuota } from "../lib/google-agy.js";
+import { parseProviderModelRef } from "../lib/provider-model-matching.js";
+import {
+  formatGoogleAccountErrors,
+  formatGoogleAccountLabel,
+} from "./google-account-format.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+function isAgyModel(model: string): boolean {
+  const { providerId } = parseProviderModelRef(model);
+  return ["google-agy", "opencode-agy-auth", "google-agy-auth"].includes(providerId);
+}
+
+async function isAgyConfigured(ctx: QuotaProviderContext): Promise<boolean> {
+  try {
+    return await hasAgyQuotaRuntimeAvailable(ctx.client);
+  } catch {
+    return false;
+  }
+}
+
+export const googleAgyProvider: QuotaProvider = {
+  id: "google-agy",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    return await isAgyConfigured(ctx);
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    return isAgyModel(model);
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const result = await queryGoogleAgyQuota(ctx.client, {
+      requestTimeoutMs: ctx.config?.requestTimeoutMsConfigured
+        ? ctx.config.requestTimeoutMs
+        : undefined,
+    });
+
+    if (!result) {
+      return notAttemptedResult();
+    }
+
+    if (!result.success) {
+      return attemptedErrorResult("Google Agy", result.error);
+    }
+
+    const entries = result.buckets.map((bucket) => {
+      const emailLabel = formatGoogleAccountLabel(bucket.accountEmail, "domainHint");
+      const parsedRemaining = bucket.remainingAmount
+        ? Number.parseInt(bucket.remainingAmount, 10)
+        : Number.NaN;
+      const remainingAmount = bucket.remainingAmount
+        ? `${Number.isFinite(parsedRemaining) ? parsedRemaining.toLocaleString("en-US") : bucket.remainingAmount} left`
+        : undefined;
+      const tokenType = bucket.tokenType?.trim().toUpperCase();
+      const right = [remainingAmount, tokenType && tokenType !== "REQUESTS" ? tokenType : undefined]
+        .filter(Boolean)
+        .join(" ");
+
+      return {
+        name: `${bucket.displayName} (${emailLabel})`,
+        group: "Google Agy",
+        label: `${bucket.displayName}:`,
+        ...(right ? { right } : {}),
+        percentRemaining: bucket.percentRemaining,
+        resetTimeIso: bucket.resetTimeIso,
+      };
+    });
+
+    return attemptedResult(entries, formatGoogleAccountErrors(result.errors, "domainHint"), {
+      singleWindowDisplayName: "Google Agy",
+      singleWindowShowRight: true,
+    });
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -11,6 +11,7 @@ import { openaiProvider } from "./openai.js";
 import { cursorProvider } from "./cursor.js";
 import { googleAntigravityProvider } from "./google-antigravity.js";
 import { googleGeminiCliProvider } from "./google-gemini-cli.js";
+import { googleAgyProvider } from "./google-agy.js";
 import { syntheticProvider } from "./synthetic.js";
 import { chutesProvider } from "./chutes.js";
 import { qwenCodeProvider } from "./qwen-code.js";
@@ -40,6 +41,7 @@ export function getProviders(): QuotaProvider[] {
     chutesProvider,
     googleAntigravityProvider,
     googleGeminiCliProvider,
+    googleAgyProvider,
     zaiProvider,
     zhipuProvider,
     nanoGptProvider,

--- a/tests/lib.google-agy-companion.test.ts
+++ b/tests/lib.google-agy-companion.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const moduleMocks = vi.hoisted(() => ({
+  resolveImpl: vi.fn<(specifier: string, options?: { paths?: string[] }) => string>(),
+  runtimeDirs: {
+    value: {
+      cacheDirs: [] as string[],
+    },
+  },
+}));
+
+vi.mock("node:module", () => ({
+  createRequire: () => ({
+    resolve: moduleMocks.resolveImpl,
+  }),
+}));
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => moduleMocks.runtimeDirs.value,
+}));
+
+function moduleNotFound(): Error & { code?: string } {
+  const error = new Error("Cannot find module");
+  error.code = "MODULE_NOT_FOUND";
+  return error;
+}
+
+function packagePathNotExported(): Error & { code?: string } {
+  const error = new Error('Package subpath is not defined by "exports"');
+  error.code = "ERR_PACKAGE_PATH_NOT_EXPORTED";
+  return error;
+}
+
+function writeAgyCredentials(
+  path: string,
+  params?: { declaration?: "export const" | "const" | "var" },
+): void {
+  const declaration = params?.declaration ?? "export const";
+  writeFileSync(
+    path,
+    [
+      `${declaration} AGY_CLIENT_ID = 'client-id';`,
+      `${declaration} AGY_CLIENT_SECRET = 'client-secret';`,
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+describe("google agy companion resolution", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    vi.resetModules();
+    moduleMocks.resolveImpl.mockReset();
+    moduleMocks.runtimeDirs.value = { cacheDirs: [] };
+    tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-agy-companion-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports missing when the companion package cannot be resolved", async () => {
+    moduleMocks.resolveImpl.mockImplementation(() => {
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.inspectAgyCompanionPresence()).resolves.toMatchObject({
+      state: "missing",
+    });
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "missing",
+    });
+  });
+
+  it("reads credentials from the published source constants file", async () => {
+    const constantsPath = join(tempDir, "constants.ts");
+    writeFileSync(
+      constantsPath,
+      [
+        "export const AGY_CLIENT_ID = 'client-id';",
+        "export const AGY_CLIENT_SECRET = 'client-secret';",
+      ].join("\n"),
+      "utf8",
+    );
+    moduleMocks.resolveImpl.mockImplementation((specifier) => {
+      if (specifier === "@anthonyhaussman/opencode-agy-auth/src/constants.ts") {
+        return constantsPath;
+      }
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.inspectAgyCompanionPresence()).resolves.toMatchObject({
+      state: "present",
+      resolvedPath: constantsPath,
+    });
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "configured",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      resolvedPath: constantsPath,
+    });
+  });
+
+  it("reads credentials from the bundled dist file", async () => {
+    const packageRoot = join(tempDir, "@anthonyhaussman/opencode-agy-auth");
+    const packageJsonPath = join(packageRoot, "package.json");
+    const distPath = join(packageRoot, "dist", "index.js");
+    mkdirSync(join(packageRoot, "dist"), { recursive: true });
+    writeFileSync(packageJsonPath, JSON.stringify({ name: "@anthonyhaussman/opencode-agy-auth" }), "utf8");
+    writeFileSync(
+      distPath,
+      [
+        "var AGY_CLIENT_ID = 'dist-client-id';",
+        "var AGY_CLIENT_SECRET = 'dist-client-secret';",
+      ].join("\n"),
+      "utf8",
+    );
+    moduleMocks.resolveImpl.mockImplementation((specifier) => {
+      if (specifier === "@anthonyhaussman/opencode-agy-auth/package.json") {
+        return packageJsonPath;
+      }
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "configured",
+      clientId: "dist-client-id",
+      clientSecret: "dist-client-secret",
+      resolvedPath: distPath,
+    });
+  });
+
+  it("falls through package export blocks and reads credentials from the package root export", async () => {
+    const packageRoot = join(tempDir, "@anthonyhaussman/opencode-agy-auth");
+    const distPath = join(packageRoot, "dist", "index.js");
+    mkdirSync(join(packageRoot, "dist"), { recursive: true });
+    writeFileSync(
+      distPath,
+      [
+        "var AGY_CLIENT_ID = 'export-client-id';",
+        "var AGY_CLIENT_SECRET = 'export-client-secret';",
+      ].join("\n"),
+      "utf8",
+    );
+    moduleMocks.resolveImpl.mockImplementation((specifier) => {
+      if (specifier === "@anthonyhaussman/opencode-agy-auth") {
+        return distPath;
+      }
+      if (specifier.startsWith("@anthonyhaussman/opencode-agy-auth/")) {
+        throw packagePathNotExported();
+      }
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "configured",
+      clientId: "export-client-id",
+      clientSecret: "export-client-secret",
+      resolvedPath: distPath,
+    });
+  });
+
+  it("reports invalid when package export blocks prove the package exists but no fallback resolves", async () => {
+    moduleMocks.resolveImpl.mockImplementation((specifier) => {
+      if (specifier.startsWith("@anthonyhaussman/opencode-agy-auth/")) {
+        throw packagePathNotExported();
+      }
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.inspectAgyCompanionPresence()).resolves.toMatchObject({
+      state: "invalid",
+    });
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "invalid",
+    });
+  });
+
+  it("reads credentials from a nested node_modules structure in runtime packages directory", async () => {
+    const runtimeCacheDir = join(tempDir, "cache", "opencode");
+    const packageRoot = join(runtimeCacheDir, "packages", "@anthonyhaussman/opencode-agy-auth-1.0.0");
+    const nestedRoot = join(packageRoot, "node_modules", "@anthonyhaussman/opencode-agy-auth");
+    const distPath = join(nestedRoot, "dist", "index.js");
+    mkdirSync(join(nestedRoot, "dist"), { recursive: true });
+    writeAgyCredentials(distPath, { declaration: "var" });
+    moduleMocks.runtimeDirs.value = { cacheDirs: [runtimeCacheDir] };
+    moduleMocks.resolveImpl.mockImplementation(() => {
+      throw moduleNotFound();
+    });
+
+    const mod = await import("../src/lib/google-agy-companion.js");
+
+    await expect(mod.resolveAgyClientCredentials()).resolves.toMatchObject({
+      state: "configured",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      resolvedPath: distPath,
+    });
+  });
+});

--- a/tests/lib.google-agy.extra.test.ts
+++ b/tests/lib.google-agy.extra.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { formatDisplayName, queryGoogleAgyQuota } from "../src/lib/google-agy";
+
+describe("google-agy extra logic", () => {
+  describe("formatDisplayName", () => {
+    it("should format Claude models correctly", () => {
+      expect(formatDisplayName("claude-3-5-sonnet")).toBe("Claude 3.5 Sonnet");
+      expect(formatDisplayName("claude-3-opus")).toBe("Claude 3 Opus");
+      expect(formatDisplayName("claude-3-sonnet")).toBe("Claude 3 Sonnet");
+      expect(formatDisplayName("claude-3-5-haiku")).toBe("Claude 3.5 Haiku");
+    });
+
+    it("should format GPT-OSS models correctly", () => {
+      expect(formatDisplayName("gpt_oss_120b_medium")).toBe("GPT-OSS 120B (Medium)");
+      expect(formatDisplayName("gpt_oss_7b")).toBe("GPT-OSS 7B");
+    });
+
+    it("should format Gemini models correctly", () => {
+      expect(formatDisplayName("gemini-1-5-pro")).toBe("Gemini 1.5 Pro");
+      expect(formatDisplayName("gemini-1-0-pro")).toBe("Gemini 1.0 Pro");
+    });
+  });
+});

--- a/tests/lib.google-agy.test.ts
+++ b/tests/lib.google-agy.test.ts
@@ -150,6 +150,51 @@ describe("google agy logic", () => {
     });
   });
 
+  it("prioritizes managedProjectId and quotaProjectId over developer projectIds in resolveAgyAccounts", () => {
+    const auth = {
+      "google-agy": {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+        managedProjectId: "managed-project-entry",
+        quotaProjectId: "quota-project-entry",
+      },
+    };
+
+    // Test 1: entry.managedProjectId takes top priority
+    let resolved = resolveAgyAccounts(auth, "configured-project");
+    expect(resolved[0].projectId).toBe("managed-project-entry");
+
+    // Test 2: entry.quotaProjectId takes priority over entry.projectId/projectID and parts and configuredProjectId
+    const auth2 = {
+      "google-agy": {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+        quotaProjectId: "quota-project-entry",
+      },
+    };
+    resolved = resolveAgyAccounts(auth2, "configured-project");
+    expect(resolved[0].projectId).toBe("quota-project-entry");
+
+    // Test 3: parts.managedProjectId takes priority over entry.projectId/projectID and parts.projectId and configuredProjectId
+    const auth3 = {
+      "google-agy": {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+      },
+    };
+    resolved = resolveAgyAccounts(auth3, "configured-project");
+    expect(resolved[0].projectId).toBe("managed-project-part");
+  });
+
   it("returns error if companion credentials are missing or invalid", async () => {
     mocks.readAuthFileCached.mockResolvedValueOnce({
       "google-agy": {

--- a/tests/lib.google-agy.test.ts
+++ b/tests/lib.google-agy.test.ts
@@ -1,0 +1,301 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readAuthFileCached: vi.fn(),
+  fetchWithTimeout: vi.fn(),
+  getCachedAccessToken: vi.fn(),
+  makeAccountCacheKey: vi.fn(),
+  setCachedAccessToken: vi.fn(),
+  inspectAgyCompanionPresence: vi.fn(),
+  resolveAgyClientCredentials: vi.fn(),
+  clearAgyCompanionCacheForTests: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: mocks.readAuthFileCached,
+}));
+
+vi.mock("../src/lib/http.js", () => ({
+  fetchWithTimeout: mocks.fetchWithTimeout,
+}));
+
+vi.mock("../src/lib/google-token-cache.js", () => ({
+  getCachedAccessToken: mocks.getCachedAccessToken,
+  makeAccountCacheKey: mocks.makeAccountCacheKey,
+  setCachedAccessToken: mocks.setCachedAccessToken,
+}));
+
+vi.mock("../src/lib/google-agy-companion.js", () => ({
+  inspectAgyCompanionPresence: mocks.inspectAgyCompanionPresence,
+  resolveAgyClientCredentials: mocks.resolveAgyClientCredentials,
+  clearAgyCompanionCacheForTests: mocks.clearAgyCompanionCacheForTests,
+}));
+
+import {
+  DEFAULT_AGY_AUTH_CACHE_MAX_AGE_MS,
+  inspectAgyAuthPresence,
+  parseAgyRefreshParts,
+  queryGoogleAgyQuota,
+  resolveAgyAccounts,
+  resolveAgyConfiguredProjectId,
+  formatDisplayName,
+} from "../src/lib/google-agy.js";
+
+function mockJsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  };
+}
+
+describe("google agy logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.readAuthFileCached.mockResolvedValue(null);
+    mocks.fetchWithTimeout.mockResolvedValue(mockJsonResponse({ buckets: [] }));
+    mocks.getCachedAccessToken.mockResolvedValue({ accessToken: "cached-access-token" });
+    mocks.makeAccountCacheKey.mockReturnValue("test-cache-key");
+    mocks.resolveAgyClientCredentials.mockResolvedValue({
+      state: "configured",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    delete process.env.OPENCODE_AGY_PROJECT_ID;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+    delete process.env.GOOGLE_CLOUD_PROJECT_ID;
+  });
+
+  it("parses opencode-agy-auth packed refresh strings", () => {
+    expect(parseAgyRefreshParts("refresh-token|project-1|managed-project")).toEqual({
+      refreshToken: "refresh-token",
+      projectId: "project-1",
+      managedProjectId: "managed-project",
+    });
+  });
+
+  it("formats model display names correctly", () => {
+    expect(formatDisplayName("gemini-3.5-flash")).toBe("Gemini 3.5 Flash");
+    expect(formatDisplayName("claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
+    expect(formatDisplayName("gpt-oss-120b-medium")).toBe("GPT-OSS 120B (Medium)");
+    expect(formatDisplayName("gpt_oss_120b_medium")).toBe("GPT-OSS 120B (Medium)");
+    expect(formatDisplayName("gemini_3_5_flash")).toBe("Gemini 3.5 Flash");
+  });
+
+  it("resolves the project id with correct precedence", async () => {
+    process.env.GOOGLE_CLOUD_PROJECT = "generic-gcp-project";
+    await expect(resolveAgyConfiguredProjectId()).resolves.toBe("generic-gcp-project");
+
+    await expect(
+      resolveAgyConfiguredProjectId({
+        config: {
+          get: async () => ({
+            data: {
+              provider: {
+                "google-agy": { options: { projectId: "configured-agy-project" } },
+              },
+            },
+          }),
+        },
+      }),
+    ).resolves.toBe("configured-agy-project");
+
+    process.env.OPENCODE_AGY_PROJECT_ID = "explicit-agy-project";
+    await expect(
+      resolveAgyConfiguredProjectId({
+        config: {
+          get: async () => ({
+            data: {
+              provider: {
+                "google-agy": { options: { projectId: "configured-agy-project" } },
+              },
+            },
+          }),
+        },
+      }),
+    ).resolves.toBe("explicit-agy-project");
+  });
+
+  it("resolves accounts correctly and deduplicates them", () => {
+    const auth = {
+      "google-agy": {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+      "opencode-agy-auth": {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+      "google-agy-auth": {
+        type: "oauth" as const,
+        refresh: "refresh-token-2|project-2",
+        email: "bob@example.com",
+      },
+    };
+    const resolved = resolveAgyAccounts(auth);
+    expect(resolved).toHaveLength(2);
+    expect(resolved[0]).toEqual({
+      sourceKey: "google-agy",
+      refreshToken: "refresh-token-1",
+      projectId: "project-1",
+      email: "alice@example.com",
+    });
+    expect(resolved[1]).toEqual({
+      sourceKey: "google-agy-auth",
+      refreshToken: "refresh-token-2",
+      projectId: "project-2",
+      email: "bob@example.com",
+    });
+  });
+
+  it("returns error if companion credentials are missing or invalid", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      "google-agy": {
+        type: "oauth",
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+    });
+    mocks.resolveAgyClientCredentials.mockResolvedValueOnce({
+      state: "missing",
+      error: "Companion plugin is missing",
+    });
+    const result = await queryGoogleAgyQuota();
+    expect(result).toEqual({
+      success: false,
+      error: "Companion plugin is missing",
+    });
+  });
+
+  it("aggregates multiple limits per model ID keeping the lowest remaining percent", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      "google-agy": {
+        type: "oauth",
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+    });
+    mocks.resolveAgyClientCredentials.mockResolvedValueOnce({
+      state: "configured",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    mocks.getCachedAccessToken.mockResolvedValueOnce({ accessToken: "cached-token" });
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        buckets: [
+          {
+            modelId: "gemini-3.5-flash",
+            remainingFraction: 0.8,
+            tokenType: "REQUESTS",
+          },
+          {
+            modelId: "gemini-3.5-flash",
+            remainingFraction: 0.25,
+            tokenType: "TOKENS",
+          },
+          {
+            modelId: "claude-sonnet-4-6",
+            remainingFraction: 0.9,
+          },
+        ],
+      }),
+    );
+
+    const result = await queryGoogleAgyQuota();
+    expect(result).toMatchObject({ success: true });
+    if (!result || !result.success) {
+      throw new Error("expected success");
+    }
+    expect(result.buckets).toEqual([
+      {
+        modelId: "gemini-3.5-flash",
+        displayName: "Gemini 3.5 Flash",
+        percentRemaining: 25,
+        tokenType: "TOKENS",
+        accountEmail: "alice@example.com",
+        sourceKey: "google-agy",
+      },
+      {
+        modelId: "claude-sonnet-4-6",
+        displayName: "Claude Sonnet 4.6",
+        percentRemaining: 90,
+        accountEmail: "alice@example.com",
+        sourceKey: "google-agy",
+      },
+    ]);
+  });
+
+  it("refreshes token when cache is empty and handles force refresh on auth error", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      "google-agy": {
+        type: "oauth",
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+    });
+    mocks.resolveAgyClientCredentials.mockResolvedValueOnce({
+      state: "configured",
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    });
+    mocks.getCachedAccessToken.mockResolvedValueOnce(null);
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        access_token: "new-access-token",
+        expires_in: 3600,
+      })
+    );
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    });
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        access_token: "retry-access-token",
+        expires_in: 3600,
+      })
+    );
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        buckets: [
+          {
+            modelId: "gemini-3.5-flash",
+            remainingFraction: 0.5,
+          },
+        ],
+      })
+    );
+
+    const result = await queryGoogleAgyQuota();
+    expect(result).toMatchObject({ success: true });
+    if (!result || !result.success) {
+      throw new Error("expected success");
+    }
+    expect(result.buckets[0]).toMatchObject({
+      modelId: "gemini-3.5-flash",
+      percentRemaining: 50,
+    });
+  });
+
+  it("reports invalid auth when OAuth exists but no project id can be resolved", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      "google-agy": { type: "oauth", refresh: "refresh-token" },
+    });
+
+    await expect(inspectAgyAuthPresence()).resolves.toMatchObject({
+      state: "invalid",
+      sourceKey: "google-agy",
+      accountCount: 1,
+      validAccountCount: 0,
+    });
+  });
+});

--- a/tests/lib.google-gemini-cli.test.ts
+++ b/tests/lib.google-gemini-cli.test.ts
@@ -110,7 +110,7 @@ describe("gemini cli auth resolution", () => {
       {
         sourceKey: "google",
         refreshToken: "refresh-token",
-        projectId: "project-1",
+        projectId: "managed-project",
         email: "user@example.com",
         accessToken: "access-token",
         expiresAt: 123,
@@ -149,6 +149,51 @@ describe("gemini cli auth resolution", () => {
         projectId: "configured-project",
       },
     ]);
+  });
+
+  it("prioritizes managedProjectId and quotaProjectId over developer projectIds in resolveGeminiCliAccounts", () => {
+    const auth = {
+      google: {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+        managedProjectId: "managed-project-entry",
+        quotaProjectId: "quota-project-entry",
+      },
+    };
+
+    // Test 1: entry.managedProjectId takes top priority
+    let resolved = resolveGeminiCliAccounts(auth, "configured-project");
+    expect(resolved[0].projectId).toBe("managed-project-entry");
+
+    // Test 2: entry.quotaProjectId takes priority over entry.projectId/projectID and parts and configuredProjectId
+    const auth2 = {
+      google: {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+        quotaProjectId: "quota-project-entry",
+      },
+    };
+    resolved = resolveGeminiCliAccounts(auth2, "configured-project");
+    expect(resolved[0].projectId).toBe("quota-project-entry");
+
+    // Test 3: parts.managedProjectId takes priority over entry.projectId/projectID and parts.projectId and configuredProjectId
+    const auth3 = {
+      google: {
+        type: "oauth" as const,
+        refresh: "refresh-token-1|dev-project-part|managed-project-part",
+        email: "alice@example.com",
+        projectId: "dev-project-entry",
+        projectID: "dev-project-entry-2",
+      },
+    };
+    resolved = resolveGeminiCliAccounts(auth3, "configured-project");
+    expect(resolved[0].projectId).toBe("managed-project-part");
   });
 
   it("prefers explicit OpenCode provider config over generic Google project env vars", async () => {

--- a/tests/lib.google.multi-account-refresh.test.ts
+++ b/tests/lib.google.multi-account-refresh.test.ts
@@ -146,4 +146,52 @@ describe("google antigravity multi-account refresh", () => {
       error: "Google Antigravity requires the opencode-antigravity-auth plugin",
     });
   });
+
+  it("prioritizes managedProjectId and quotaProjectId over projectId/projectID", async () => {
+    const { readFile } = await import("fs/promises");
+
+    (readFile as any).mockResolvedValueOnce(
+      JSON.stringify({
+        version: 1,
+        accounts: [
+          {
+            email: "a@b.com",
+            refreshToken: "rtok",
+            projectId: "dev-proj",
+            projectID: "dev-proj-2",
+            managedProjectId: "managed-proj",
+            addedAt: 0,
+            lastUsed: 0,
+          },
+        ],
+      }),
+    );
+
+    const fetchSpy = vi.fn();
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ access_token: "new_token", expires_in: 3600 }),
+    });
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          models: {
+            "claude-opus-4-5-thinking": {
+              quotaInfo: { remainingFraction: 0.75, resetTime: "2026-01-01T01:00:00Z" },
+            },
+          },
+        }),
+    });
+
+    vi.stubGlobal("fetch", fetchSpy as any);
+
+    await queryGoogleQuota(["CLAUDE"] as any);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondCall = fetchSpy.mock.calls[1];
+    expect(secondCall[0]).toBe("https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels");
+    const bodyObj = JSON.parse(secondCall[1].body);
+    expect(bodyObj.project).toBe("managed-proj");
+  });
 });

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -84,6 +84,13 @@ describe("provider-metadata", () => {
         quickSetupAnchor: "gemini-cli",
       },
       {
+        id: "google-agy",
+        autoSetup: "needs_quick_setup",
+        authentication: "companion_auth_oauth_token",
+        quota: "remote_api",
+        quickSetupAnchor: "google-agy-quick-setup",
+      },
+      {
         id: "zai",
         autoSetup: "yes",
         authentication: "opencode_auth_api_key",
@@ -187,6 +194,11 @@ describe("provider-metadata", () => {
       "opencode-gemini-auth",
       "google",
     ]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS["google-agy"]).toEqual([
+      "google-agy",
+      "opencode-agy-auth",
+      "google-agy-auth",
+    ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.zai).toEqual(["zai", "glm", "zai-coding-plan"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.zhipu).toEqual([
       "zhipu",
@@ -234,6 +246,11 @@ describe("provider-metadata", () => {
       "gemini",
       "opencode-gemini-auth",
       "google",
+    ]);
+    expect(getQuotaProviderRuntimeIds("google-agy")).toEqual([
+      "google-agy",
+      "opencode-agy-auth",
+      "google-agy-auth",
     ]);
     expect(getQuotaProviderRuntimeIds("zai")).toEqual(["zai", "glm", "zai-coding-plan"]);
     expect(getQuotaProviderRuntimeIds("zhipu-coding-plan")).toEqual([
@@ -288,6 +305,13 @@ describe("provider-metadata", () => {
       quota: "remote_api",
       quickSetupAnchor: "gemini-cli",
     });
+    expect(getQuotaProviderShape("google-agy")).toEqual({
+      id: "google-agy",
+      autoSetup: "needs_quick_setup",
+      authentication: "companion_auth_oauth_token",
+      quota: "remote_api",
+      quickSetupAnchor: "google-agy-quick-setup",
+    });
     expect(getQuotaProviderShape("deep-seek")).toEqual({
       id: "deepseek",
       autoSetup: "yes",
@@ -302,6 +326,7 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("anthropic")).toBe("Anthropic");
     expect(getQuotaProviderDisplayLabel("google-antigravity")).toBe("Google");
     expect(getQuotaProviderDisplayLabel("gemini-cli")).toBe("Gemini CLI");
+    expect(getQuotaProviderDisplayLabel("google-agy")).toBe("Google Agy");
     expect(getQuotaProviderDisplayLabel("cursor")).toBe("Cursor");
     expect(getQuotaProviderDisplayLabel("alibaba-coding-plan")).toBe("Alibaba Coding Plan");
     expect(getQuotaProviderDisplayLabel("synthetic")).toBe("Synthetic");

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -326,7 +326,7 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("anthropic")).toBe("Anthropic");
     expect(getQuotaProviderDisplayLabel("google-antigravity")).toBe("Google");
     expect(getQuotaProviderDisplayLabel("gemini-cli")).toBe("Gemini CLI");
-    expect(getQuotaProviderDisplayLabel("google-agy")).toBe("Google Agy");
+    expect(getQuotaProviderDisplayLabel("google-agy")).toBe("Google AGY");
     expect(getQuotaProviderDisplayLabel("cursor")).toBe("Cursor");
     expect(getQuotaProviderDisplayLabel("alibaba-coding-plan")).toBe("Alibaba Coding Plan");
     expect(getQuotaProviderDisplayLabel("synthetic")).toBe("Synthetic");

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -1670,6 +1670,7 @@ nanogpt:
 copilot_quota_auth:
 google_antigravity:
 google_gemini_cli:
+google_agy:
 storage:
 pricing_snapshot:
 supported_providers_pricing:

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -84,6 +84,19 @@ const geminiCliMocks = vi.hoisted(() => ({
   })),
 }));
 
+const agyMocks = vi.hoisted(() => ({
+  inspectAgyAuthPresence: vi.fn(async () => ({
+    state: "missing" as const,
+    accountCount: 0,
+    validAccountCount: 0,
+  })),
+  inspectAgyCompanionPresence: vi.fn(async () => ({
+    state: "missing" as const,
+    importSpecifier: "@anthonyhaussman/opencode-agy-auth/dist/src/constants.js",
+    error: "Install @anthonyhaussman/opencode-agy-auth separately to enable Google AGY quota",
+  })),
+}));
+
 const openaiMocks = vi.hoisted(() => ({
   resolveOpenAIOAuth: vi.fn(() => ({ state: "none" as const })),
 }));
@@ -239,6 +252,14 @@ vi.mock("../src/lib/google-gemini-cli.js", () => ({
 
 vi.mock("../src/lib/google-gemini-cli-companion.js", () => ({
   inspectGeminiCliCompanionPresence: geminiCliMocks.inspectGeminiCliCompanionPresence,
+}));
+
+vi.mock("../src/lib/google-agy.js", () => ({
+  inspectAgyAuthPresence: agyMocks.inspectAgyAuthPresence,
+}));
+
+vi.mock("../src/lib/google-agy-companion.js", () => ({
+  inspectAgyCompanionPresence: agyMocks.inspectAgyCompanionPresence,
 }));
 
 vi.mock("../src/lib/anthropic.js", () => ({
@@ -988,6 +1009,65 @@ describe("buildQuotaStatusReport", () => {
     expect(chutesSection).toContain("- live_error_1: probe failed with noise");
     expect(chutesSection).not.toContain("\u001b[31m");
     expect(chutesSection).not.toContain("\u0007");
+  });
+
+  it("reports Google AGY auth, companion, and live quota diagnostics", async () => {
+    const agyClient = { config: { get: vi.fn() } };
+    agyMocks.inspectAgyAuthPresence.mockResolvedValueOnce({
+      state: "present",
+      sourceKey: "google-agy",
+      accountCount: 2,
+      validAccountCount: 2,
+    });
+    agyMocks.inspectAgyCompanionPresence.mockResolvedValueOnce({
+      state: "present",
+      importSpecifier: "@anthonyhaussman/opencode-agy-auth/dist/src/constants.js",
+      resolvedPath: "/tmp/node_modules/@anthonyhaussman/opencode-agy-auth/dist/src/constants.js",
+    });
+
+    const report = await buildProviderStatusReport("google-agy", {
+      agyClient,
+      providerLiveProbes: [
+        {
+          providerId: "google-agy",
+          result: {
+            attempted: true,
+            entries: [
+              {
+                label: "Gemini Models:",
+                name: "Gemini Models (alice@example.com)",
+                group: "Google AGY",
+                percentRemaining: 42,
+                right: "120 left",
+                resetTimeIso: "2026-04-24T00:00:00.000Z",
+              },
+            ],
+            errors: [
+              {
+                label: "Google AGY",
+                message: "secondary account unavailable",
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const agySection = getReportSection(report, "google_agy:");
+    expect(agySection).toContain("- auth_state: present");
+    expect(agySection).toContain("- auth_source: google-agy");
+    expect(agySection).toContain("- account_count: 2");
+    expect(agySection).toContain("- valid_account_count: 2");
+    expect(agySection).toContain("- companion_package_state: present");
+    expect(agySection).toContain(
+      "- companion_package_path: /tmp/node_modules/@anthonyhaussman/opencode-agy-auth/dist/src/constants.js",
+    );
+    expect(agySection).toContain("- live_probe: success");
+    expect(agySection).toContain(
+      "- live_entry_1: Gemini Models: 120 left percent_remaining=42 reset_at=2026-04-24T00:00:00.000Z",
+    );
+    expect(agySection).toContain("- live_error_1: secondary account unavailable");
+    expect(agyMocks.inspectAgyAuthPresence).toHaveBeenCalledWith(agyClient);
   });
 
   it("sanitizes and truncates Synthetic live probe errors", async () => {

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -57,9 +57,9 @@ describe("google agy provider", () => {
     expect(out.attempted).toBe(true);
     expect(out.entries).toEqual([
       {
-        name: "Gemini 2.5 (ali..example)",
+        name: "Gemini Models (ali..example)",
         group: "Google Agy",
-        label: "Gemini 2.5:",
+        label: "Gemini Models:",
         right: "1,234 left",
         percentRemaining: 64,
         resetTimeIso: "2026-01-01T00:00:00.000Z",
@@ -93,9 +93,9 @@ describe("google agy provider", () => {
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toEqual([
       {
-        name: "Gemini 3.5 (ali..example)",
+        name: "Gemini Models (ali..example)",
         group: "Google Agy",
-        label: "Gemini 3.5:",
+        label: "Gemini Models:",
         right: "50 left TOKENS",
         percentRemaining: 20,
         resetTimeIso: "2026-01-01T12:00:00Z",
@@ -127,13 +127,11 @@ describe("google agy provider", () => {
     const out = await googleAgyProvider.fetch({ client: {} } as any);
     expectAttemptedWithNoErrors(out);
     
-    // Check that we only get the 4 consolidated groups, sorted alphabetically
+    // Check that we only get the 2 consolidated groups, sorted alphabetically
     const entryLabels = out.entries.map(e => e.label);
     expect(entryLabels).toEqual([
-      "Claude 4.6:",
-      "Gemini 2.5:",
-      "Gemini 3 & 3.1:",
-      "Gemini 3.5:",
+      "Claude and GPT models:",
+      "Gemini Models:",
     ]);
   });
 

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -41,8 +41,8 @@ describe("google agy provider", () => {
       success: true,
       buckets: [
         {
-          modelId: "gpt-4",
-          displayName: "GPT 4",
+          modelId: "gemini-2-5-flash",
+          displayName: "Gemini 2.5 Flash",
           accountEmail: "alice@example.com",
           percentRemaining: 64,
           resetTimeIso: "2026-01-01T00:00:00.000Z",
@@ -57,9 +57,9 @@ describe("google agy provider", () => {
     expect(out.attempted).toBe(true);
     expect(out.entries).toEqual([
       {
-        name: "GPT 4 (ali..example)",
+        name: "Gemini 2.5 (ali..example)",
         group: "Google Agy",
-        label: "GPT 4:",
+        label: "Gemini 2.5:",
         right: "1,234 left",
         percentRemaining: 64,
         resetTimeIso: "2026-01-01T00:00:00.000Z",
@@ -78,8 +78,8 @@ describe("google agy provider", () => {
       success: true,
       buckets: [
         {
-          modelId: "gpt-4",
-          displayName: "GPT 4",
+          modelId: "gemini-3-5-flash",
+          displayName: "Gemini 3.5 Flash",
           accountEmail: "alice@example.com",
           percentRemaining: 20,
           resetTimeIso: "2026-01-01T12:00:00Z",
@@ -93,9 +93,9 @@ describe("google agy provider", () => {
     expectAttemptedWithNoErrors(out);
     expect(out.entries).toEqual([
       {
-        name: "GPT 4 (ali..example)",
+        name: "Gemini 3.5 (ali..example)",
         group: "Google Agy",
-        label: "GPT 4:",
+        label: "Gemini 3.5:",
         right: "50 left TOKENS",
         percentRemaining: 20,
         resetTimeIso: "2026-01-01T12:00:00Z",
@@ -105,6 +105,36 @@ describe("google agy provider", () => {
       singleWindowDisplayName: "Google Agy",
       singleWindowShowRight: true,
     });
+  });
+
+  it("groups and filters multiple models into canonical display buckets", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: true,
+      buckets: [
+        { modelId: "gemini-2-5-flash", displayName: "Gemini 2.5 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
+        { modelId: "gemini-2-5-pro", displayName: "Gemini 2.5 Pro", accountEmail: "test@a.com", percentRemaining: 12 },
+        { modelId: "gemini-3-flash", displayName: "Gemini 3 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
+        { modelId: "gemini-3-1-pro-high", displayName: "Gemini 3.1 Pro High", accountEmail: "test@a.com", percentRemaining: 12 },
+        { modelId: "gemini-3-5-flash", displayName: "Gemini 3.5 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
+        { modelId: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", accountEmail: "test@a.com", percentRemaining: 0 },
+        { modelId: "claude-opus-4-6-thinking", displayName: "Claude Opus 4.6 Thinking", accountEmail: "test@a.com", percentRemaining: 0 },
+        { modelId: "gpt-oss-120b", displayName: "GPT-OSS 120B (Medium)", accountEmail: "test@a.com", percentRemaining: 0 }, // Should be filtered out
+        { modelId: "chat-20706", displayName: "Chat 20706", accountEmail: "test@a.com", percentRemaining: 100 }, // Should be filtered out
+      ],
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    
+    // Check that we only get the 4 consolidated groups, sorted alphabetically
+    const entryLabels = out.entries.map(e => e.label);
+    expect(entryLabels).toEqual([
+      "Claude 4.6:",
+      "Gemini 2.5:",
+      "Gemini 3 & 3.1:",
+      "Gemini 3.5:",
+    ]);
   });
 
   it("maps fetch failures into toast errors", async () => {

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+import { googleAgyProvider } from "../src/providers/google-agy.js";
+
+vi.mock("../src/lib/google-agy.js", () => ({
+  hasAgyQuotaRuntimeAvailable: vi.fn(),
+  queryGoogleAgyQuota: vi.fn(),
+}));
+
+describe("google agy provider", () => {
+  it("preserves the Google Agy quota timeout default unless requestTimeoutMs is user-configured", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValue(null);
+
+    await googleAgyProvider.fetch({ client: {}, config: { requestTimeoutMs: 5000 } } as any);
+    expect(queryGoogleAgyQuota).toHaveBeenLastCalledWith({}, { requestTimeoutMs: undefined });
+
+    await googleAgyProvider.fetch({
+      client: {},
+      config: { requestTimeoutMs: 12000, requestTimeoutMsConfigured: true },
+    } as any);
+    expect(queryGoogleAgyQuota).toHaveBeenLastCalledWith({}, { requestTimeoutMs: 12000 });
+  });
+
+  it("returns attempted:false when Google Agy auth is not configured", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce(null);
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectNotAttempted(out);
+  });
+
+  it("maps quota buckets into grouped toast entries and truncated error labels", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: true,
+      buckets: [
+        {
+          modelId: "gpt-4",
+          displayName: "GPT 4",
+          accountEmail: "alice@example.com",
+          percentRemaining: 64,
+          resetTimeIso: "2026-01-01T00:00:00.000Z",
+          remainingAmount: "1234",
+          tokenType: "REQUESTS",
+        },
+      ],
+      errors: [{ email: "bob@example.com", error: "Unauthorized" }],
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expect(out.attempted).toBe(true);
+    expect(out.entries).toEqual([
+      {
+        name: "GPT 4 (ali..example)",
+        group: "Google Agy",
+        label: "GPT 4:",
+        right: "1,234 left",
+        percentRemaining: 64,
+        resetTimeIso: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    expect(out.errors).toEqual([{ label: "bob..example", message: "Unauthorized" }]);
+    expect(out.presentation).toEqual({
+      singleWindowDisplayName: "Google Agy",
+      singleWindowShowRight: true,
+    });
+  });
+
+  it("maps aggregated Google Agy quality tiers without changing provider presentation", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: true,
+      buckets: [
+        {
+          modelId: "gpt-4",
+          displayName: "GPT 4",
+          accountEmail: "alice@example.com",
+          percentRemaining: 20,
+          resetTimeIso: "2026-01-01T12:00:00Z",
+          remainingAmount: "50",
+          tokenType: "TOKENS",
+        },
+      ],
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "GPT 4 (ali..example)",
+        group: "Google Agy",
+        label: "GPT 4:",
+        right: "50 left TOKENS",
+        percentRemaining: 20,
+        resetTimeIso: "2026-01-01T12:00:00Z",
+      },
+    ]);
+    expect(out.presentation).toEqual({
+      singleWindowDisplayName: "Google Agy",
+      singleWindowShowRight: true,
+    });
+  });
+
+  it("maps fetch failures into toast errors", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: false,
+      error: "Token expired",
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectAttemptedWithErrorLabel(out, "Google Agy");
+  });
+
+  it("is available only when the Google Agy runtime is configured", async () => {
+    const { hasAgyQuotaRuntimeAvailable } = await import("../src/lib/google-agy.js");
+    (hasAgyQuotaRuntimeAvailable as any).mockResolvedValueOnce(true);
+    await expect(googleAgyProvider.isAvailable({ client: {} } as any)).resolves.toBe(true);
+
+    (hasAgyQuotaRuntimeAvailable as any).mockResolvedValueOnce(false);
+    await expect(googleAgyProvider.isAvailable({ client: {} } as any)).resolves.toBe(false);
+  });
+
+  it("matches Google Agy current model ids", () => {
+    expect(googleAgyProvider.matchesCurrentModel?.("google-agy/gpt-4")).toBe(true);
+    expect(googleAgyProvider.matchesCurrentModel?.("opencode-agy-auth/gpt-4")).toBe(true);
+    expect(googleAgyProvider.matchesCurrentModel?.("google-agy-auth/gpt-4")).toBe(true);
+    expect(googleAgyProvider.matchesCurrentModel?.("google/claude-opus")).toBe(false);
+  });
+});

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -13,7 +13,7 @@ vi.mock("../src/lib/google-agy.js", () => ({
 }));
 
 describe("google agy provider", () => {
-  it("preserves the Google Agy quota timeout default unless requestTimeoutMs is user-configured", async () => {
+  it("preserves the Google AGY quota timeout default unless requestTimeoutMs is user-configured", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValue(null);
 
@@ -27,7 +27,7 @@ describe("google agy provider", () => {
     expect(queryGoogleAgyQuota).toHaveBeenLastCalledWith({}, { requestTimeoutMs: 12000 });
   });
 
-  it("returns attempted:false when Google Agy auth is not configured", async () => {
+  it("returns attempted:false when Google AGY auth is not configured", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce(null);
 
@@ -58,7 +58,7 @@ describe("google agy provider", () => {
     expect(out.entries).toEqual([
       {
         name: "Gemini Models (ali..example)",
-        group: "Google Agy",
+        group: "Google AGY",
         label: "Gemini Models:",
         right: "1,234 left",
         percentRemaining: 64,
@@ -67,12 +67,12 @@ describe("google agy provider", () => {
     ]);
     expect(out.errors).toEqual([{ label: "bob..example", message: "Unauthorized" }]);
     expect(out.presentation).toEqual({
-      singleWindowDisplayName: "Google Agy",
+      singleWindowDisplayName: "Google AGY",
       singleWindowShowRight: true,
     });
   });
 
-  it("maps aggregated Google Agy quality tiers without changing provider presentation", async () => {
+  it("maps aggregated Google AGY quality tiers without changing provider presentation", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({
       success: true,
@@ -94,7 +94,7 @@ describe("google agy provider", () => {
     expect(out.entries).toEqual([
       {
         name: "Gemini Models (ali..example)",
-        group: "Google Agy",
+        group: "Google AGY",
         label: "Gemini Models:",
         right: "50 left TOKENS",
         percentRemaining: 20,
@@ -102,7 +102,7 @@ describe("google agy provider", () => {
       },
     ]);
     expect(out.presentation).toEqual({
-      singleWindowDisplayName: "Google Agy",
+      singleWindowDisplayName: "Google AGY",
       singleWindowShowRight: true,
     });
   });
@@ -143,10 +143,10 @@ describe("google agy provider", () => {
     });
 
     const out = await googleAgyProvider.fetch({ client: {} } as any);
-    expectAttemptedWithErrorLabel(out, "Google Agy");
+    expectAttemptedWithErrorLabel(out, "Google AGY");
   });
 
-  it("is available only when the Google Agy runtime is configured", async () => {
+  it("is available only when the Google AGY runtime is configured", async () => {
     const { hasAgyQuotaRuntimeAvailable } = await import("../src/lib/google-agy.js");
     (hasAgyQuotaRuntimeAvailable as any).mockResolvedValueOnce(true);
     await expect(googleAgyProvider.isAvailable({ client: {} } as any)).resolves.toBe(true);
@@ -155,7 +155,7 @@ describe("google agy provider", () => {
     await expect(googleAgyProvider.isAvailable({ client: {} } as any)).resolves.toBe(false);
   });
 
-  it("matches Google Agy current model ids", () => {
+  it("matches Google AGY current model ids", () => {
     expect(googleAgyProvider.matchesCurrentModel?.("google-agy/gpt-4")).toBe(true);
     expect(googleAgyProvider.matchesCurrentModel?.("opencode-agy-auth/gpt-4")).toBe(true);
     expect(googleAgyProvider.matchesCurrentModel?.("google-agy-auth/gpt-4")).toBe(true);


### PR DESCRIPTION
## Summary

Introduces the `google-agy` quota provider, enabling the system to fetch and display usage data from the Google Agy Code Assist API. 

```
# Current returns:
> node dist/bin/opencode-quota.js show --provider google-agy
[Google Agy]
Claude and GPT models                           4d
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    0% left
Gemini Models                                   3d
░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░    1% left
```

## Linked Issue

https://github.com/slkiser/opencode-quota/issues/125

## OpenCode Validation

- Current production released OpenCode version tested: 1.17.4
- Why this version is relevant to the fix:

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test`
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
