### PR TITLE
fix(opencode-go): add dual parser for SolidJS SSR and data-slot formats

### DIFF
--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -46,15 +46,6 @@ const RE_MONTHLY_RESET_FIRST = new RegExp(
   String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
 );
 
-/**
- * Regex patterns for the newer data-slot HTML format.
- * Used for extracting usage values from HTML like:
- * <span data-slot="usage-value"><!--$-->66<!--/-->%</span>
- */
-const RE_DATA_SLOT_USAGE_VALUE = new RegExp(
-  String.raw`data-slot="usage-value">[^%]*${SCRAPED_NUMBER_PATTERN}%?`,
-);
-
 interface ScrapedWindowUsage {
   usagePercent: number;
   resetInSec: number;
@@ -115,14 +106,11 @@ function parseHumanReadableTime(timeStr: string): number {
 function parseDataSlotFormat(html: string): Partial<Record<string, ScrapedWindowUsage>> {
   const result: Partial<Record<string, ScrapedWindowUsage>> = {};
 
-  // Split by usage-item to get each window's content
+  // ponytail: split consumes the delimiter, so each chunk is already isolated
   const items = html.split(/data-slot="usage-item"/);
 
   for (let i = 1; i < items.length; i++) {
-    const itemHtml = items[i];
-    // Get content until the next usage-item or end
-    const endIndex = itemHtml.indexOf('data-slot="usage-item"');
-    const content = endIndex >= 0 ? itemHtml.substring(0, endIndex) : itemHtml;
+    const content = items[i];
 
     // Extract the label (Rolling Usage, Weekly Usage, Monthly Usage)
     const labelMatch = content.match(/data-slot="usage-label">([^<]+)</);
@@ -213,37 +201,32 @@ export async function queryOpenCodeGoQuota(
     const html = await response.text();
 
     // Try SolidJS SSR format first (more reliable when present)
-    const rolling = parseWindowUsage(html, RE_ROLLING_PCT_FIRST, RE_ROLLING_RESET_FIRST);
-    const weekly = parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST);
-    const monthly = parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST);
+    let rolling = parseWindowUsage(html, RE_ROLLING_PCT_FIRST, RE_ROLLING_RESET_FIRST);
+    let weekly = parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST);
+    let monthly = parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST);
 
-    // If SolidJS SSR parsing found at least one window, use it
-    if (rolling || weekly || monthly) {
-      const now = Date.now();
+    // Fall back to data-slot HTML format if SSR found nothing
+    if (!rolling && !weekly && !monthly) {
+      const dataSlotResult = parseDataSlotFormat(html);
+      rolling = dataSlotResult.rolling ?? null;
+      weekly = dataSlotResult.weekly ?? null;
+      monthly = dataSlotResult.monthly ?? null;
+    }
+
+    if (!rolling && !weekly && !monthly) {
       return {
-        success: true,
-        ...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
-        ...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
-        ...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
+        success: false,
+        error:
+          "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)",
       };
     }
 
-    // Fall back to data-slot HTML format
-    const dataSlotResult = parseDataSlotFormat(html);
-    if (Object.keys(dataSlotResult).length > 0) {
-      const now = Date.now();
-      return {
-        success: true,
-        ...(dataSlotResult.rolling ? { rolling: normalizeWindowUsage(dataSlotResult.rolling, now) } : {}),
-        ...(dataSlotResult.weekly ? { weekly: normalizeWindowUsage(dataSlotResult.weekly, now) } : {}),
-        ...(dataSlotResult.monthly ? { monthly: normalizeWindowUsage(dataSlotResult.monthly, now) } : {}),
-      };
-    }
-
+    const now = Date.now();
     return {
-      success: false,
-      error:
-        "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)",
+      success: true,
+      ...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
+      ...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
+      ...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
     };
   } catch (err) {
     return {

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -106,7 +106,6 @@ function parseHumanReadableTime(timeStr: string): number {
 function parseDataSlotFormat(html: string): Partial<Record<string, ScrapedWindowUsage>> {
   const result: Partial<Record<string, ScrapedWindowUsage>> = {};
 
-  // ponytail: split consumes the delimiter, so each chunk is already isolated
   const items = html.split(/data-slot="usage-item"/);
 
   for (let i = 1; i < items.length; i++) {

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -1,9 +1,12 @@
 /**
  * OpenCode Go dashboard scraper.
  *
- * Fetches the OpenCode Go workspace page and parses SolidJS SSR hydration
- * output for known usage windows (`rollingUsage`, `weeklyUsage`, and
- * `monthlyUsage`) containing `usagePercent` and `resetInSec`.
+ * Fetches the OpenCode Go workspace page and parses usage data from two
+ * possible formats:
+ * 1. SolidJS SSR hydration output (`$R[\d+]={...usagePercent...resetInSec...}`)
+ * 2. HTML with `data-slot` attributes (newer format)
+ *
+ * The scraper tries SolidJS SSR first, then falls back to data-slot parsing.
  */
 
 import { fetchWithTimeout } from "./http.js";
@@ -43,6 +46,15 @@ const RE_MONTHLY_RESET_FIRST = new RegExp(
   String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
 );
 
+/**
+ * Regex patterns for the newer data-slot HTML format.
+ * Used for extracting usage values from HTML like:
+ * <span data-slot="usage-value"><!--$-->66<!--/-->%</span>
+ */
+const RE_DATA_SLOT_USAGE_VALUE = new RegExp(
+  String.raw`data-slot="usage-value">[^%]*${SCRAPED_NUMBER_PATTERN}%?`,
+);
+
 interface ScrapedWindowUsage {
   usagePercent: number;
   resetInSec: number;
@@ -72,6 +84,84 @@ function parseWindowUsage(
   }
 
   return null;
+}
+
+/**
+ * Parse human-readable time strings like "1 hour 56 minutes", "6 days 2 hours", "26 days 17 hours"
+ * into seconds.
+ */
+function parseHumanReadableTime(timeStr: string): number {
+  const normalized = timeStr.toLowerCase().trim();
+  let totalSeconds = 0;
+
+  // Match patterns like "X days", "X hours", "X minutes", "X seconds"
+  const dayMatch = normalized.match(/(\d+(?:\.\d+)?)\s*days?/);
+  const hourMatch = normalized.match(/(\d+(?:\.\d+)?)\s*hours?/);
+  const minuteMatch = normalized.match(/(\d+(?:\.\d+)?)\s*minutes?/);
+  const secondMatch = normalized.match(/(\d+(?:\.\d+)?)\s*seconds?/);
+
+  if (dayMatch) totalSeconds += Number(dayMatch[1]) * 86400;
+  if (hourMatch) totalSeconds += Number(hourMatch[1]) * 3600;
+  if (minuteMatch) totalSeconds += Number(minuteMatch[1]) * 60;
+  if (secondMatch) totalSeconds += Number(secondMatch[1]);
+
+  return totalSeconds;
+}
+
+/**
+ * Parse the newer data-slot HTML format.
+ * Returns a record of window names to their usage data.
+ */
+function parseDataSlotFormat(html: string): Partial<Record<string, ScrapedWindowUsage>> {
+  const result: Partial<Record<string, ScrapedWindowUsage>> = {};
+
+  // Split by usage-item to get each window's content
+  const items = html.split(/data-slot="usage-item"/);
+
+  for (let i = 1; i < items.length; i++) {
+    const itemHtml = items[i];
+    // Get content until the next usage-item or end
+    const endIndex = itemHtml.indexOf('data-slot="usage-item"');
+    const content = endIndex >= 0 ? itemHtml.substring(0, endIndex) : itemHtml;
+
+    // Extract the label (Rolling Usage, Weekly Usage, Monthly Usage)
+    const labelMatch = content.match(/data-slot="usage-label">([^<]+)</);
+    if (!labelMatch) continue;
+
+    const label = labelMatch[1].trim().toLowerCase();
+
+    // Extract usage percentage - get the number after data-slot="usage-value">
+    const usageMatch = content.match(/data-slot="usage-value">[^0-9]*(\d+(?:\.\d+)?)/);
+    if (!usageMatch) continue;
+    const usagePercent = Number(usageMatch[1]);
+
+    // Extract reset time - get content between reset-time"> and </span>
+    const resetMatch = content.match(/data-slot="reset-time">([\s\S]*?)<\/span>/);
+    if (!resetMatch) continue;
+
+    // Clean up SolidJS comments and "Resets in" prefix
+    const resetContent = resetMatch[1]
+      .replace(/<!--\$-->/g, "")
+      .replace(/<!--\/-->/g, "")
+      .replace(/Resets?\s*in\s*/i, "")
+      .trim();
+
+    const resetInSec = parseHumanReadableTime(resetContent);
+
+    if (!Number.isFinite(usagePercent) || !Number.isFinite(resetInSec) || resetInSec === 0) continue;
+
+    // Map label to window key
+    let windowKey: string | null = null;
+    if (label.includes("rolling")) windowKey = "rolling";
+    else if (label.includes("weekly")) windowKey = "weekly";
+    else if (label.includes("monthly")) windowKey = "monthly";
+
+    if (windowKey) {
+      result[windowKey] = { usagePercent, resetInSec };
+    }
+  }
+
+  return result;
 }
 
 function sanitizeMessage(text: string, maxLength = 120): string {
@@ -121,25 +211,39 @@ export async function queryOpenCodeGoQuota(
     }
 
     const html = await response.text();
+
+    // Try SolidJS SSR format first (more reliable when present)
     const rolling = parseWindowUsage(html, RE_ROLLING_PCT_FIRST, RE_ROLLING_RESET_FIRST);
     const weekly = parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST);
     const monthly = parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST);
 
-    if (!rolling && !weekly && !monthly) {
+    // If SolidJS SSR parsing found at least one window, use it
+    if (rolling || weekly || monthly) {
+      const now = Date.now();
       return {
-        success: false,
-        error:
-          "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)",
+        success: true,
+        ...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
+        ...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
+        ...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
       };
     }
 
-    const now = Date.now();
+    // Fall back to data-slot HTML format
+    const dataSlotResult = parseDataSlotFormat(html);
+    if (Object.keys(dataSlotResult).length > 0) {
+      const now = Date.now();
+      return {
+        success: true,
+        ...(dataSlotResult.rolling ? { rolling: normalizeWindowUsage(dataSlotResult.rolling, now) } : {}),
+        ...(dataSlotResult.weekly ? { weekly: normalizeWindowUsage(dataSlotResult.weekly, now) } : {}),
+        ...(dataSlotResult.monthly ? { monthly: normalizeWindowUsage(dataSlotResult.monthly, now) } : {}),
+      };
+    }
 
     return {
-      success: true,
-      ...(rolling ? { rolling: normalizeWindowUsage(rolling, now) } : {}),
-      ...(weekly ? { weekly: normalizeWindowUsage(weekly, now) } : {}),
-      ...(monthly ? { monthly: normalizeWindowUsage(monthly, now) } : {}),
+      success: false,
+      error:
+        "Could not parse any known OpenCode Go dashboard usage windows (rollingUsage, weeklyUsage, monthlyUsage)",
     };
   } catch (err) {
     return {
@@ -149,4 +253,4 @@ export async function queryOpenCodeGoQuota(
   }
 }
 
-export { parseWindowUsage as _parseWindowUsage };
+export { parseWindowUsage as _parseWindowUsage, parseDataSlotFormat as _parseDataSlotFormat };

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -21,7 +21,7 @@ vi.mock("../src/lib/http.js", () => ({
 }));
 
 import { opencodeGoProvider } from "../src/providers/opencode-go.js";
-import { _parseWindowUsage } from "../src/lib/opencode-go.js";
+import { _parseWindowUsage, _parseDataSlotFormat } from "../src/lib/opencode-go.js";
 
 function mockConfigNone() {
   mocks.resolveOpenCodeGoConfigCached.mockResolvedValueOnce({ state: "none" });
@@ -101,6 +101,59 @@ function buildPartialDashboardHtml(
     .join("");
 
   return `<html><script>${chunks}</script></html>`;
+}
+
+/**
+ * Build HTML in the newer data-slot format (as seen in the dashboard after OpenCode UI changes).
+ */
+function buildDataSlotDashboardHtml(
+  rollingUsagePercent: number,
+  rollingResetTime: string,
+  weeklyUsagePercent: number,
+  weeklyResetTime: string,
+  monthlyUsagePercent: number,
+  monthlyResetTime: string,
+): string {
+  return `<div data-slot="usage"><!--$-->
+    <div data-slot="usage-item">
+      <div data-slot="usage-header"><span data-slot="usage-label">Rolling Usage</span><span data-slot="usage-value"><!--$-->${rollingUsagePercent}<!--/-->%</span></div>
+      <div data-slot="progress"><div data-slot="progress-bar" style="width: ${rollingUsagePercent}%;"></div></div>
+      <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->${rollingResetTime}<!--/--></span>
+    </div>
+    <div data-slot="usage-item">
+      <div data-slot="usage-header"><span data-slot="usage-label">Weekly Usage</span><span data-slot="usage-value"><!--$-->${weeklyUsagePercent}<!--/-->%</span></div>
+      <div data-slot="progress"><div data-slot="progress-bar" style="width: ${weeklyUsagePercent}%;"></div></div>
+      <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->${weeklyResetTime}<!--/--></span>
+    </div>
+    <div data-slot="usage-item">
+      <div data-slot="usage-header"><span data-slot="usage-label">Monthly Usage</span><span data-slot="usage-value"><!--$-->${monthlyUsagePercent}<!--/-->%</span></div>
+      <div data-slot="progress"><div data-slot="progress-bar" style="width: ${monthlyUsagePercent}%;"></div></div>
+      <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->${monthlyResetTime}<!--/--></span>
+    </div>
+  </div>`;
+}
+
+/**
+ * Build HTML with only data-slot format (no SolidJS SSR variables).
+ */
+function buildDataSlotOnlyHtml(
+  windows: Partial<Record<OpenCodeGoTestWindow, [usagePercent: number, resetTime: string]>>,
+): string {
+  const items = (["rolling", "weekly", "monthly"] as const)
+    .map((window) => {
+      const usage = windows[window];
+      if (!usage) return "";
+      const [usagePercent, resetTime] = usage;
+      const label = window === "rolling" ? "Rolling Usage" : window === "weekly" ? "Weekly Usage" : "Monthly Usage";
+      return `<div data-slot="usage-item">
+        <div data-slot="usage-header"><span data-slot="usage-label">${label}</span><span data-slot="usage-value"><!--$-->${usagePercent}<!--/-->%</span></div>
+        <div data-slot="progress"><div data-slot="progress-bar" style="width: ${usagePercent}%;"></div></div>
+        <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->${resetTime}<!--/--></span>
+      </div>`;
+    })
+    .join("");
+
+  return `<div data-slot="usage"><!--$-->${items}</div>`;
 }
 
 function mockDashboardSuccess(html: string) {
@@ -367,6 +420,88 @@ describe("opencode-go provider", () => {
     expectAttemptedWithErrorLabel(out, "OpenCode Go");
     expect(out.errors[0]?.message).toBe("OpenCode Go dashboard error 500: Internal Error retry");
   });
+
+  it("parses data-slot HTML format when SolidJS SSR is not present", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(
+      buildDataSlotOnlyHtml({
+        rolling: [1, "1 hour 56 minutes"],
+        weekly: [1, "6 days 2 hours"],
+        monthly: [0, "26 days 17 hours"],
+      }),
+    );
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(3);
+    expect(out.entries[0]).toMatchObject({
+      name: "OpenCode Go 5h",
+      group: "OpenCode Go",
+      label: "5h:",
+      percentRemaining: 99,
+    });
+    expect(out.entries[1]).toMatchObject({
+      name: "OpenCode Go Weekly",
+      group: "OpenCode Go",
+      label: "Weekly:",
+      percentRemaining: 99,
+    });
+    expect(out.entries[2]).toMatchObject({
+      name: "OpenCode Go Monthly",
+      group: "OpenCode Go",
+      label: "Monthly:",
+      percentRemaining: 100,
+    });
+  });
+
+  it("prefers SolidJS SSR format when both formats are present", async () => {
+    mockConfigConfigured();
+    // HTML with both SolidJS SSR and data-slot formats
+    const mixedHtml = `<html><script>rollingUsage:$R[10]={usagePercent:7,resetInSec:18000}weeklyUsage:$R[11]={usagePercent:2,resetInSec:540000}monthlyUsage:$R[12]={usagePercent:16,resetInSec:2480000}</script>
+    <div data-slot="usage">
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Rolling Usage</span>
+        <span data-slot="usage-value"><!--$-->99<!--/-->%</span>
+        <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->1 hour<!--/--></span>
+      </div>
+    </div></html>`;
+    mockDashboardSuccess(mixedHtml);
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithNoErrors(out);
+    // Should use SolidJS SSR values (7%, 2%, 16%) not data-slot values (99%)
+    expect(out.entries[0]).toMatchObject({ percentRemaining: 93 });
+    expect(out.entries[1]).toMatchObject({ percentRemaining: 98 });
+    expect(out.entries[2]).toMatchObject({ percentRemaining: 84 });
+  });
+
+  it("parses data-slot format with partial windows", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess(
+      buildDataSlotOnlyHtml({
+        rolling: [5, "2 hours"],
+        monthly: [50, "30 days"],
+      }),
+    );
+
+    const out = await runProviderFetch();
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0]).toMatchObject({ name: "OpenCode Go 5h", percentRemaining: 95 });
+    expect(out.entries[1]).toMatchObject({ name: "OpenCode Go Monthly", percentRemaining: 50 });
+  });
+
+  it("returns error when neither SolidJS SSR nor data-slot format is found", async () => {
+    mockConfigConfigured();
+    mockDashboardSuccess("<html><body><div>No usage data at all</div></body></html>");
+
+    const out = await runProviderFetch();
+    expectAttemptedWithErrorLabel(out, "OpenCode Go");
+    expect(out.errors[0]?.message).toContain("Could not parse any known OpenCode Go dashboard usage windows");
+  });
 });
 
 describe("opencode-go matchesCurrentModel", () => {
@@ -433,5 +568,90 @@ describe("_parseWindowUsage", () => {
       usagePercent: 10,
       resetInSec: 500,
     });
+  });
+});
+
+describe("_parseDataSlotFormat", () => {
+  it("returns empty object for HTML without data-slot usage items", () => {
+    expect(_parseDataSlotFormat("<html><body>no usage</body></html>")).toEqual({});
+  });
+
+  it("parses all three windows from data-slot HTML", () => {
+    const html = buildDataSlotOnlyHtml({
+      rolling: [1, "1 hour 56 minutes"],
+      weekly: [10, "6 days 2 hours"],
+      monthly: [50, "26 days 17 hours"],
+    });
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.rolling).toEqual({ usagePercent: 1, resetInSec: 6960 }); // 1h 56m = 6960s
+    expect(result.weekly).toEqual({ usagePercent: 10, resetInSec: 525600 }); // 6d 2h = 525600s
+    expect(result.monthly).toEqual({ usagePercent: 50, resetInSec: 2307600 }); // 26d 17h = 2307600s
+  });
+
+  it("parses partial windows", () => {
+    const html = buildDataSlotOnlyHtml({
+      rolling: [5, "2 hours"],
+      monthly: [80, "30 days"],
+    });
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.rolling).toEqual({ usagePercent: 5, resetInSec: 7200 });
+    expect(result.weekly).toBeUndefined();
+    expect(result.monthly).toEqual({ usagePercent: 80, resetInSec: 2592000 });
+  });
+
+  it("handles decimal usage percentages", () => {
+    const html = buildDataSlotOnlyHtml({
+      monthly: [66.5, "26 days"],
+    });
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.monthly).toEqual({ usagePercent: 66.5, resetInSec: 2246400 });
+  });
+
+  it("handles various time formats", () => {
+    const html = `<div data-slot="usage">
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Monthly Usage</span>
+        <span data-slot="usage-value"><!--$-->10<!--/-->%</span>
+        <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->5 minutes<!--/--></span>
+      </div>
+    </div>`;
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.monthly).toEqual({ usagePercent: 10, resetInSec: 300 });
+  });
+
+  it("handles time with only days", () => {
+    const html = `<div data-slot="usage">
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Monthly Usage</span>
+        <span data-slot="usage-value"><!--$-->20<!--/-->%</span>
+        <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->15 days<!--/--></span>
+      </div>
+    </div>`;
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.monthly).toEqual({ usagePercent: 20, resetInSec: 1296000 });
+  });
+
+  it("handles time with only hours", () => {
+    const html = `<div data-slot="usage">
+      <div data-slot="usage-item">
+        <span data-slot="usage-label">Rolling Usage</span>
+        <span data-slot="usage-value"><!--$-->5<!--/-->%</span>
+        <span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->3 hours<!--/--></span>
+      </div>
+    </div>`;
+
+    const result = _parseDataSlotFormat(html);
+
+    expect(result.rolling).toEqual({ usagePercent: 5, resetInSec: 10800 });
   });
 });


