### PR TITLE
feat(google-agy): migrate to retrieveUserQuotaSummary API

### DIFF
--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -14,6 +14,10 @@ export interface GroupedQuotaEntryMeta {
   label?: string;
   /** Optional compact right-hand summary, e.g. "42/300". */
   right?: string;
+  /** Optional sort-rank override for groupQuotaEntries intra-group ordering. Lower sorts first. */
+  rankOverride?: number;
+  /** Optional sort-rank override for inter-group ordering in groupQuotaEntries. Lower sorts first. */
+  groupSortOverride?: number;
 }
 
 export type QuotaToastEntry =

--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -15,10 +15,11 @@ import {
 import type {
   AuthData,
   GoogleAgyAuthSourceKey,
-  GoogleAgyQuotaBucket,
   GoogleAgyResult,
   GoogleAccountError,
   GeminiCliOAuthAuthData,
+  RetrieveUserQuotaSummaryGroup,
+  RetrieveUserQuotaSummaryResponse,
 } from "./types.js";
 
 export const DEFAULT_AGY_AUTH_CACHE_MAX_AGE_MS = 5_000;
@@ -30,12 +31,12 @@ export const AGY_AUTH_KEYS = [
 ] as const satisfies readonly GoogleAgyAuthSourceKey[];
 
 const AGY_CODE_ASSIST_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
-const AGY_QUOTA_API_URL = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal:retrieveUserQuota`;
+const AGY_QUOTA_SUMMARY_API_URL = `${AGY_CODE_ASSIST_ENDPOINT}/v1internal:retrieveUserQuotaSummary`;
 const AGY_TOKEN_REFRESH_URL = "https://oauth2.googleapis.com/token";
 const AGY_TOKEN_TIMEOUT_MS = 8_000;
 const AGY_QUOTA_TIMEOUT_MS = 6_000;
 const AGY_ACCOUNTS_CONCURRENCY = 3;
-const AGY_USER_AGENT = "antigravity/cli/1.0.3 darwin/amd64";
+const AGY_USER_AGENT = "antigravity/1.18.3 darwin/arm64";
 
 function createAgyActivityRequestId(): string {
   return crypto.randomUUID();
@@ -87,18 +88,6 @@ export type AgyAuthPresence =
       validAccountCount: number;
       error: string;
     };
-
-type RetrieveUserQuotaBucket = {
-  remainingAmount?: string;
-  remainingFraction?: number;
-  resetTime?: string;
-  tokenType?: string;
-  modelId?: string;
-};
-
-type RetrieveUserQuotaResponse = {
-  buckets?: RetrieveUserQuotaBucket[];
-};
 
 type ConfigClient = {
   config?: {
@@ -386,13 +375,13 @@ async function refreshAgyAccessTokenWithCache(params: {
   return { accessToken: refreshed.accessToken };
 }
 
-async function retrieveGoogleAgyQuota(
+async function retrieveUserQuotaSummary(
   accessToken: string,
   projectId: string,
   timeoutMs: number = AGY_QUOTA_TIMEOUT_MS,
-): Promise<RetrieveUserQuotaResponse> {
+): Promise<RetrieveUserQuotaSummaryResponse> {
   const response = await fetchWithTimeout(
-    AGY_QUOTA_API_URL,
+    AGY_QUOTA_SUMMARY_API_URL,
     {
       method: "POST",
       headers: {
@@ -413,121 +402,7 @@ async function retrieveGoogleAgyQuota(
     throw new Error(`Google AGY quota API error: ${response.status}`);
   }
 
-  return response.json() as Promise<RetrieveUserQuotaResponse>;
-}
-
-export function formatDisplayName(modelId: string): string {
-  // Replace all underscores with hyphens
-  let cleaned = modelId.replace(/_/g, "-").trim();
-
-  // Special cases for well-known prefixes
-  if (cleaned.toLowerCase().startsWith("claude-")) {
-    // Handle versions like claude-3-5-sonnet -> Claude 3.5 Sonnet
-    return cleaned
-      .split("-")
-      .map((part, i) => {
-        if (i === 0) return "Claude";
-        if (/^\d+$/.test(part) && /^\d+$/.test(cleaned.split("-")[i + 1] || "")) {
-          return part + "." + cleaned.split("-")[i + 1];
-        }
-        if (/^\d+$/.test(part) && /^\d+$/.test(cleaned.split("-")[i - 1] || "")) {
-          return ""; // Skip second part of version
-        }
-        return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
-      })
-      .filter(Boolean)
-      .join(" ");
-  }
-
-  // Replace gpt-oss (case-insensitive) with a temporary placeholder
-  cleaned = cleaned.replace(/gpt-oss/gi, "GPT_OSS");
-  // Replace digit-digit with digit.digit (e.g. 4-6 to 4.6)
-  cleaned = cleaned.replace(/(\d+)-(\d+)/g, "$1.$2");
-
-  let suffix = "";
-  if (cleaned.toLowerCase().endsWith("-medium")) {
-    suffix = " (Medium)";
-    cleaned = cleaned.slice(0, -7);
-  } else if (cleaned.toLowerCase().endsWith("-large")) {
-    suffix = " (Large)";
-    cleaned = cleaned.slice(0, -6);
-  }
-
-  const parts = cleaned.split("-").filter(Boolean);
-  const formattedParts = parts.map((part) => {
-    if (part === "GPT_OSS") {
-      return "GPT-OSS";
-    }
-    const lower = part.toLowerCase();
-    if (lower === "gpt") return "GPT";
-    if (lower === "oss") return "OSS";
-    // If it's a size like 120b, capitalize it to 120B
-    if (/^\d+[a-zA-Z]+$/.test(part)) {
-      return part.toUpperCase();
-    }
-    // If it's a version number like 3.5 or 4.6, keep as-is
-    if (/^[0-9]+(?:\.[0-9]+)*$/.test(part)) {
-      return part;
-    }
-    return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();
-  });
-
-  return formattedParts.join(" ") + suffix;
-}
-
-function aggregateAgyBuckets(buckets: GoogleAgyQuotaBucket[]): GoogleAgyQuotaBucket[] {
-  const grouped = new Map<string, GoogleAgyQuotaBucket>();
-  for (const bucket of buckets) {
-    const existing = grouped.get(bucket.modelId);
-    if (!existing || bucket.percentRemaining < existing.percentRemaining) {
-      grouped.set(bucket.modelId, bucket);
-    }
-  }
-  return Array.from(grouped.values());
-}
-
-function mapQuotaBuckets(
-  buckets: RetrieveUserQuotaBucket[] | undefined,
-  account: AgyAccount,
-): GoogleAgyQuotaBucket[] {
-  if (!buckets) {
-    return [];
-  }
-
-  const normalizedBuckets = buckets
-    .filter((bucket) => normalizeString(bucket.modelId))
-    .map((bucket) => {
-      const modelId = normalizeString(bucket.modelId)!;
-      const remainingFraction = bucket.remainingFraction;
-
-      let percentRemaining: number;
-      if (typeof remainingFraction === "number" && Number.isFinite(remainingFraction)) {
-        percentRemaining = Math.round(remainingFraction * 100);
-      } else if (
-        normalizeString(bucket.remainingAmount) &&
-        bucket.remainingAmount?.toLowerCase().includes("unlimited")
-      ) {
-        percentRemaining = 100;
-      } else {
-        percentRemaining = 0;
-      }
-
-      return {
-        modelId,
-        displayName: formatDisplayName(modelId),
-        percentRemaining,
-        ...(normalizeString(bucket.resetTime) ? { resetTimeIso: bucket.resetTime!.trim() } : {}),
-        ...(normalizeString(bucket.remainingAmount)
-          ? { remainingAmount: bucket.remainingAmount!.trim() }
-          : {}),
-        ...(normalizeString(bucket.tokenType) ? { tokenType: bucket.tokenType!.trim() } : {}),
-        ...(account.email ? { accountEmail: account.email } : {}),
-        accountKey: createAgyAccountKey(account),
-        sourceKey: account.sourceKey,
-      };
-    });
-
-  return aggregateAgyBuckets(normalizedBuckets);
+  return response.json() as Promise<RetrieveUserQuotaSummaryResponse>;
 }
 
 async function fetchAccountQuota(params: {
@@ -536,7 +411,7 @@ async function fetchAccountQuota(params: {
   timeoutMs?: number;
 }): Promise<{
   success: boolean;
-  buckets?: GoogleAgyQuotaBucket[];
+  summaryGroups?: RetrieveUserQuotaSummaryGroup[];
   error?: string;
   accountEmail?: string;
 }> {
@@ -552,37 +427,41 @@ async function fetchAccountQuota(params: {
       return { success: false, error: tokenResult.error, accountEmail };
     }
 
-    let quota: RetrieveUserQuotaResponse;
-    try {
-      quota = await retrieveGoogleAgyQuota(
-        tokenResult.accessToken,
-        params.account.projectId,
-        params.timeoutMs,
-      );
-    } catch (err) {
-      if (err instanceof Error && err.message.includes("auth error")) {
-        const retryToken = await refreshAgyAccessTokenWithCache({
-          account: params.account,
-          credentials: params.credentials,
-          force: true,
-          timeoutMs: params.timeoutMs,
-        });
-        if ("error" in retryToken) {
-          return { success: false, error: retryToken.error, accountEmail };
-        }
-        quota = await retrieveGoogleAgyQuota(
-          retryToken.accessToken,
+    const summaryResult = await (async () => {
+      try {
+        return await retrieveUserQuotaSummary(
+          tokenResult.accessToken,
           params.account.projectId,
           params.timeoutMs,
         );
-      } else {
+      } catch (err) {
+        if (err instanceof Error && err.message.includes("auth error")) {
+          const retryToken = await refreshAgyAccessTokenWithCache({
+            account: params.account,
+            credentials: params.credentials,
+            force: true,
+            timeoutMs: params.timeoutMs,
+          });
+          if ("error" in retryToken) {
+            throw new Error(retryToken.error);
+          }
+          return await retrieveUserQuotaSummary(
+            retryToken.accessToken,
+            params.account.projectId,
+            params.timeoutMs,
+          );
+        }
         throw err;
       }
+    })();
+
+    if (!summaryResult.groups || summaryResult.groups.length === 0) {
+      return { success: false, error: "Quota summary API unavailable", accountEmail };
     }
 
     return {
       success: true,
-      buckets: mapQuotaBuckets(quota.buckets, params.account),
+      summaryGroups: summaryResult.groups,
       accountEmail,
     };
   } catch (err) {
@@ -595,6 +474,43 @@ async function fetchAccountQuota(params: {
       accountEmail,
     };
   }
+}
+
+function mergeSummaryGroupsAcrossAccounts(
+  groups: RetrieveUserQuotaSummaryGroup[],
+): RetrieveUserQuotaSummaryGroup[] {
+  if (groups.length === 0) return [];
+
+  const aggregated = new Map<string, RetrieveUserQuotaSummaryGroup>();
+
+  for (const group of groups) {
+    const existing = aggregated.get(group.displayName);
+    if (!existing) {
+      aggregated.set(group.displayName, {
+        displayName: group.displayName,
+        description: group.description,
+        buckets: group.buckets.map((b) => ({ ...b })),
+      });
+    } else {
+      for (const bucket of group.buckets) {
+        const existingIdx = existing.buckets.findIndex((b) => b.bucketId === bucket.bucketId);
+        if (existingIdx === -1) {
+          existing.buckets.push({ ...bucket });
+        } else {
+          const existingBucket = existing.buckets[existingIdx]!;
+          existingBucket.remainingFraction = Math.min(existingBucket.remainingFraction ?? 1, bucket.remainingFraction ?? 1);
+          if (bucket.disabled) existingBucket.disabled = true;
+          const existingTs = Date.parse(existingBucket.resetTime ?? "");
+          const bucketTs = Date.parse(bucket.resetTime ?? "");
+          if (Number.isFinite(bucketTs) && (!Number.isFinite(existingTs) || bucketTs < existingTs)) {
+            existingBucket.resetTime = bucket.resetTime;
+          }
+        }
+      }
+    }
+  }
+
+  return Array.from(aggregated.values());
 }
 
 export async function queryGoogleAgyQuota(
@@ -625,18 +541,21 @@ export async function queryGoogleAgyQuota(
       fetchAccountQuota({ account, credentials, timeoutMs: options.requestTimeoutMs }),
   });
 
-  const allBuckets: GoogleAgyQuotaBucket[] = [];
+  const allSummaryGroups: RetrieveUserQuotaSummaryGroup[] = [];
   const errors: GoogleAccountError[] = [];
 
   for (const result of results) {
-    if (result.success && result.buckets && result.buckets.length > 0) {
-      allBuckets.push(...result.buckets);
-    } else if (!result.success && result.error && result.accountEmail) {
+    if (result.success && result.summaryGroups && result.summaryGroups.length > 0) {
+      allSummaryGroups.push(...result.summaryGroups);
+    }
+    if (!result.success && result.error && result.accountEmail) {
       errors.push({ email: result.accountEmail, error: result.error });
     }
   }
 
-  if (allBuckets.length === 0 && errors.length === 0) {
+  const mergedGroups = mergeSummaryGroupsAcrossAccounts(allSummaryGroups);
+
+  if (mergedGroups.length === 0 && errors.length === 0) {
     return {
       success: false,
       error: "No Google AGY quota data available",
@@ -645,7 +564,7 @@ export async function queryGoogleAgyQuota(
 
   return {
     success: true,
-    buckets: allBuckets,
+    summaryGroups: mergedGroups,
     errors: errors.length > 0 ? errors : undefined,
   };
 }

--- a/src/lib/grouped-entry-normalization.ts
+++ b/src/lib/grouped-entry-normalization.ts
@@ -4,6 +4,8 @@ export type GroupedRenderTarget = "toast" | "quota";
 
 export type NormalizedGroupedQuotaEntry = QuotaToastEntry & {
   group: string;
+  rankOverride?: number;
+  groupSortOverride?: number;
 };
 
 export type QuotaEntryGroup = {
@@ -62,6 +64,7 @@ function getDurationRankFromText(value?: string): number | null {
 }
 
 function getDurationRank(entry: NormalizedGroupedQuotaEntry): number | null {
+  if (entry.rankOverride !== undefined) return entry.rankOverride;
   return entry.label ? getDurationRankFromText(entry.label) : getDurationRankFromText(entry.name);
 }
 
@@ -104,6 +107,7 @@ export function groupQuotaEntries(
 ): QuotaEntryGroup[] {
   const groupOrder: string[] = [];
   const groupedEntries = new Map<string, RankedGroupedQuotaEntry[]>();
+  const groupSortOverrides = new Map<string, number | undefined>();
 
   for (const [originalIndex, entry] of entries.entries()) {
     const normalizedEntry = normalizeGroupedQuotaEntry(entry, target);
@@ -112,17 +116,30 @@ export function groupQuotaEntries(
       originalIndex,
       rank: getDurationRank(normalizedEntry),
     };
-    const existing = groupedEntries.get(normalizedEntry.group);
+    const groupName = normalizedEntry.group;
+    const existing = groupedEntries.get(groupName);
     if (existing) {
       existing.push(rankedEntry);
       continue;
     }
 
-    groupOrder.push(normalizedEntry.group);
-    groupedEntries.set(normalizedEntry.group, [rankedEntry]);
+    groupOrder.push(groupName);
+    groupedEntries.set(groupName, [rankedEntry]);
+    groupSortOverrides.set(groupName, normalizedEntry.groupSortOverride);
   }
 
-  return groupOrder.map((group) => {
+  const sortedGroupOrder = groupOrder.slice().sort((a, b) => {
+    const aOverride = groupSortOverrides.get(a);
+    const bOverride = groupSortOverrides.get(b);
+    if (aOverride !== undefined && bOverride !== undefined && aOverride !== bOverride) {
+      return aOverride - bOverride;
+    }
+    if (aOverride !== undefined && bOverride === undefined) return -1;
+    if (aOverride === undefined && bOverride !== undefined) return 1;
+    return groupOrder.indexOf(a) - groupOrder.indexOf(b);
+  });
+
+  return sortedGroupOrder.map((group) => {
     const rankedEntries = groupedEntries.get(group) ?? [];
     const entries = rankedEntries
       .slice()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -604,21 +604,31 @@ export interface GeminiCliQuotaResult {
   errors?: GoogleAccountError[];
 }
 
-export interface GoogleAgyQuotaBucket {
-  modelId: string;
-  displayName: string;
-  percentRemaining: number;
-  resetTimeIso?: string;
+export interface RetrieveUserQuotaSummaryBucket {
+  bucketId: string;
+  displayName?: string;
+  description?: string;
+  window: "weekly" | "5h";
+  remainingFraction?: number;
   remainingAmount?: string;
-  tokenType?: string;
-  accountEmail?: string;
-  accountKey?: string;
-  sourceKey?: GoogleAgyAuthSourceKey;
+  disabled?: boolean;
+  resetTime?: string;
+}
+
+export interface RetrieveUserQuotaSummaryGroup {
+  displayName: string;
+  description?: string;
+  buckets: RetrieveUserQuotaSummaryBucket[];
+}
+
+export interface RetrieveUserQuotaSummaryResponse {
+  groups?: RetrieveUserQuotaSummaryGroup[];
+  description?: string;
 }
 
 export interface GoogleAgyQuotaResult {
   success: true;
-  buckets: GoogleAgyQuotaBucket[];
+  summaryGroups: RetrieveUserQuotaSummaryGroup[];
   errors?: GoogleAccountError[];
 }
 

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -1,9 +1,9 @@
 import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import type { RetrieveUserQuotaSummaryGroup } from "../lib/types.js";
 import { hasAgyQuotaRuntimeAvailable, queryGoogleAgyQuota } from "../lib/google-agy.js";
 import { parseProviderModelRef } from "../lib/provider-model-matching.js";
 import {
   formatGoogleAccountErrors,
-  formatGoogleAccountLabel,
 } from "./google-account-format.js";
 import { attemptedErrorResult, attemptedResult, notAttemptedResult } from "./result-helpers.js";
 
@@ -12,19 +12,29 @@ function isAgyModel(model: string): boolean {
   return ["google-agy", "opencode-agy-auth", "google-agy-auth"].includes(providerId);
 }
 
-function formatAgyAccountLabel(bucket: { accountEmail?: string; accountKey?: string }): string {
-  if (bucket.accountEmail) {
-    return formatGoogleAccountLabel(bucket.accountEmail, "domainHint");
-  }
-  return bucket.accountKey ? `Account ${bucket.accountKey.slice(0, 8)}` : "Unknown";
-}
-
 async function isAgyConfigured(ctx: QuotaProviderContext): Promise<boolean> {
   try {
     return await hasAgyQuotaRuntimeAvailable(ctx.client);
   } catch {
     return false;
   }
+}
+
+function familyGroupSortOverride(displayName: string): number {
+  if (displayName.toLowerCase().includes("gemini")) return 1;
+  return 2;
+}
+
+function windowToRankOverride(window: string): number {
+  return window === "weekly" ? 1 : 2;
+}
+
+function windowLabel(window: string): string {
+  return window === "weekly" ? "Weekly:" : "5h:";
+}
+
+function windowSuffix(window: string): string {
+  return window === "weekly" ? "Weekly" : "5h";
 }
 
 export const googleAgyProvider: QuotaProvider = {
@@ -53,55 +63,42 @@ export const googleAgyProvider: QuotaProvider = {
       return attemptedErrorResult("Google AGY", result.error);
     }
 
-    const groupedBuckets = new Map<string, typeof result.buckets[0]>();
-
-    for (const bucket of result.buckets) {
-      let groupName: string | undefined;
-      const name = bucket.displayName;
-
-      if (name.includes("Gemini")) {
-        groupName = "Gemini Models";
-      } else if (name.includes("Claude") || name.includes("GPT")) {
-        groupName = "Claude and GPT models";
-      }
-
-      if (!groupName) continue;
-
-      const accountKey = bucket.accountKey || bucket.accountEmail || "";
-      const key = `${accountKey}::${groupName}`;
-      const existing = groupedBuckets.get(key);
-
-      if (!existing || bucket.percentRemaining < existing.percentRemaining) {
-        groupedBuckets.set(key, { ...bucket, displayName: groupName });
-      }
-    }
-
-    const finalBuckets = Array.from(groupedBuckets.values()).sort((a, b) => 
-      a.displayName.localeCompare(b.displayName)
+    const sortedGroups = [...result.summaryGroups].sort(
+      (a, b) => familyGroupSortOverride(a.displayName) - familyGroupSortOverride(b.displayName),
     );
 
-    const entries = finalBuckets.map((bucket) => {
-      const emailLabel = formatAgyAccountLabel(bucket);
-      const parsedRemaining = bucket.remainingAmount
-        ? Number.parseInt(bucket.remainingAmount, 10)
-        : Number.NaN;
-      const remainingAmount = bucket.remainingAmount
-        ? `${Number.isFinite(parsedRemaining) ? parsedRemaining.toLocaleString("en-US") : bucket.remainingAmount} left`
-        : undefined;
-      const tokenType = bucket.tokenType?.trim().toUpperCase();
-      const right = [remainingAmount, tokenType && tokenType !== "REQUESTS" ? tokenType : undefined]
-        .filter(Boolean)
-        .join(" ");
+    const entries: import("../lib/entries.js").QuotaToastEntry[] = [];
 
-      return {
-        name: `${bucket.displayName} (${emailLabel})`,
-        group: "Google AGY",
-        label: `${bucket.displayName}:`,
-        ...(right ? { right } : {}),
-        percentRemaining: bucket.percentRemaining,
-        resetTimeIso: bucket.resetTimeIso,
-      };
-    });
+    for (const group of sortedGroups) {
+      const familyName = group.displayName;
+      const groupLabel = `Google AGY \u00b7 ${familyName}`;
+      const groupSort = familyGroupSortOverride(familyName);
+
+      const sortedBuckets = [...group.buckets]
+        .filter((b) => !b.disabled)
+        .sort((a, b) => windowToRankOverride(a.window) - windowToRankOverride(b.window));
+
+      for (const bucket of sortedBuckets) {
+        const parsedRemaining = bucket.remainingAmount
+          ? Number.parseInt(bucket.remainingAmount, 10)
+          : Number.NaN;
+        const remainingDisplay = bucket.remainingAmount
+          ? `${Number.isFinite(parsedRemaining) ? parsedRemaining.toLocaleString("en-US") : bucket.remainingAmount} left`
+          : undefined;
+        const right = remainingDisplay || undefined;
+
+        entries.push({
+          name: `Google AGY ${familyName} ${windowSuffix(bucket.window)}`,
+          group: groupLabel,
+          label: windowLabel(bucket.window),
+          rankOverride: windowToRankOverride(bucket.window),
+          groupSortOverride: groupSort,
+          ...(right ? { right } : {}),
+          percentRemaining: Math.round((bucket.remainingFraction ?? 1) * 100),
+          ...(bucket.resetTime ? { resetTimeIso: bucket.resetTime } : {}),
+        });
+      }
+    }
 
     return attemptedResult(entries, formatGoogleAccountErrors(result.errors, "domainHint"), {
       singleWindowDisplayName: "Google AGY",

--- a/tests/lib.google-agy.extra.test.ts
+++ b/tests/lib.google-agy.extra.test.ts
@@ -1,23 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { formatDisplayName, queryGoogleAgyQuota } from "../src/lib/google-agy";
 
 describe("google-agy extra logic", () => {
-  describe("formatDisplayName", () => {
-    it("should format Claude models correctly", () => {
-      expect(formatDisplayName("claude-3-5-sonnet")).toBe("Claude 3.5 Sonnet");
-      expect(formatDisplayName("claude-3-opus")).toBe("Claude 3 Opus");
-      expect(formatDisplayName("claude-3-sonnet")).toBe("Claude 3 Sonnet");
-      expect(formatDisplayName("claude-3-5-haiku")).toBe("Claude 3.5 Haiku");
-    });
-
-    it("should format GPT-OSS models correctly", () => {
-      expect(formatDisplayName("gpt_oss_120b_medium")).toBe("GPT-OSS 120B (Medium)");
-      expect(formatDisplayName("gpt_oss_7b")).toBe("GPT-OSS 7B");
-    });
-
-    it("should format Gemini models correctly", () => {
-      expect(formatDisplayName("gemini-1-5-pro")).toBe("Gemini 1.5 Pro");
-      expect(formatDisplayName("gemini-1-0-pro")).toBe("Gemini 1.0 Pro");
-    });
+  it("placeholder - formatDisplayName removed with old per-model API", () => {
+    expect(true).toBe(true);
   });
 });

--- a/tests/lib.google-agy.test.ts
+++ b/tests/lib.google-agy.test.ts
@@ -38,7 +38,6 @@ import {
   queryGoogleAgyQuota,
   resolveAgyAccounts,
   resolveAgyConfiguredProjectId,
-  formatDisplayName,
 } from "../src/lib/google-agy.js";
 
 function mockJsonResponse(data: unknown, status = 200) {
@@ -49,11 +48,32 @@ function mockJsonResponse(data: unknown, status = 200) {
   };
 }
 
+const SUMMARY_RESPONSE = {
+  groups: [
+    {
+      displayName: "Gemini Models",
+      description: "Gemini model family",
+      buckets: [
+        { bucketId: "gemini-weekly", displayName: "Weekly", window: "weekly", remainingFraction: 0.58, resetTime: "2026-06-22T00:00:00Z" },
+        { bucketId: "gemini-5h", displayName: "5 Hour", window: "5h", remainingFraction: 0.25, remainingAmount: "1234" },
+      ],
+    },
+    {
+      displayName: "Claude and GPT models",
+      description: "Third-party model family",
+      buckets: [
+        { bucketId: "3p-weekly", displayName: "Weekly", window: "weekly", remainingFraction: 1, resetTime: "2026-06-22T00:00:00Z" },
+        { bucketId: "3p-5h", displayName: "5 Hour", window: "5h", remainingFraction: 0.9, remainingAmount: "50" },
+      ],
+    },
+  ],
+};
+
 describe("google agy logic", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readAuthFileCached.mockResolvedValue(null);
-    mocks.fetchWithTimeout.mockResolvedValue(mockJsonResponse({ buckets: [] }));
+    mocks.fetchWithTimeout.mockResolvedValue(mockJsonResponse({ groups: [] }));
     mocks.getCachedAccessToken.mockResolvedValue({ accessToken: "cached-access-token" });
     mocks.makeAccountCacheKey.mockReturnValue("test-cache-key");
     mocks.resolveAgyClientCredentials.mockResolvedValue({
@@ -73,14 +93,6 @@ describe("google agy logic", () => {
       projectId: "project-1",
       managedProjectId: "managed-project",
     });
-  });
-
-  it("formats model display names correctly", () => {
-    expect(formatDisplayName("gemini-3.5-flash")).toBe("Gemini 3.5 Flash");
-    expect(formatDisplayName("claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
-    expect(formatDisplayName("gpt-oss-120b-medium")).toBe("GPT-OSS 120B (Medium)");
-    expect(formatDisplayName("gpt_oss_120b_medium")).toBe("GPT-OSS 120B (Medium)");
-    expect(formatDisplayName("gemini_3_5_flash")).toBe("Gemini 3.5 Flash");
   });
 
   it("resolves the project id with correct precedence", async () => {
@@ -164,11 +176,9 @@ describe("google agy logic", () => {
       },
     };
 
-    // Test 1: entry.managedProjectId takes top priority
     let resolved = resolveAgyAccounts(auth, "configured-project");
     expect(resolved[0].projectId).toBe("managed-project-entry");
 
-    // Test 2: entry.quotaProjectId takes priority over entry.projectId/projectID and parts and configuredProjectId
     const auth2 = {
       "google-agy": {
         type: "oauth" as const,
@@ -182,7 +192,6 @@ describe("google agy logic", () => {
     resolved = resolveAgyAccounts(auth2, "configured-project");
     expect(resolved[0].projectId).toBe("quota-project-entry");
 
-    // Test 3: parts.managedProjectId takes priority over entry.projectId/projectID and parts.projectId and configuredProjectId
     const auth3 = {
       "google-agy": {
         type: "oauth" as const,
@@ -215,7 +224,7 @@ describe("google agy logic", () => {
     });
   });
 
-  it("aggregates multiple limits per model ID keeping the lowest remaining percent", async () => {
+  it("calls retrieveUserQuotaSummary and returns merged summaryGroups", async () => {
     mocks.readAuthFileCached.mockResolvedValueOnce({
       "google-agy": {
         type: "oauth",
@@ -223,32 +232,9 @@ describe("google agy logic", () => {
         email: "alice@example.com",
       },
     });
-    mocks.resolveAgyClientCredentials.mockResolvedValueOnce({
-      state: "configured",
-      clientId: "client-id",
-      clientSecret: "client-secret",
-    });
     mocks.getCachedAccessToken.mockResolvedValueOnce({ accessToken: "cached-token" });
-
     mocks.fetchWithTimeout.mockResolvedValueOnce(
-      mockJsonResponse({
-        buckets: [
-          {
-            modelId: "gemini-3.5-flash",
-            remainingFraction: 0.8,
-            tokenType: "REQUESTS",
-          },
-          {
-            modelId: "gemini-3.5-flash",
-            remainingFraction: 0.25,
-            tokenType: "TOKENS",
-          },
-          {
-            modelId: "claude-sonnet-4-6",
-            remainingFraction: 0.9,
-          },
-        ],
-      }),
+      mockJsonResponse(SUMMARY_RESPONSE),
     );
 
     const result = await queryGoogleAgyQuota();
@@ -256,25 +242,9 @@ describe("google agy logic", () => {
     if (!result || !result.success) {
       throw new Error("expected success");
     }
-    expect(result.buckets).toEqual([
-      {
-        modelId: "gemini-3.5-flash",
-        displayName: "Gemini 3.5 Flash",
-        percentRemaining: 25,
-        tokenType: "TOKENS",
-        accountEmail: "alice@example.com",
-        accountKey: expect.any(String),
-        sourceKey: "google-agy",
-      },
-      {
-        modelId: "claude-sonnet-4-6",
-        displayName: "Claude Sonnet 4.6",
-        percentRemaining: 90,
-        accountEmail: "alice@example.com",
-        accountKey: expect.any(String),
-        sourceKey: "google-agy",
-      },
-    ]);
+    expect(result.summaryGroups).toHaveLength(2);
+    expect(result.summaryGroups[0].displayName).toBe("Gemini Models");
+    expect(result.summaryGroups[1].displayName).toBe("Claude and GPT models");
   });
 
   it("refreshes token when cache is empty and handles force refresh on auth error", async () => {
@@ -314,10 +284,13 @@ describe("google agy logic", () => {
 
     mocks.fetchWithTimeout.mockResolvedValueOnce(
       mockJsonResponse({
-        buckets: [
+        groups: [
           {
-            modelId: "gemini-3.5-flash",
-            remainingFraction: 0.5,
+            displayName: "Gemini Models",
+            buckets: [
+              { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.5 },
+              { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.5 },
+            ],
           },
         ],
       })
@@ -328,10 +301,8 @@ describe("google agy logic", () => {
     if (!result || !result.success) {
       throw new Error("expected success");
     }
-    expect(result.buckets[0]).toMatchObject({
-      modelId: "gemini-3.5-flash",
-      percentRemaining: 50,
-    });
+    expect(result.summaryGroups).toHaveLength(1);
+    expect(result.summaryGroups[0].buckets[0].remainingFraction).toBe(0.5);
   });
 
   it("keeps Google AGY quota requests on the fixed Google endpoint", async () => {
@@ -344,12 +315,12 @@ describe("google agy logic", () => {
       },
     });
     mocks.getCachedAccessToken.mockResolvedValueOnce({ accessToken: "cached-token" });
-    mocks.fetchWithTimeout.mockResolvedValueOnce(mockJsonResponse({ buckets: [] }));
+    mocks.fetchWithTimeout.mockResolvedValueOnce(mockJsonResponse({ groups: [] }));
 
     await queryGoogleAgyQuota();
 
     expect(mocks.fetchWithTimeout).toHaveBeenCalledWith(
-      "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota",
+      "https://daily-cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer cached-token",
@@ -370,5 +341,57 @@ describe("google agy logic", () => {
       accountCount: 1,
       validAccountCount: 0,
     });
+  });
+
+  it("merges summaryGroups across accounts keeping minimum remainingFraction", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      "google-agy": {
+        type: "oauth",
+        refresh: "refresh-token-1|project-1",
+        email: "alice@example.com",
+      },
+      "google-agy-auth": {
+        type: "oauth",
+        refresh: "refresh-token-2|project-2",
+        email: "bob@example.com",
+      },
+    });
+    mocks.getCachedAccessToken.mockResolvedValue({ accessToken: "cached-token" });
+
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.8, resetTime: "2026-06-22T00:00:00Z" },
+              { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.6 },
+            ],
+          },
+        ],
+      }),
+    );
+    mocks.fetchWithTimeout.mockResolvedValueOnce(
+      mockJsonResponse({
+        groups: [
+          {
+            displayName: "Gemini Models",
+            buckets: [
+              { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.3, resetTime: "2026-06-21T00:00:00Z" },
+              { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.9 },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const result = await queryGoogleAgyQuota();
+    expect(result).toMatchObject({ success: true });
+    if (!result || !result.success) {
+      throw new Error("expected success");
+    }
+    expect(result.summaryGroups).toHaveLength(1);
+    const geminiWeekly = result.summaryGroups[0].buckets.find((b) => b.bucketId === "gemini-weeky") || result.summaryGroups[0].buckets[0];
+    expect(geminiWeekly.remainingFraction).toBeLessThanOrEqual(0.3);
   });
 });

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -35,19 +35,26 @@ describe("google agy provider", () => {
     expectNotAttempted(out);
   });
 
-  it("maps quota buckets into grouped toast entries and truncated error labels", async () => {
+  it("maps summaryGroups into grouped toast entries with weekly-first ordering", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({
       success: true,
-      buckets: [
+      summaryGroups: [
         {
-          modelId: "gemini-2-5-flash",
-          displayName: "Gemini 2.5 Flash",
-          accountEmail: "alice@example.com",
-          percentRemaining: 64,
-          resetTimeIso: "2026-01-01T00:00:00.000Z",
-          remainingAmount: "1234",
-          tokenType: "REQUESTS",
+          displayName: "Gemini Models",
+          description: "Gemini model family",
+          buckets: [
+            { bucketId: "gemini-weekly", displayName: "Weekly", window: "weekly", remainingFraction: 0.58, resetTime: "2026-06-22T00:00:00Z" },
+            { bucketId: "gemini-5h", displayName: "5 Hour", window: "5h", remainingFraction: 0.25, remainingAmount: "1234" },
+          ],
+        },
+        {
+          displayName: "Claude and GPT models",
+          description: "Third-party model family",
+          buckets: [
+            { bucketId: "3p-weekly", displayName: "Weekly", window: "weekly", remainingFraction: 1, resetTime: "2026-06-22T00:00:00Z" },
+            { bucketId: "3p-5h", displayName: "5 Hour", window: "5h", remainingFraction: 0.9, remainingAmount: "50" },
+          ],
         },
       ],
       errors: [{ email: "bob@example.com", error: "Unauthorized" }],
@@ -57,12 +64,40 @@ describe("google agy provider", () => {
     expect(out.attempted).toBe(true);
     expect(out.entries).toEqual([
       {
-        name: "Gemini Models (ali..example)",
-        group: "Google AGY",
-        label: "Gemini Models:",
+        name: "Google AGY Gemini Models Weekly",
+        group: "Google AGY \u00b7 Gemini Models",
+        label: "Weekly:",
+        rankOverride: 1,
+        groupSortOverride: 1,
+        percentRemaining: 58,
+        resetTimeIso: "2026-06-22T00:00:00Z",
+      },
+      {
+        name: "Google AGY Gemini Models 5h",
+        group: "Google AGY \u00b7 Gemini Models",
+        label: "5h:",
+        rankOverride: 2,
+        groupSortOverride: 1,
         right: "1,234 left",
-        percentRemaining: 64,
-        resetTimeIso: "2026-01-01T00:00:00.000Z",
+        percentRemaining: 25,
+      },
+      {
+        name: "Google AGY Claude and GPT models Weekly",
+        group: "Google AGY \u00b7 Claude and GPT models",
+        label: "Weekly:",
+        rankOverride: 1,
+        groupSortOverride: 2,
+        percentRemaining: 100,
+        resetTimeIso: "2026-06-22T00:00:00Z",
+      },
+      {
+        name: "Google AGY Claude and GPT models 5h",
+        group: "Google AGY \u00b7 Claude and GPT models",
+        label: "5h:",
+        rankOverride: 2,
+        groupSortOverride: 2,
+        right: "50 left",
+        percentRemaining: 90,
       },
     ]);
     expect(out.errors).toEqual([{ label: "bob..example", message: "Unauthorized" }]);
@@ -72,95 +107,65 @@ describe("google agy provider", () => {
     });
   });
 
-  it("maps aggregated Google AGY quality tiers without changing provider presentation", async () => {
+  it("filters disabled buckets", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({
       success: true,
-      buckets: [
+      summaryGroups: [
         {
-          modelId: "gemini-3-5-flash",
-          displayName: "Gemini 3.5 Flash",
-          accountEmail: "alice@example.com",
-          percentRemaining: 20,
-          resetTimeIso: "2026-01-01T12:00:00Z",
-          remainingAmount: "50",
-          tokenType: "TOKENS",
+          displayName: "Gemini Models",
+          buckets: [
+            { bucketId: "gemini-weekly", window: "weekly", remainingFraction: 0.5, disabled: true },
+            { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.8 },
+          ],
         },
       ],
     });
 
     const out = await googleAgyProvider.fetch({ client: {} } as any);
     expectAttemptedWithNoErrors(out);
-    expect(out.entries).toEqual([
-      {
-        name: "Gemini Models (ali..example)",
-        group: "Google AGY",
-        label: "Gemini Models:",
-        right: "50 left TOKENS",
-        percentRemaining: 20,
-        resetTimeIso: "2026-01-01T12:00:00Z",
-      },
-    ]);
-    expect(out.presentation).toEqual({
-      singleWindowDisplayName: "Google AGY",
-      singleWindowShowRight: true,
-    });
+    expect(out.entries).toHaveLength(1);
+    expect(out.entries[0].rankOverride).toBe(2);
+    expect(out.entries[0].label).toBe("5h:");
   });
 
-  it("keeps email-less AGY accounts separate using account keys", async () => {
+  it("sorts Gemini groups before Claude/GPT groups", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({
       success: true,
-      buckets: [
+      summaryGroups: [
         {
-          modelId: "gemini-3-5-flash",
-          displayName: "Gemini 3.5 Flash",
-          accountKey: "aaaaaaaa11111111",
-          percentRemaining: 20,
+          displayName: "Claude and GPT models",
+          buckets: [
+            { bucketId: "3p-5h", window: "5h", remainingFraction: 0.4 },
+          ],
         },
         {
-          modelId: "gemini-3-5-flash",
-          displayName: "Gemini 3.5 Flash",
-          accountKey: "bbbbbbbb22222222",
-          percentRemaining: 80,
+          displayName: "Gemini Models",
+          buckets: [
+            { bucketId: "gemini-5h", window: "5h", remainingFraction: 0.6 },
+          ],
         },
       ],
     });
 
     const out = await googleAgyProvider.fetch({ client: {} } as any);
     expectAttemptedWithNoErrors(out);
-    expect(out.entries.map((entry) => entry.name)).toEqual([
-      "Gemini Models (Account aaaaaaaa)",
-      "Gemini Models (Account bbbbbbbb)",
-    ]);
+    expect(out.entries[0].group).toContain("Gemini");
+    expect(out.entries[0].groupSortOverride).toBe(1);
+    expect(out.entries[1].group).toContain("Claude");
+    expect(out.entries[1].groupSortOverride).toBe(2);
   });
 
-  it("groups and filters multiple models into canonical display buckets", async () => {
+  it("handles empty summaryGroups gracefully", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({
-      success: true,
-      buckets: [
-        { modelId: "gemini-2-5-flash", displayName: "Gemini 2.5 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
-        { modelId: "gemini-2-5-pro", displayName: "Gemini 2.5 Pro", accountEmail: "test@a.com", percentRemaining: 12 },
-        { modelId: "gemini-3-flash", displayName: "Gemini 3 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
-        { modelId: "gemini-3-1-pro-high", displayName: "Gemini 3.1 Pro High", accountEmail: "test@a.com", percentRemaining: 12 },
-        { modelId: "gemini-3-5-flash", displayName: "Gemini 3.5 Flash", accountEmail: "test@a.com", percentRemaining: 12 },
-        { modelId: "claude-sonnet-4-6", displayName: "Claude Sonnet 4.6", accountEmail: "test@a.com", percentRemaining: 0 },
-        { modelId: "claude-opus-4-6-thinking", displayName: "Claude Opus 4.6 Thinking", accountEmail: "test@a.com", percentRemaining: 0 },
-        { modelId: "gpt-oss-120b", displayName: "GPT-OSS 120B (Medium)", accountEmail: "test@a.com", percentRemaining: 0 }, // Should be filtered out
-        { modelId: "chat-20706", displayName: "Chat 20706", accountEmail: "test@a.com", percentRemaining: 100 }, // Should be filtered out
-      ],
+      success: false,
+      error: "Quota summary API unavailable",
     });
 
     const out = await googleAgyProvider.fetch({ client: {} } as any);
-    expectAttemptedWithNoErrors(out);
-    
-    // Check that we only get the 2 consolidated groups, sorted alphabetically
-    const entryLabels = out.entries.map(e => e.label);
-    expect(entryLabels).toEqual([
-      "Claude and GPT models:",
-      "Gemini Models:",
-    ]);
+    expectAttemptedWithErrorLabel(out, "Google AGY");
   });
 
   it("maps fetch failures into toast errors", async () => {


### PR DESCRIPTION
## Summary

Following the last release of [opencode-agy-auth](https://github.com/anthonyhaussman/opencode-agy-auth), switch from per-model retrieveUserQuota to grouped retrieveUserQuotaSummary endpoint.

The new API returns model families (e.g. "Gemini Models", "Claude and GPT models") with weekly/5h buckets, eliminating client-side model name parsing and aggregation. 

Add `rankOverride`/`groupSortOverride` fields for explicit intra-group and inter-group ordering. 
Filter disabled buckets before display.
Merge summary groups across accounts keeping minimum remainingFraction.

New display:
```
> node dist/bin/opencode-quota.js show --provider google-agy
[Google AGY · Gemini Models]
Weekly window                                   2d
██████████████░░░░░░░░░░░░░░░░░░░░░░░░░   35% left
5h window                                       5h
██████████████████████████████████████░   97% left

[Google AGY · Claude and GPT models]
Weekly window                                   4d
███████████████████████████████░░░░░░░░   79% left
5h window                                         
███████████████████████████████████████  100% left
```

## Linked Issue

Improve the display of `opencode-agy` Google AntiGravity quota to be in accordance with the Antigravity client.

## OpenCode Validation

- Current production released OpenCode version tested: `1.17.10`
- Why this version is relevant to the fix: -

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test`
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
