### PR TITLE
providers: Add neuralwatt

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | Zhipu Coding Plan | OpenCode config | Remote API | Usage/quota |
 | NanoGPT | API key/config | Remote API | Usage + balance |
 | DeepSeek | API key/config | Remote API | Balance/status |
+| Neuralwatt | API key/config | Remote API | Subscription kWh + credits |
 | Ollama Cloud | [Needs setup](docs/readme/providers.md#ollama-cloud) | Dashboard scraping | Dashboard usage |
 | OpenCode Go | [Needs setup](docs/readme/providers.md#opencode-go) | Dashboard scraping | Dashboard usage |
 

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -138,6 +138,35 @@ Or put the key in trusted user/global OpenCode config, not repo-local config:
 If you use manual provider selection, include `deepseek` in `enabledProviders`.
 
 
+<a id="neuralwatt"></a>
+### Neuralwatt
+
+Neuralwatt shows the subscription kWh allowance (when active) and USD credit balance from `GET https://api.neuralwatt.com/v1/quota`. Neuralwatt is an OpenAI-compatible API; set `baseURL` to `https://api.neuralwatt.com/v1`.
+
+Use one of these trusted API-key sources:
+
+```bash
+export NEURALWATT_API_KEY="sk-your-api-key"
+```
+
+Or put the key in trusted user/global OpenCode config, not repo-local config:
+
+```jsonc
+{
+  "provider": {
+    "neuralwatt": {
+      "options": {
+        "baseURL": "https://api.neuralwatt.com/v1",
+        "apiKey": "{env:NEURALWATT_API_KEY}",
+      },
+    },
+  },
+}
+```
+
+If you use manual provider selection, include `neuralwatt` in `enabledProviders`.
+
+
 <a id="ollama-cloud"></a>
 ### Ollama Cloud
 

--- a/docs/readme/troubleshooting.md
+++ b/docs/readme/troubleshooting.md
@@ -117,7 +117,7 @@ Run `/quota_status` and check the Alibaba auth, resolved tier, state-file path, 
 </details>
 
 <details>
-<summary><strong>MiniMax, Kimi, Chutes AI, Synthetic, Z.ai, Zhipu, NanoGPT, and DeepSeek</strong></summary>
+<summary><strong>MiniMax, Kimi, Chutes AI, Synthetic, Z.ai, Zhipu, NanoGPT, DeepSeek, and Neuralwatt</strong></summary>
 
 These providers use trusted env vars, trusted user/global OpenCode config, or native OpenCode auth. Run `/quota_status` and check the provider-specific API-key diagnostics.
 
@@ -132,6 +132,7 @@ These providers use trusted env vars, trusted user/global OpenCode config, or na
 | Zhipu Coding Plan | Use `ZHIPU_API_KEY` or `ZHIPU_CODING_PLAN_API_KEY`; malformed fallback auth is surfaced as an auth error. |
 | NanoGPT | Use `NANOGPT_API_KEY`, `NANO_GPT_API_KEY`, trusted user/global config, or OpenCode auth. |
 | DeepSeek | Use `DEEPSEEK_API_KEY`, trusted user/global config under `provider.deepseek.options.apiKey`, or OpenCode auth. This provider shows balance only because DeepSeek does not expose a quota reset window. |
+| Neuralwatt | Use `NEURALWATT_API_KEY`, trusted user/global config under `provider.neuralwatt.options.apiKey` (OpenAI-compatible; set `baseURL` to `https://api.neuralwatt.com/v1`), or OpenCode auth. Shows subscription kWh allowance plus USD credit balance from `GET https://api.neuralwatt.com/v1/quota`. |
 
 For security, repo-local `opencode.json` / `opencode.jsonc` is ignored for provider secrets in these integrations. Put secrets in environment variables or trusted user/global config. OpenCode auth fallbacks for API-key providers require `{ "type": "api", "key": "..." }` entries.
 

--- a/src/lib/neuralwatt-config.ts
+++ b/src/lib/neuralwatt-config.ts
@@ -1,0 +1,51 @@
+import { readAuthFile } from "./opencode-auth.js";
+import {
+  getApiKeyDiagnostics,
+  getGlobalOpencodeConfigCandidatePaths,
+  resolveProviderApiKey,
+} from "./api-key-resolver.js";
+
+const ENV_KEYS = ["NEURALWATT_API_KEY"] as const;
+const PROVIDER_KEYS = ["neuralwatt"] as const;
+
+export type NeuralwattKeySource =
+  | "env:NEURALWATT_API_KEY"
+  | "opencode.json"
+  | "opencode.jsonc"
+  | "auth.json";
+
+export interface NeuralwattApiKeyResult {
+  key: string;
+  source: NeuralwattKeySource;
+}
+
+export async function resolveNeuralwattApiKey(): Promise<NeuralwattApiKeyResult | null> {
+  return resolveProviderApiKey<NeuralwattKeySource>({
+    envVars: [{ name: "NEURALWATT_API_KEY", source: "env:NEURALWATT_API_KEY" }],
+    providerKeys: PROVIDER_KEYS,
+    allowedEnvVars: ENV_KEYS,
+    configJsonSource: "opencode.json",
+    configJsoncSource: "opencode.jsonc",
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+    auth: {
+      readAuth: readAuthFile,
+      authSource: "auth.json",
+    },
+  });
+}
+
+export async function hasNeuralwattApiKey(): Promise<boolean> {
+  return (await resolveNeuralwattApiKey()) !== null;
+}
+
+export async function getNeuralwattKeyDiagnostics(): Promise<{
+  configured: boolean;
+  source: NeuralwattKeySource | null;
+  checkedPaths: string[];
+}> {
+  return getApiKeyDiagnostics<NeuralwattKeySource>({
+    envVarNames: ["NEURALWATT_API_KEY"],
+    resolve: resolveNeuralwattApiKey,
+    getConfigCandidates: getGlobalOpencodeConfigCandidatePaths,
+  });
+}

--- a/src/lib/neuralwatt.ts
+++ b/src/lib/neuralwatt.ts
@@ -1,0 +1,405 @@
+/**
+ * Neuralwatt live quota fetcher.
+ *
+ * Queries:
+ * - https://api.neuralwatt.com/v1/quota
+ *
+ * Returns account balance, usage, limits, subscription state (kWh allowance),
+ * and per-key spending allowance.
+ */
+
+import type { QuotaError } from "./types.js";
+import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
+import { clampPercent, fmtUsdAmount } from "./format-utils.js";
+import { fetchWithTimeout } from "./http.js";
+import {
+  getNeuralwattKeyDiagnostics,
+  resolveNeuralwattApiKey,
+  type NeuralwattKeySource,
+} from "./neuralwatt-config.js";
+
+type NeuralwattRecord = Record<string, unknown>;
+
+/**
+ * A normalized percent window with a reset time. Used for the subscription
+ * kWh allowance and the per-key spending allowance.
+ */
+export interface NeuralwattUsageWindow {
+  used: number;
+  limit: number;
+  remaining: number;
+  percentRemaining: number;
+  resetTimeIso?: string;
+}
+
+export interface NeuralwattSubscription {
+  active: boolean;
+  state: string;
+  billingInterval?: string;
+  currentPeriodStartIso?: string;
+  currentPeriodEndIso?: string;
+  autoRenew?: boolean;
+  /** Charged kWh allowance window for the current billing period. */
+  kwh?: NeuralwattUsageWindow;
+  inOverage?: boolean;
+}
+
+export interface NeuralwattKeyAllowance {
+  limitUsd: number;
+  spentUsd: number;
+  remainingUsd: number;
+  period: string;
+  blocked: boolean;
+  /** Percent remaining for the current period. */
+  window: NeuralwattUsageWindow;
+}
+
+export interface NeuralwattBalance {
+  creditsRemainingUsd?: number;
+  totalCreditsUsd?: number;
+  creditsUsedUsd?: number;
+  accountingMethod?: string;
+}
+
+export interface NeuralwattUsageTotals {
+  costUsd?: number;
+  requests?: number;
+  tokens?: number;
+  energyKwh?: number;
+}
+
+export type NeuralwattResult =
+  | {
+      success: true;
+      balance?: NeuralwattBalance;
+      subscription?: NeuralwattSubscription;
+      keyAllowance?: NeuralwattKeyAllowance;
+      lifetimeUsage?: NeuralwattUsageTotals;
+      currentMonthUsage?: NeuralwattUsageTotals;
+    }
+  | QuotaError
+  | null;
+
+interface NeuralwattQuotaResponse {
+  snapshot_at?: string;
+  balance?: {
+    credits_remaining_usd?: number;
+    total_credits_usd?: number;
+    credits_used_usd?: number;
+    accounting_method?: string;
+  };
+  usage?: {
+    lifetime?: NeuralwattUsageTotalsResponse;
+    current_month?: NeuralwattUsageTotalsResponse;
+  };
+  limits?: {
+    overage_limit_usd?: number | null;
+    rate_limit_tier?: string;
+  };
+  subscription?: {
+    plan?: string;
+    status?: string;
+    billing_interval?: string | null;
+    current_period_start?: string | null;
+    current_period_end?: string | null;
+    auto_renew?: boolean | null;
+    kwh_included?: number | null;
+    kwh_used?: number | null;
+    kwh_remaining?: number | null;
+    in_overage?: boolean | null;
+  } | null;
+  key?: {
+    name?: string | null;
+    allowance?: {
+      limit_usd?: number;
+      period?: string;
+      spent_usd?: number;
+      remaining_usd?: number;
+      blocked?: boolean;
+    } | null;
+  };
+}
+
+interface NeuralwattUsageTotalsResponse {
+  cost_usd?: number;
+  requests?: number;
+  tokens?: number;
+  energy_kwh?: number;
+}
+
+const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+const NEURALWATT_QUOTA_URL = "https://api.neuralwatt.com/v1/quota";
+
+function isRecord(value: unknown): value is NeuralwattRecord {
+  return Boolean(value) && typeof value === "object";
+}
+
+function getFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getIsoString(value: unknown): string | undefined {
+  const raw = getNonEmptyString(value);
+  if (!raw) return undefined;
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return undefined;
+  return new Date(ms).toISOString();
+}
+
+function getBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function normalizeAllowanceWindow(
+  used: number,
+  limit: number,
+  remaining: number,
+  fallbackResetTimeIso?: string,
+): NeuralwattUsageWindow {
+  const safeLimit = limit > 0 ? limit : used + remaining;
+  const percentRemaining =
+    safeLimit > 0 ? clampPercent((Math.max(0, remaining) / safeLimit) * 100) : 0;
+  return {
+    used,
+    limit: safeLimit,
+    remaining: Math.max(0, remaining),
+    percentRemaining,
+    resetTimeIso: fallbackResetTimeIso,
+  };
+}
+
+function parseBalance(payload: unknown): NeuralwattBalance | undefined {
+  if (!isRecord(payload)) return undefined;
+  const creditsRemainingUsd = getFiniteNumber(payload.credits_remaining_usd);
+  const totalCreditsUsd = getFiniteNumber(payload.total_credits_usd);
+  const creditsUsedUsd = getFiniteNumber(payload.credits_used_usd);
+  const accountingMethod = getNonEmptyString(payload.accounting_method);
+  if (
+    creditsRemainingUsd === undefined &&
+    totalCreditsUsd === undefined &&
+    creditsUsedUsd === undefined &&
+    accountingMethod === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    creditsRemainingUsd,
+    totalCreditsUsd,
+    creditsUsedUsd,
+    accountingMethod,
+  };
+}
+
+function parseUsageTotals(payload: unknown): NeuralwattUsageTotals | undefined {
+  if (!isRecord(payload)) return undefined;
+  const costUsd = getFiniteNumber(payload.cost_usd);
+  const requests = getFiniteNumber(payload.requests);
+  const tokens = getFiniteNumber(payload.tokens);
+  const energyKwh = getFiniteNumber(payload.energy_kwh);
+  if (
+    costUsd === undefined &&
+    requests === undefined &&
+    tokens === undefined &&
+    energyKwh === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    costUsd,
+    requests: requests !== undefined ? Math.trunc(requests) : undefined,
+    tokens: tokens !== undefined ? Math.trunc(tokens) : undefined,
+    energyKwh,
+  };
+}
+
+function parseSubscription(payload: unknown): {
+  subscription?: NeuralwattSubscription;
+  error?: string;
+} {
+  if (payload === null || payload === undefined) return {};
+  if (!isRecord(payload)) {
+    return { error: "Neuralwatt subscription returned an unexpected response shape" };
+  }
+  const data = payload as NonNullable<NeuralwattQuotaResponse["subscription"]>;
+  const status = getNonEmptyString(data.status);
+  const kwhIncluded = getFiniteNumber(data.kwh_included);
+  const currentPeriodEndIso = getIsoString(data.current_period_end);
+
+  let kwh: NeuralwattUsageWindow | undefined;
+  if (kwhIncluded !== undefined && kwhIncluded > 0) {
+    const kwhUsed = getFiniteNumber(data.kwh_used) ?? 0;
+    const kwhRemainingRaw = getFiniteNumber(data.kwh_remaining);
+    const kwhRemaining =
+      kwhRemainingRaw !== undefined ? kwhRemainingRaw : Math.max(0, kwhIncluded - kwhUsed);
+    kwh = normalizeAllowanceWindow(kwhUsed, kwhIncluded, kwhRemaining, currentPeriodEndIso);
+  }
+
+  const subscription: NeuralwattSubscription = {
+    active: status === "active",
+    state: status ?? "unknown",
+    billingInterval: getNonEmptyString(data.billing_interval) ?? undefined,
+    currentPeriodStartIso: getIsoString(data.current_period_start),
+    currentPeriodEndIso,
+    autoRenew: getBoolean(data.auto_renew),
+    kwh,
+    inOverage: getBoolean(data.in_overage),
+  };
+
+  return { subscription };
+}
+
+function parseKeyAllowance(payload: unknown): {
+  keyAllowance?: NeuralwattKeyAllowance;
+  error?: string;
+} {
+  if (!isRecord(payload)) return {};
+  const allowance = payload.allowance;
+  if (allowance === null || allowance === undefined) return {};
+  if (!isRecord(allowance)) {
+    return { error: "Neuralwatt key allowance returned an unexpected response shape" };
+  }
+
+  const limitUsd = getFiniteNumber(allowance.limit_usd);
+  const spentUsd = getFiniteNumber(allowance.spent_usd);
+  const remainingUsd = getFiniteNumber(allowance.remaining_usd);
+  const period = getNonEmptyString(allowance.period);
+  if (limitUsd === undefined || spentUsd === undefined || remainingUsd === undefined) {
+    return { error: "Neuralwatt key allowance returned an unexpected response shape" };
+  }
+
+  const window = normalizeAllowanceWindow(spentUsd, limitUsd, remainingUsd);
+  return {
+    keyAllowance: {
+      limitUsd,
+      spentUsd,
+      remainingUsd,
+      period: period ?? "unknown",
+      blocked: getBoolean(allowance.blocked) ?? false,
+      window,
+    },
+  };
+}
+
+function parseNeuralwattQuota(
+  payload: unknown,
+): { success: true } & Omit<NeuralwattResult & { success: true }, "success"> {
+  if (!isRecord(payload)) {
+    throw new Error("Neuralwatt quota response returned an unexpected response shape");
+  }
+
+  const data = payload as NeuralwattQuotaResponse;
+  const balance = parseBalance(data.balance);
+  const lifetimeUsage = parseUsageTotals(data.usage?.lifetime);
+  const currentMonthUsage = parseUsageTotals(data.usage?.current_month);
+  const { subscription, error: subscriptionError } = parseSubscription(data.subscription);
+  const { keyAllowance, error: keyAllowanceError } = parseKeyAllowance(data.key);
+
+  if (!balance && !subscription && !keyAllowance && !lifetimeUsage && !currentMonthUsage) {
+    throw new Error("Neuralwatt quota response returned an unexpected response shape");
+  }
+
+  const errors: string[] = [];
+  if (subscriptionError) errors.push(subscriptionError);
+  if (keyAllowanceError) errors.push(keyAllowanceError);
+  if (errors.length > 0) {
+    throw new Error(errors.join("; "));
+  }
+
+  return {
+    success: true,
+    balance,
+    subscription,
+    keyAllowance,
+    lifetimeUsage,
+    currentMonthUsage,
+  };
+}
+
+async function fetchNeuralwattQuota(
+  headers: Record<string, string>,
+  requestTimeoutMs?: number,
+): Promise<{ success: true; payload: unknown } | { success: false; message: string }> {
+  try {
+    const response = await fetchWithTimeout(
+      NEURALWATT_QUOTA_URL,
+      {
+        method: "GET",
+        headers,
+      },
+      requestTimeoutMs,
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      const retryAfter = response.headers.get("Retry-After");
+      const suffix =
+        response.status === 429 && retryAfter ? ` (rate limited; retry after ${retryAfter}s)` : "";
+      return {
+        success: false,
+        message: `Neuralwatt API error ${response.status}${suffix}: ${sanitizeDisplaySnippet(
+          text,
+          120,
+        )}`,
+      };
+    }
+
+    return { success: true, payload: await response.json() };
+  } catch (err) {
+    return {
+      success: false,
+      message: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+export { getNeuralwattKeyDiagnostics, type NeuralwattKeySource } from "./neuralwatt-config.js";
+
+export function formatNeuralwattBalanceValue(balance: {
+  creditsRemainingUsd?: number;
+}): string | null {
+  if (
+    typeof balance.creditsRemainingUsd === "number" &&
+    Number.isFinite(balance.creditsRemainingUsd)
+  ) {
+    return fmtUsdAmount(balance.creditsRemainingUsd);
+  }
+  return null;
+}
+
+function fmtKwh(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  return `${value.toFixed(2).replace(/\.?0+$/, "")} kWh`;
+}
+
+export function formatNeuralwattKwhRight(window: { used: number; limit: number }): string {
+  return `${fmtKwh(window.used)}/${fmtKwh(window.limit)}`;
+}
+
+export async function queryNeuralwattQuota(
+  options: { requestTimeoutMs?: number } = {},
+): Promise<NeuralwattResult> {
+  const resolved = await resolveNeuralwattApiKey();
+  if (!resolved) return null;
+
+  const headers = {
+    Authorization: `Bearer ${resolved.key}`,
+    "User-Agent": USER_AGENT,
+  };
+
+  const result = await fetchNeuralwattQuota(headers, options.requestTimeoutMs);
+  if (!result.success) {
+    return { success: false, error: result.message };
+  }
+
+  try {
+    return parseNeuralwattQuota(result.payload);
+  } catch (err) {
+    return {
+      success: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -18,7 +18,8 @@ export type CanonicalQuotaProviderId =
   | "kimi-for-coding"
   | "deepseek"
   | "opencode-go"
-  | "ollama-cloud";
+  | "ollama-cloud"
+  | "neuralwatt";
 
 export type QuotaProviderAutoSetup = "yes" | "usually" | "manual_env_config" | "needs_quick_setup";
 
@@ -74,6 +75,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   deepseek: "DeepSeek",
   "opencode-go": "OpenCode Go",
   "ollama-cloud": "Ollama Cloud",
+  neuralwatt: "Neuralwatt",
 };
 
 export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
@@ -144,6 +146,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   deepseek: ["deepseek"],
   "opencode-go": ["opencode-go"],
   "ollama-cloud": ["ollama-cloud"],
+  neuralwatt: ["neuralwatt"],
 };
 
 const LIVE_LOCAL_USAGE_PROVIDER_ID_SET = new Set<string>([
@@ -293,6 +296,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     authentication: "state_only",
     quota: "remote_api",
     notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
+  },
+  {
+    id: "neuralwatt",
+    autoSetup: "yes",
+    authentication: "opencode_auth_api_key",
+    authFallbacks: ["env_api_key", "global_opencode_config"],
+    quota: "remote_api",
   },
 ];
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -12,6 +12,7 @@ import { inspectAgyAuthPresence } from "./google-agy.js";
 import { getAnthropicDiagnostics } from "./anthropic.js";
 import { getChutesKeyDiagnostics } from "./chutes.js";
 import { getNanoGptKeyDiagnostics, queryNanoGptQuota } from "./nanogpt.js";
+import { getNeuralwattKeyDiagnostics, queryNeuralwattQuota } from "./neuralwatt.js";
 import { getDeepSeekKeyDiagnostics } from "./deepseek.js";
 import { getSyntheticKeyDiagnostics } from "./synthetic.js";
 import { getCopilotQuotaAuthDiagnostics } from "./copilot.js";
@@ -516,6 +517,14 @@ function supportedProviderPricingRow(params: {
       id,
       pricing: "no",
       notes: "account balance only (not token-priced)",
+    };
+  }
+
+  if (id === "neuralwatt") {
+    return {
+      id,
+      pricing: "no",
+      notes: "subscription kWh allowance + account balance (not token-priced)",
     };
   }
 
@@ -1402,6 +1411,106 @@ export async function buildQuotaStatusReport(params: {
   }
   appendProviderCompactLiveProbeRows(nanoGptRows, "nanogpt", params.providerLiveProbes);
   sections.push(createKvSection("nanogpt", "nanogpt:", nanoGptRows));
+
+  // === neuralwatt ===
+  const neuralwattDiag = await readBasicApiKeyDiagnostics(getNeuralwattKeyDiagnostics);
+  const neuralwattRows: ReportKvRow[] = [
+    {
+      key: "neuralwatt api key",
+      value: formatInlineApiKeyDiagnosticsValue(neuralwattDiag),
+    },
+  ];
+  if (neuralwattDiag.configured) {
+    try {
+      const neuralwattQuota = await queryNeuralwattQuota();
+      if (!neuralwattQuota) {
+        neuralwattRows.push({
+          key: "live_fetch_error",
+          value: "Neuralwatt API key became unavailable before fetch",
+        });
+      } else if (!neuralwattQuota.success) {
+        neuralwattRows.push({ key: "live_fetch_error", value: neuralwattQuota.error });
+      } else {
+        if (neuralwattQuota.balance) {
+          const balance = neuralwattQuota.balance;
+          neuralwattRows.push({
+            key: "credits_remaining_usd",
+            value:
+              typeof balance.creditsRemainingUsd === "number"
+                ? fmtUsdAmount(balance.creditsRemainingUsd)
+                : "(none)",
+          });
+          neuralwattRows.push({
+            key: "total_credits_usd",
+            value:
+              typeof balance.totalCreditsUsd === "number"
+                ? fmtUsdAmount(balance.totalCreditsUsd)
+                : "(none)",
+          });
+          neuralwattRows.push({
+            key: "accounting_method",
+            value: balance.accountingMethod ?? "(none)",
+          });
+        }
+        if (neuralwattQuota.subscription) {
+          const sub = neuralwattQuota.subscription;
+          neuralwattRows.push({
+            key: "subscription_active",
+            value: sub.active ? "true" : "false",
+          });
+          neuralwattRows.push({ key: "subscription_state", value: sub.state });
+          if (sub.billingInterval) {
+            neuralwattRows.push({ key: "billing_interval", value: sub.billingInterval });
+          }
+          if (sub.kwh) {
+            neuralwattRows.push({
+              key: "kwh_usage",
+              value: `${sub.kwh.used.toFixed(4)}/${sub.kwh.limit.toFixed(4)} remaining=${sub.kwh.remaining.toFixed(
+                4,
+              )} percent_remaining=${sub.kwh.percentRemaining} reset_at=${sub.kwh.resetTimeIso ?? "(none)"}`,
+            });
+          }
+          if (sub.inOverage !== undefined) {
+            neuralwattRows.push({
+              key: "in_overage",
+              value: sub.inOverage ? "true" : "false",
+            });
+          }
+          neuralwattRows.push({
+            key: "billing_period_end",
+            value: sub.currentPeriodEndIso ?? "(none)",
+          });
+        }
+        if (neuralwattQuota.keyAllowance) {
+          const allowance = neuralwattQuota.keyAllowance;
+          neuralwattRows.push({
+            key: "key_allowance",
+            value: `${allowance.spentUsd.toFixed(2)}/${allowance.limitUsd.toFixed(
+              2,
+            )} remaining=${allowance.remainingUsd.toFixed(2)} period=${allowance.period} percent_remaining=${
+              allowance.window.percentRemaining
+            } blocked=${allowance.blocked ? "true" : "false"}`,
+          });
+        }
+        if (neuralwattQuota.currentMonthUsage) {
+          const month = neuralwattQuota.currentMonthUsage;
+          neuralwattRows.push({
+            key: "current_month_usage",
+            value: `cost_usd=${
+              typeof month.costUsd === "number" ? fmtUsdAmount(month.costUsd) : "(none)"
+            } requests=${month.requests ?? "(none)"} tokens=${month.tokens ?? "(none)"} energy_kwh=${
+              typeof month.energyKwh === "number" ? month.energyKwh.toFixed(4) : "(none)"
+            }`,
+          });
+        }
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      neuralwattRows.push({ key: "live_fetch_error", value: msg });
+    }
+  }
+  appendProviderCompactLiveProbeRows(neuralwattRows, "neuralwatt", params.providerLiveProbes);
+  sections.push(createKvSection("neuralwatt", "neuralwatt:", neuralwattRows));
 
   // === copilot auth ===
   const copilotDiag = getCopilotQuotaAuthDiagnostics(authData);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -305,6 +305,11 @@ export interface SyntheticAuthData {
   key: string;
 }
 
+export interface NeuralwattAuthData {
+  type: "api";
+  key: string;
+}
+
 export interface MiniMaxAuthData {
   type: string;
   key?: string;
@@ -384,6 +389,7 @@ export interface AuthData {
   };
   nanogpt?: NanoGptAuthData;
   "nano-gpt"?: NanoGptAuthData;
+  neuralwatt?: NeuralwattAuthData;
   deepseek?: DeepSeekAuthData;
   cursor?: CursorOAuthAuthData;
   // Canonical OpenCode provider id used by the Qwen auth plugin.

--- a/src/providers/neuralwatt.ts
+++ b/src/providers/neuralwatt.ts
@@ -1,0 +1,123 @@
+/**
+ * Neuralwatt provider wrapper.
+ *
+ * Normalizes Neuralwatt account quota into generic toast entries. When a
+ * subscription with a kWh allowance is active, shows the remaining kWh
+ * percentage (reset = billing period end); always shows the USD credit
+ * balance as a value entry. Falls back to credits-only when no subscription.
+ */
+
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import { hasNeuralwattApiKey } from "../lib/neuralwatt-config.js";
+import {
+  formatNeuralwattBalanceValue,
+  formatNeuralwattKwhRight,
+  queryNeuralwattQuota,
+} from "../lib/neuralwatt.js";
+import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
+import { modelProviderIncludesAny } from "../lib/provider-model-matching.js";
+import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+type NeuralwattQuotaSuccess = Extract<
+  NonNullable<Awaited<ReturnType<typeof queryNeuralwattQuota>>>,
+  { success: true }
+>;
+
+function mapNeuralwattSuccess(result: NeuralwattQuotaSuccess): QuotaProviderResult {
+  const entries: QuotaToastEntry[] = [];
+  const errors: { label: string; message: string }[] = [];
+
+  const subscription = result.subscription;
+  if (subscription?.kwh) {
+    entries.push({
+      name: "Neuralwatt Subscription",
+      group: "Neuralwatt",
+      label: "Plan:",
+      right: formatNeuralwattKwhRight(subscription.kwh),
+      percentRemaining: subscription.kwh.percentRemaining,
+      resetTimeIso: subscription.kwh.resetTimeIso,
+    });
+  }
+
+  if (result.keyAllowance) {
+    entries.push({
+      name: "Neuralwatt Key",
+      group: "Neuralwatt",
+      label: "Key:",
+      right: `$${result.keyAllowance.spentUsd.toFixed(2)}/$${result.keyAllowance.limitUsd.toFixed(
+        2,
+      )}`,
+      percentRemaining: result.keyAllowance.window.percentRemaining,
+    });
+  }
+
+  const balanceValue = result.balance ? formatNeuralwattBalanceValue(result.balance) : null;
+  if (balanceValue) {
+    entries.push({
+      kind: "value",
+      name: "Neuralwatt Credits",
+      group: "Neuralwatt",
+      label: "Credits:",
+      value: balanceValue,
+    });
+  }
+
+  if (subscription?.state && subscription.state.toLowerCase() !== "active") {
+    errors.push({
+      label: "Neuralwatt",
+      message: `Subscription state: ${subscription.state}`,
+    });
+  }
+
+  if (result.keyAllowance?.blocked) {
+    errors.push({
+      label: "Neuralwatt",
+      message: "API key is blocked (spending allowance reached)",
+    });
+  }
+
+  if (entries.length === 0) {
+    errors.push({
+      label: "Neuralwatt",
+      message: "No usable Neuralwatt quota or balance data",
+    });
+  }
+
+  return attemptedResult(entries, errors);
+}
+
+export const neuralwattProvider: QuotaProvider = {
+  id: "neuralwatt",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const providerAvailable = await isCanonicalProviderAvailable({
+      ctx,
+      providerId: "neuralwatt",
+      fallbackOnError: false,
+    });
+    if (providerAvailable) return true;
+
+    return await hasNeuralwattApiKey();
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    return modelProviderIncludesAny(model, ["neuralwatt"]);
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const result = await queryNeuralwattQuota({ requestTimeoutMs: ctx.config?.requestTimeoutMs });
+
+    if (!result) return notAttemptedResult();
+
+    if (!result.success) {
+      return attemptedErrorResult("Neuralwatt", result.error);
+    }
+
+    return mapNeuralwattSuccess(result);
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -27,6 +27,7 @@ import { opencodeGoProvider } from "./opencode-go.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
 import { ollamaCloudProvider } from "./ollama-cloud.js";
+import { neuralwattProvider } from "./neuralwatt.js";
 
 export function getProviders(): QuotaProvider[] {
   // Order here defines display ordering in the toast.
@@ -51,5 +52,6 @@ export function getProviders(): QuotaProvider[] {
     deepseekProvider,
     opencodeGoProvider,
     ollamaCloudProvider,
+    neuralwattProvider,
   ];
 }

--- a/tests/lib.neuralwatt-config.test.ts
+++ b/tests/lib.neuralwatt-config.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createRuntimePathsMockModule,
+  getTrustedOpencodeConfigPaths,
+  getWorkspaceOpencodeConfigPaths,
+  loadFsConfigMocks,
+  mockTrustedConfigFile,
+  resetFsConfigMocks,
+  resetProcessEnv,
+} from "./helpers/trusted-config-test-harness.js";
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => createRuntimePathsMockModule());
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFile: vi.fn(),
+}));
+
+describe("neuralwatt config", () => {
+  const originalEnv = process.env;
+  const trustedPaths = getTrustedOpencodeConfigPaths();
+  const workspacePaths = getWorkspaceOpencodeConfigPaths();
+  let fsConfigMocks: Awaited<ReturnType<typeof loadFsConfigMocks>>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    resetProcessEnv(originalEnv, [
+      "NEURALWATT_API_KEY",
+      "MY_NEURALWATT_KEY",
+      "XDG_CONFIG_HOME",
+      "XDG_DATA_HOME",
+      "XDG_CACHE_HOME",
+      "XDG_STATE_HOME",
+    ]);
+    fsConfigMocks = await loadFsConfigMocks();
+    resetFsConfigMocks(fsConfigMocks);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("resolves from env:NEURALWATT_API_KEY", async () => {
+    process.env.NEURALWATT_API_KEY = "env-key";
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toEqual({
+      key: "env-key",
+      source: "env:NEURALWATT_API_KEY",
+    });
+  });
+
+  it("resolves from trusted user/global OpenCode config", async () => {
+    mockTrustedConfigFile(
+      fsConfigMocks,
+      trustedPaths.json,
+      JSON.stringify({
+        provider: {
+          neuralwatt: {
+            options: {
+              apiKey: "config-key",
+            },
+          },
+        },
+      }),
+    );
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toEqual({
+      key: "config-key",
+      source: "opencode.json",
+    });
+  });
+
+  it("returns null when a trusted global config env reference is unset", async () => {
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+
+    mockTrustedConfigFile(
+      fsConfigMocks,
+      trustedPaths.json,
+      JSON.stringify({
+        provider: {
+          neuralwatt: {
+            options: {
+              apiKey: "{env:NEURALWATT_API_KEY}",
+            },
+          },
+        },
+      }),
+    );
+    (readAuthFile as any).mockResolvedValue(null);
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toBeNull();
+  });
+
+  it("rejects arbitrary {env:VAR_NAME} syntax in trusted global config", async () => {
+    process.env.MY_NEURALWATT_KEY = "resolved-from-env";
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+
+    mockTrustedConfigFile(
+      fsConfigMocks,
+      trustedPaths.json,
+      JSON.stringify({
+        provider: {
+          neuralwatt: {
+            options: {
+              apiKey: "{env:MY_NEURALWATT_KEY}",
+            },
+          },
+        },
+      }),
+    );
+    (readAuthFile as any).mockResolvedValue(null);
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toBeNull();
+  });
+
+  it.each([
+    ["opencode.json", workspacePaths.json],
+    ["opencode.jsonc", workspacePaths.jsonc],
+  ])("ignores repo-local provider secrets from %s", async (_label, workspacePath) => {
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+
+    fsConfigMocks.existsSync.mockImplementation((path: string) => path === workspacePath);
+    (readAuthFile as any).mockResolvedValue(null);
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toBeNull();
+  });
+
+  it("resolves from existing OpenCode auth when env/global config are absent", async () => {
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+
+    fsConfigMocks.existsSync.mockReturnValue(false);
+    (readAuthFile as any).mockResolvedValueOnce({
+      neuralwatt: { type: "api", key: "auth-key" },
+    });
+
+    const { resolveNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    await expect(resolveNeuralwattApiKey()).resolves.toEqual({
+      key: "auth-key",
+      source: "auth.json",
+    });
+  });
+});

--- a/tests/lib.neuralwatt.test.ts
+++ b/tests/lib.neuralwatt.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  formatNeuralwattBalanceValue,
+  formatNeuralwattKwhRight,
+  queryNeuralwattQuota,
+} from "../src/lib/neuralwatt.js";
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFile: vi.fn(),
+  getAuthPaths: vi.fn(() => []),
+}));
+
+describe("queryNeuralwattQuota", () => {
+  const originalEnv = process.env;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-neuralwatt-"));
+    process.env = {
+      ...originalEnv,
+      XDG_CONFIG_HOME: tempDir,
+      XDG_DATA_HOME: tempDir,
+      XDG_CACHE_HOME: tempDir,
+      XDG_STATE_HOME: tempDir,
+    };
+    delete process.env.NEURALWATT_API_KEY;
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.unstubAllGlobals();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null when not configured", async () => {
+    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
+    (readAuthFile as any).mockResolvedValueOnce({});
+
+    await expect(queryNeuralwattQuota()).resolves.toBeNull();
+  });
+
+  it("returns Neuralwatt quota data (balance + subscription + key allowance)", async () => {
+    process.env.NEURALWATT_API_KEY = "test-key";
+
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            snapshot_at: "2026-04-16T18:30:00Z",
+            balance: {
+              credits_remaining_usd: 32.6774,
+              total_credits_usd: 52.34,
+              credits_used_usd: 19.6626,
+              accounting_method: "energy",
+            },
+            usage: {
+              lifetime: {
+                cost_usd: 243.9145,
+                requests: 37801,
+                tokens: 1235477176,
+                energy_kwh: 15.6009,
+              },
+              current_month: {
+                cost_usd: 160.1463,
+                requests: 23902,
+                tokens: 1116658995,
+                energy_kwh: 9.7278,
+              },
+            },
+            limits: { overage_limit_usd: null, rate_limit_tier: "standard" },
+            subscription: {
+              plan: "standard",
+              status: "active",
+              billing_interval: "month",
+              current_period_start: "2026-04-11T05:05:25Z",
+              current_period_end: "2026-05-11T05:05:25Z",
+              auto_renew: true,
+              kwh_included: 20.0,
+              kwh_used: 13.9023,
+              kwh_remaining: 6.0977,
+              in_overage: false,
+            },
+            key: {
+              name: "my-production-key",
+              allowance: {
+                limit_usd: 100,
+                period: "monthly",
+                spent_usd: 25,
+                remaining_usd: 75,
+                blocked: false,
+              },
+            },
+          }),
+          { status: 200 },
+        ),
+    ) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await queryNeuralwattQuota({ requestTimeoutMs: 1234 });
+
+    expect(out).toEqual({
+      success: true,
+      balance: {
+        creditsRemainingUsd: 32.6774,
+        totalCreditsUsd: 52.34,
+        creditsUsedUsd: 19.6626,
+        accountingMethod: "energy",
+      },
+      subscription: {
+        active: true,
+        state: "active",
+        billingInterval: "month",
+        currentPeriodStartIso: "2026-04-11T05:05:25.000Z",
+        currentPeriodEndIso: "2026-05-11T05:05:25.000Z",
+        autoRenew: true,
+        kwh: {
+          used: 13.9023,
+          limit: 20.0,
+          remaining: 6.0977,
+          percentRemaining: 30,
+          resetTimeIso: "2026-05-11T05:05:25.000Z",
+        },
+        inOverage: false,
+      },
+      keyAllowance: {
+        limitUsd: 100,
+        spentUsd: 25,
+        remainingUsd: 75,
+        period: "monthly",
+        blocked: false,
+        window: {
+          used: 25,
+          limit: 100,
+          remaining: 75,
+          percentRemaining: 75,
+          resetTimeIso: undefined,
+        },
+      },
+      lifetimeUsage: { costUsd: 243.9145, requests: 37801, tokens: 1235477176, energyKwh: 15.6009 },
+      currentMonthUsage: {
+        costUsd: 160.1463,
+        requests: 23902,
+        tokens: 1116658995,
+        energyKwh: 9.7278,
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.neuralwatt.com/v1/quota",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-key",
+          "User-Agent": "OpenCode-Quota-Toast/1.0",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("handles a PAYG account with null subscription (credits-only)", async () => {
+    process.env.NEURALWATT_API_KEY = "test-key";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              balance: {
+                credits_remaining_usd: 5.0,
+                total_credits_usd: 5.0,
+                accounting_method: "token",
+              },
+              subscription: null,
+              key: { name: "k", allowance: null },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryNeuralwattQuota();
+    expect(out && out.success).toBe(true);
+    if (out && out.success) {
+      expect(out.balance?.creditsRemainingUsd).toBe(5.0);
+      expect(out.subscription).toBeUndefined();
+      expect(out.keyAllowance).toBeUndefined();
+    }
+  });
+
+  it("derives kwh_remaining when missing", async () => {
+    process.env.NEURALWATT_API_KEY = "test-key";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              balance: { credits_remaining_usd: 1, accounting_method: "energy" },
+              subscription: {
+                status: "active",
+                current_period_end: "2026-05-11T05:05:25Z",
+                kwh_included: 20.0,
+                kwh_used: 5.0,
+              },
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    const out = await queryNeuralwattQuota();
+    expect(out && out.success ? out.subscription?.kwh : undefined).toEqual({
+      used: 5,
+      limit: 20,
+      remaining: 15,
+      percentRemaining: 75,
+      resetTimeIso: "2026-05-11T05:05:25.000Z",
+    });
+  });
+
+  it("maps a 401 into an error result", async () => {
+    process.env.NEURALWATT_API_KEY = "bad-key";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ error: { message: "Invalid API key", type: "authentication_error" } }),
+            { status: 401 },
+          ),
+      ) as any,
+    );
+
+    await expect(queryNeuralwattQuota()).resolves.toEqual({
+      success: false,
+      error: expect.stringContaining("Neuralwatt API error 401"),
+    });
+  });
+
+  it("maps a 429 into a rate-limited error result", async () => {
+    process.env.NEURALWATT_API_KEY = "test-key";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ error: "rate limited" }), {
+            status: 429,
+            headers: { "Retry-After": "1" },
+          }),
+      ) as any,
+    );
+
+    const out = await queryNeuralwattQuota();
+    expect(out && !out.success ? out.error : "").toContain("429");
+    expect(out && !out.success ? out.error : "").toContain("retry after 1s");
+  });
+
+  it("maps an unexpected response shape into an error result", async () => {
+    process.env.NEURALWATT_API_KEY = "test-key";
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify({ unrelated: true }), { status: 200 })) as any,
+    );
+
+    await expect(queryNeuralwattQuota()).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("unexpected response shape"),
+    });
+  });
+
+  it("formats balance and kwh display values", () => {
+    expect(formatNeuralwattBalanceValue({ creditsRemainingUsd: 32.6 })).toBe("$32.60");
+    expect(formatNeuralwattBalanceValue({})).toBeNull();
+    expect(formatNeuralwattKwhRight({ used: 13.9023, limit: 20 })).toBe("13.9 kWh/20 kWh");
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -154,6 +154,13 @@ describe("provider-metadata", () => {
         quota: "remote_api",
         notes: "Scrapes the Ollama Cloud settings page; requires __Secure-session cookie via OLLAMA_USAGE_COOKIE env or ollama-usage config",
       },
+      {
+        id: "neuralwatt",
+        autoSetup: "yes",
+        authentication: "opencode_auth_api_key",
+        authFallbacks: ["env_api_key", "global_opencode_config"],
+        quota: "remote_api",
+      },
     ]);
   });
 
