### PR TITLE
fix: restore slash commands on Desktop App via command.execute.before fallback

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,6 +54,12 @@ import {
   formatMaintainerAnnouncementHomeCountLine,
   getMaintainerAnnouncementsSummary,
 } from "./lib/maintainer-announcements.js";
+import {
+  buildQuotaDialogCommandOutput,
+  isQuotaDialogCommand,
+  type QuotaDialogCommandId,
+} from "./lib/quota-dialog-commands.js";
+import { handled } from "./lib/command-handled.js";
 
 // =============================================================================
 // Types
@@ -1258,6 +1264,54 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
           cfg.default_agent = matches[0];
         }
       }
+    },
+
+    // Handle slash commands on environments without TUI keymap (e.g., Desktop App).
+    // On CLI with TUI, the keymap layer intercepts these commands first and calls
+    // handled(), so this hook is only reached when no TUI is available.
+    "command.execute.before": async (input: {
+      command: string;
+      args?: string;
+      query?: string;
+      arguments?: string;
+      sessionID?: string;
+    }) => {
+      const cmd = input.command;
+      if (!isQuotaDialogCommand(cmd)) return;
+
+      if (!configLoaded) {
+        await refreshConfig();
+      }
+
+      if (!config.enabled && cmd !== "quota_announcements") {
+        handled();
+      }
+
+      const runtime = await resolvePluginRuntimeContext({
+        sessionID: input.sessionID,
+        includeSessionMeta: true,
+      });
+
+      const commandArgs = input.arguments ?? input.args ?? input.query;
+      const result = await buildQuotaDialogCommandOutput({
+        command: cmd as QuotaDialogCommandId,
+        arguments: commandArgs,
+        client: runtime.client,
+        roots: { ...runtime.roots, fallbackDirectory: runtime.roots.workspaceRoot },
+        sessionID: input.sessionID,
+        sessionMeta: runtime.session.sessionMeta,
+        resolveSessionMeta: (sessionID) => getSessionModelMeta(sessionID),
+        lastSessionTokenError,
+        setLastSessionTokenError: (error) => {
+          lastSessionTokenError = error;
+        },
+      });
+
+      if (result.state === "output" && input.sessionID) {
+        await injectRawOutput(input.sessionID, result.output);
+      }
+
+      handled();
     },
 
     tool: {

--- a/tests/plugin.command-handled-boundary.test.ts
+++ b/tests/plugin.command-handled-boundary.test.ts
@@ -79,7 +79,7 @@ describe("plugin command handled boundary", () => {
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });
   });
 
-  it("does not register or handle migrated deterministic slash commands in the server plugin", async () => {
+  it("registers command.execute.before for Desktop App fallback when TUI keymap is unavailable", async () => {
     const { QuotaToastPlugin } = await import("../src/plugin.js");
     const client = createClient();
     const hooks = await QuotaToastPlugin({ client } as any);
@@ -88,7 +88,7 @@ describe("plugin command handled boundary", () => {
     await hooks.config?.(cfg as any);
 
     expect(cfg.command).toBeUndefined();
-    expect(hooks["command.execute.before"]).toBeUndefined();
+    expect(hooks["command.execute.before"]).toBeDefined();
     expect(client.session.prompt).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Restores `command.execute.before` hook for Desktop App slash command fallback. In v3.10.0, deterministic slash commands were moved entirely to TUI dialogs, which broke `/quota`, `/quota_status`, `/quota_announcements`, `/pricing_refresh`, and all `/tokens_*` commands on Desktop App (which has no TUI keymap).

## Fix

Added back `command.execute.before` hook in `plugin.ts` that:
1. Checks if command is a quota dialog command
2. Builds output using existing `buildQuotaDialogCommandOutput()`
3. Injects via `injectRawOutput()` (zero context pollution)

**No conflict with CLI:** On CLI, the TUI keymap intercepts slash commands first and calls `handled()`, so this hook never fires. On Desktop App without keymap, the hook fires.

## Changes

| File | Change |
|------|--------|
| `src/plugin.ts` | Added `command.execute.before` hook + imports |
| `tests/plugin.command-handled-boundary.test.ts` | Expect hook is defined |

## Verification

- `pnpm run typecheck` passes
- `pnpm run build` passes  
- `pnpm test` — 1071 passed
- `pnpm test -- tests/plugin.command-handled-boundary.test.ts` — all 5 pass