### PR TITLE
fix: do not cache error-only quota results

### DIFF
--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -292,7 +292,7 @@ export async function fetchQuotaProviderResult(params: {
     const fetched = await provider.fetch(ctx);
     const snapshot = cloneQuotaProviderResult(fetched);
 
-    if (!snapshot.attempted) {
+    if (!snapshot.attempted || snapshot.entries.length === 0) {
       inMemoryCache.delete(key);
       await safeRm(getQuotaProviderStateCacheFilePath(provider.id, key));
       return snapshot;

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -320,6 +320,38 @@ describe("quota-state shared cache", () => {
     expect(provider.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it("does not cache attempted error-only results without quota entries", async () => {
+    const { __resetQuotaStateForTests, fetchQuotaProviderResult, readCachedProviderResult } =
+      await import("../src/lib/quota-state.js");
+    __resetQuotaStateForTests();
+
+    const provider = {
+      id: "synthetic",
+      isAvailable: vi.fn(),
+      fetch: vi.fn().mockResolvedValue({
+        attempted: true,
+        entries: [],
+        errors: [{ label: "Synthetic", message: "Request timeout after 5s" }],
+      }),
+    } as any;
+
+    const ctx = createTestContext();
+
+    const first = await fetchQuotaProviderResult({ provider, ctx, ttlMs: 60_000 });
+    const second = await fetchQuotaProviderResult({ provider, ctx, ttlMs: 60_000 });
+    const cached = await readCachedProviderResult({ provider, ctx, ttlMs: 60_000 });
+
+    expect(first).toEqual({
+      attempted: true,
+      entries: [],
+      errors: [{ label: "Synthetic", message: "Request timeout after 5s" }],
+    });
+    expect(second).toEqual(first);
+    expect(provider.fetch).toHaveBeenCalledTimes(2);
+    expect(cached).toEqual({ hit: false });
+    await expect(readdir(`${TEST_RUNTIME_ROOT}/cache/quota-provider-state`)).rejects.toThrow();
+  });
+
   it("bypasses persistence entirely for live-local providers", async () => {
     const { __resetQuotaStateForTests, fetchQuotaProviderResult } = await import(
       "../src/lib/quota-state.js"


### PR DESCRIPTION
## Summary

- do not cache attempted quota results when they contain no quota entries
- add a regression test for timeout/error-only provider results

## Problem

`fetchQuotaProviderResult()` currently caches any result with `attempted: true`, including timeout/error-only payloads like:

```ts
{
  attempted: true,
  entries: [],
  errors: [{ label: "OpenAI", message: "Request timeout after 5s" }],
}
```

That means a transient provider timeout gets persisted and then reused for the full TTL, so quota rows can disappear for minutes even after the provider recovers.

## Fix

- treat `entries.length === 0` as a cache miss path, just like `attempted: false`
- clear any existing cache file instead of persisting the error-only snapshot
- cover the case with a regression test that verifies:
  - the provider is refetched on the next read
  - `readCachedProviderResult()` reports a miss
  - no `quota-provider-state/` file is written

## Verification

```bash
./node_modules/.bin/vitest run tests/quota-state.test.ts
./node_modules/.bin/tsc --noEmit
```