@@ -223,6 +230,7 @@ describe("provider-metadata", () => {
       "kimi-code",
     ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.deepseek).toEqual(["deepseek"]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS.neuralwatt).toEqual(["neuralwatt"]);
   });
 
   it("keeps runtime ids distinct from broad normalization aliases", () => {
@@ -340,6 +348,7 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("kimi-code")).toBe("Kimi Code");
     expect(getQuotaProviderDisplayLabel("kimi")).toBe("Kimi Code");
     expect(getQuotaProviderDisplayLabel("deep-seek")).toBe("DeepSeek");
+    expect(getQuotaProviderDisplayLabel("neuralwatt")).toBe("Neuralwatt");
     expect(getQuotaProviderDisplayLabel("something-else")).toBe("something-else");
   });
 });

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -168,6 +168,15 @@ const deepSeekMocks = vi.hoisted(() => ({
   })),
 }));
 
+const neuralwattMocks = vi.hoisted(() => ({
+  getNeuralwattKeyDiagnostics: vi.fn(async () => ({
+    configured: false,
+    source: null,
+    checkedPaths: [],
+  })),
+  queryNeuralwattQuota: vi.fn(async () => null),
+}));
+
 const syntheticMocks = vi.hoisted(() => ({
   getSyntheticKeyDiagnostics: vi.fn(async () => ({
     configured: false,
@@ -286,6 +295,11 @@ vi.mock("../src/lib/nanogpt.js", () => ({
 
 vi.mock("../src/lib/deepseek.js", () => ({
   getDeepSeekKeyDiagnostics: deepSeekMocks.getDeepSeekKeyDiagnostics,
+}));
+
+vi.mock("../src/lib/neuralwatt.js", () => ({
+  getNeuralwattKeyDiagnostics: neuralwattMocks.getNeuralwattKeyDiagnostics,
+  queryNeuralwattQuota: neuralwattMocks.queryNeuralwattQuota,
 }));
 
 vi.mock("../src/lib/copilot.js", () => ({
@@ -425,6 +439,7 @@ vi.mock("../src/providers/registry.js", () => ({
     { id: "synthetic" },
     { id: "nanogpt" },
     { id: "deepseek" },
+    { id: "neuralwatt" },
     { id: "kimi-for-coding" },
     { id: "kimi-code" },
   ],
@@ -707,6 +722,9 @@ describe("buildQuotaStatusReport", () => {
     );
     expect(report).toContain(
       "- nanogpt: pricing=no (subscription request quota + account balance (not token-priced))",
+    );
+    expect(report).toContain(
+      "- neuralwatt: pricing=no (subscription kWh allowance + account balance (not token-priced))",
     );
     expect(report).toContain(
       "- kimi-for-coding: pricing=no (request quota via Kimi Code API (not token-priced))",
@@ -1209,6 +1227,73 @@ describe("buildQuotaStatusReport", () => {
     expect(report).toContain("- balance_usd: $129.47");
     expect(report).toContain("- balance_nano: 26.71801147");
     expect(report).toContain("- live_error_balance: NanoGPT API error 401: Unauthorized");
+  });
+
+  it("reports Neuralwatt live balance and subscription diagnostics when configured", async () => {
+    neuralwattMocks.getNeuralwattKeyDiagnostics.mockResolvedValueOnce({
+      configured: true,
+      source: "env:NEURALWATT_API_KEY",
+      checkedPaths: ["env:NEURALWATT_API_KEY"],
+    });
+    neuralwattMocks.queryNeuralwattQuota.mockResolvedValueOnce({
+      success: true,
+      balance: {
+        creditsRemainingUsd: 32.6774,
+        totalCreditsUsd: 52.34,
+        accountingMethod: "energy",
+      },
+      subscription: {
+        active: true,
+        state: "active",
+        billingInterval: "month",
+        currentPeriodEndIso: "2026-05-11T05:05:25.000Z",
+        inOverage: false,
+        kwh: {
+          used: 13.9023,
+          limit: 20.0,
+          remaining: 6.0977,
+          percentRemaining: 30,
+          resetTimeIso: "2026-05-11T05:05:25.000Z",
+        },
+      },
+      keyAllowance: {
+        limitUsd: 100,
+        spentUsd: 25,
+        remainingUsd: 75,
+        period: "monthly",
+        blocked: false,
+        window: { used: 25, limit: 100, remaining: 75, percentRemaining: 75 },
+      },
+      currentMonthUsage: {
+        costUsd: 160.1463,
+        requests: 23902,
+        tokens: 1116658995,
+        energyKwh: 9.7278,
+      },
+    });
+
+    const report = await buildProviderStatusReport("neuralwatt");
+
+    expect(report).toContain("neuralwatt:");
+    expect(report).toContain(
+      "- neuralwatt api key: configured=true source=env:NEURALWATT_API_KEY checked=env:NEURALWATT_API_KEY",
+    );
+    expect(report).toContain("- credits_remaining_usd: $32.68");
+    expect(report).toContain("- accounting_method: energy");
+    expect(report).toContain("- subscription_active: true");
+    expect(report).toContain("- subscription_state: active");
+    expect(report).toContain("- billing_interval: month");
+    expect(report).toContain(
+      "- kwh_usage: 13.9023/20.0000 remaining=6.0977 percent_remaining=30 reset_at=2026-05-11T05:05:25.000Z",
+    );
+    expect(report).toContain("- in_overage: false");
+    expect(report).toContain("- billing_period_end: 2026-05-11T05:05:25.000Z");
+    expect(report).toContain(
+      "- key_allowance: 25.00/100.00 remaining=75.00 period=monthly percent_remaining=75 blocked=false",
+    );
+    expect(report).toContain(
+      "- current_month_usage: cost_usd=$160.15 requests=23902 tokens=1116658995 energy_kwh=9.7278",
+    );
   });
 
   it("reports DeepSeek API key diagnostics", async () => {
@@ -1751,6 +1836,7 @@ synthetic:
 chutes:
 deepseek:
 nanogpt:
+neuralwatt:
 copilot_quota_auth:
 google_antigravity:
 google_gemini_cli:

--- a/tests/providers.neuralwatt.test.ts
+++ b/tests/providers.neuralwatt.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+import { neuralwattProvider } from "../src/providers/neuralwatt.js";
+
+vi.mock("../src/lib/neuralwatt.js", () => ({
+  queryNeuralwattQuota: vi.fn(),
+  formatNeuralwattBalanceValue: vi.fn((balance: { creditsRemainingUsd?: number }) =>
+    typeof balance.creditsRemainingUsd === "number"
+      ? `$${balance.creditsRemainingUsd.toFixed(2)}`
+      : null,
+  ),
+  formatNeuralwattKwhRight: vi.fn(
+    (window: { used: number; limit: number }) => `${window.used} kWh/${window.limit} kWh`,
+  ),
+}));
+
+vi.mock("../src/lib/neuralwatt-config.js", () => ({
+  hasNeuralwattApiKey: vi.fn(),
+}));
+
+vi.mock("../src/lib/provider-availability.js", () => ({
+  isCanonicalProviderAvailable: vi.fn(),
+}));
+
+describe("neuralwatt provider", () => {
+  it("returns attempted:false when not configured", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce(null);
+
+    const out = await neuralwattProvider.fetch({} as any);
+    expectNotAttempted(out);
+  });
+
+  it("maps subscription + key allowance + credits into grouped rows", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce({
+      success: true,
+      balance: { creditsRemainingUsd: 32.67 },
+      subscription: {
+        active: true,
+        state: "active",
+        currentPeriodEndIso: "2026-05-11T05:05:25.000Z",
+        kwh: {
+          used: 13.9023,
+          limit: 20,
+          remaining: 6.0977,
+          percentRemaining: 30,
+          resetTimeIso: "2026-05-11T05:05:25.000Z",
+        },
+      },
+      keyAllowance: {
+        limitUsd: 100,
+        spentUsd: 25,
+        remainingUsd: 75,
+        period: "monthly",
+        blocked: false,
+        window: { used: 25, limit: 100, remaining: 75, percentRemaining: 75 },
+      },
+    });
+
+    const out = await neuralwattProvider.fetch({ config: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "Neuralwatt Subscription",
+        group: "Neuralwatt",
+        label: "Plan:",
+        right: "13.9023 kWh/20 kWh",
+        percentRemaining: 30,
+        resetTimeIso: "2026-05-11T05:05:25.000Z",
+      },
+      {
+        name: "Neuralwatt Key",
+        group: "Neuralwatt",
+        label: "Key:",
+        right: "$25.00/$100.00",
+        percentRemaining: 75,
+      },
+      {
+        kind: "value",
+        name: "Neuralwatt Credits",
+        group: "Neuralwatt",
+        label: "Credits:",
+        value: "$32.67",
+      },
+    ]);
+    expect(out.presentation).toBeUndefined();
+  });
+
+  it("falls back to credits-only when there is no subscription", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce({
+      success: true,
+      balance: { creditsRemainingUsd: 5.0 },
+    });
+
+    const out = await neuralwattProvider.fetch({ config: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        kind: "value",
+        name: "Neuralwatt Credits",
+        group: "Neuralwatt",
+        label: "Credits:",
+        value: "$5.00",
+      },
+    ]);
+  });
+
+  it("reports non-active subscription state and blocked key as errors", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce({
+      success: true,
+      balance: { creditsRemainingUsd: 1 },
+      subscription: {
+        active: false,
+        state: "past_due",
+        kwh: { used: 20, limit: 20, remaining: 0, percentRemaining: 0 },
+      },
+      keyAllowance: {
+        limitUsd: 10,
+        spentUsd: 10,
+        remainingUsd: 0,
+        period: "daily",
+        blocked: true,
+        window: { used: 10, limit: 10, remaining: 0, percentRemaining: 0 },
+      },
+    });
+
+    const out = await neuralwattProvider.fetch({ config: {} } as any);
+    expect(out.attempted).toBe(true);
+    expect(out.errors).toEqual([
+      { label: "Neuralwatt", message: "Subscription state: past_due" },
+      { label: "Neuralwatt", message: "API key is blocked (spending allowance reached)" },
+    ]);
+  });
+
+  it("reports missing usable data as an error", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce({ success: true });
+
+    const out = await neuralwattProvider.fetch({ config: {} } as any);
+    expectAttemptedWithErrorLabel(out, "Neuralwatt");
+    expect(out.entries).toEqual([]);
+  });
+
+  it("maps hard failures into toast errors", async () => {
+    const { queryNeuralwattQuota } = await import("../src/lib/neuralwatt.js");
+    (queryNeuralwattQuota as any).mockResolvedValueOnce({
+      success: false,
+      error: "Neuralwatt API error 401: Invalid API key",
+    });
+
+    const out = await neuralwattProvider.fetch({} as any);
+    expectAttemptedWithErrorLabel(out, "Neuralwatt");
+  });
+
+  it("matches Neuralwatt model ids", () => {
+    expect(neuralwattProvider.matchesCurrentModel?.("neuralwatt/Qwen/Qwen3-Coder-480B")).toBe(true);
+    expect(neuralwattProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+
+  it("is available when canonical provider metadata is available", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValueOnce(true);
+
+    await expect(neuralwattProvider.isAvailable({} as any)).resolves.toBe(true);
+  });
+
+  it("falls back to trusted API key presence when provider metadata is absent", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    const { hasNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValueOnce(false);
+    (hasNeuralwattApiKey as any).mockResolvedValueOnce(true);
+
+    await expect(neuralwattProvider.isAvailable({} as any)).resolves.toBe(true);
+  });
+
+  it("is not available when provider metadata is absent and no API key exists", async () => {
+    const { isCanonicalProviderAvailable } = await import("../src/lib/provider-availability.js");
+    const { hasNeuralwattApiKey } = await import("../src/lib/neuralwatt-config.js");
+    (isCanonicalProviderAvailable as any).mockResolvedValueOnce(false);
+    (hasNeuralwattApiKey as any).mockResolvedValueOnce(false);
+
+    await expect(neuralwattProvider.isAvailable({} as any)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Add the [neuralwatt.com](https://www.neuralwatt.com/) provider for subscriptions and available credit.

## Linked Issue

Fixes #142

## OpenCode Validation

- Current production released OpenCode version tested: 1.17.18
- Why this version is relevant to the fix:  latest version

## Quality Checklist

- [X] I ran `pnpm run typecheck`
- [X] I ran `pnpm test`
- [X] I ran `pnpm run build`
- [X] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [X] I preserved behavioral invariants and updated/added boundary tests as needed
- [X] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [X] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [X] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