### PR DESCRIPTION
## Problem

The OpenCode Go dashboard has changed its HTML format for some users. While some users still see the SolidJS SSR hydration output format, others now receive a newer `data-slot` attribute based HTML format:

```html
<span data-slot="usage-value"><!--$-->66<!--/-->%</span>
<span data-slot="reset-time"><!--$-->Resets in<!--/--> <!--$-->26 days 17 hours<!--/--></span>
```

This causes the parser to fail with: *"Could not parse any known OpenCode Go dashboard usage windows"*

## Solution

Added a dual-format parser that:
1. **Tries SolidJS SSR format first** (more reliable when present)
2. **Falls back to data-slot HTML parsing** for users with the new format

This ensures backward compatibility while supporting the new dashboard format.

## Changes

- **`src/lib/opencode-go.ts`**:
  - Added `parseDataSlotFormat()` function for HTML parsing
  - Added `parseHumanReadableTime()` to convert time strings like "26 days 17 hours" to seconds
  - Updated `queryOpenCodeGoQuota()` to try both formats with fallback
  - Exported `_parseDataSlotFormat` for testing

- **`tests/providers.opencode-go.test.ts`**:
  - Added `buildDataSlotDashboardHtml()` and `buildDataSlotOnlyHtml()` test helpers
  - Added 11 new tests covering data-slot format parsing
  - Tests cover: full parsing, partial windows, decimal percentages, various time formats

## Test Results

- All 1062 tests passing (43 in opencode-go test file, up from 32)
- Typecheck passing
- No breaking changes to existing functionality

## Verification

Tested with real dashboard HTML captured from production:
- SolidJS SSR format: ✅ Works (existing behavior preserved)
- data-slot format: ✅ Works (new functionality)
- Mixed format (both present): ✅ Prefers SolidJS SSR
