### PR TITLE
Fix opencode 1.17.14 TUI sidebar compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "./tui": {
       "types": "./dist/tui.d.ts",
-      "default": "./dist/tui.tsx"
+      "default": "./dist/tui.js"
     }
   },
   "oc-plugin": [
@@ -70,8 +70,11 @@
   },
   "homepage": "https://github.com/slkiser/opencode-quota#readme",
   "devDependencies": {
+    "@babel/core": "^7.28.0",
+    "@babel/preset-typescript": "^7.27.1",
     "@opencode-ai/plugin": "^1.4.3",
     "@types/node": "^22.0.0",
+    "babel-preset-solid": "^1.9.12",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,21 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
     devDependencies:
+      '@babel/core':
+        specifier: ^7.28.0
+        version: 7.28.0
+      '@babel/preset-typescript':
+        specifier: ^7.27.1
+        version: 7.27.1(@babel/core@7.28.0)
       '@opencode-ai/plugin':
         specifier: ^1.4.3
         version: 1.14.48(@opentui/core@0.2.7(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.2.7(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.6
+      babel-preset-solid:
+        specifier: ^1.9.12
+        version: 1.9.12(@babel/core@7.28.0)(solid-js@1.9.12)
       husky:
         specifier: ^9.1.7
         version: 9.1.7

--- a/scripts/prepare-tui-dist.mjs
+++ b/scripts/prepare-tui-dist.mjs
@@ -1,14 +1,30 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import babel from "@babel/core";
+import typescriptPreset from "@babel/preset-typescript";
+import solidPreset from "babel-preset-solid";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const rootDir = path.resolve(__dirname, '..')
-const sourcePath = path.join(rootDir, 'src', 'tui.tsx')
-const distSourcePath = path.join(rootDir, 'dist', 'tui.tsx')
-const distJsxPath = path.join(rootDir, 'dist', 'tui.jsx')
-const distJsxMapPath = path.join(rootDir, 'dist', 'tui.jsx.map')
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const sourcePath = path.join(rootDir, "src", "tui.tsx");
+const distSourcePath = path.join(rootDir, "dist", "tui.tsx");
+const distJsPath = path.join(rootDir, "dist", "tui.js");
+const distJsxPath = path.join(rootDir, "dist", "tui.jsx");
+const distJsxMapPath = path.join(rootDir, "dist", "tui.jsx.map");
 
-await fs.copyFile(sourcePath, distSourcePath)
-await fs.rm(distJsxPath, { force: true })
-await fs.rm(distJsxMapPath, { force: true })
+await fs.copyFile(sourcePath, distSourcePath);
+const source = await fs.readFile(sourcePath, "utf8");
+const transformed = await babel.transformAsync(source, {
+  filename: sourcePath,
+  configFile: false,
+  babelrc: false,
+  presets: [
+    [solidPreset, { moduleName: "@opentui/solid", generate: "universal" }],
+    [typescriptPreset],
+  ],
+});
+
+await fs.writeFile(distJsPath, `${transformed?.code ?? ""}\n`);
+await fs.rm(distJsxPath, { force: true });
+await fs.rm(distJsxMapPath, { force: true });

--- a/scripts/prepare-tui-dist.mjs
+++ b/scripts/prepare-tui-dist.mjs
@@ -25,6 +25,10 @@ const transformed = await babel.transformAsync(source, {
   ],
 });
 
-await fs.writeFile(distJsPath, `${transformed?.code ?? ""}\n`);
+if (!transformed?.code) {
+  throw new Error("Babel transform returned empty output");
+}
+
+await fs.writeFile(distJsPath, `${transformed.code}\n`);
 await fs.rm(distJsxPath, { force: true });
 await fs.rm(distJsxMapPath, { force: true });

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { access, readFile } from "node:fs/promises";
 
-const pkg = JSON.parse(
-  await readFile(new URL("../package.json", import.meta.url), "utf8"),
-) as {
+const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
   main?: string;
   bin?: Record<string, string>;
   exports?: Record<string, { default?: string; types?: string }>;
@@ -56,7 +54,7 @@ describe("package manifest compatibility", () => {
       types: "./dist/index.d.ts",
     });
     expect(pkg.exports?.["./tui"]).toEqual({
-      default: "./dist/tui.tsx",
+      default: "./dist/tui.js",
       types: "./dist/tui.d.ts",
     });
   });

--- a/tests/tui-dist-packaging.test.ts
+++ b/tests/tui-dist-packaging.test.ts
@@ -3,14 +3,21 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("solid-js", () => ({
-  createSignal: <T,>(value: T) => [() => value, vi.fn()],
+  Show: (props: { children?: unknown }) => props.children,
+  createEffect: vi.fn(),
+  createSignal: <T>(value: T) => [() => value, vi.fn()],
   onCleanup: vi.fn(),
 }));
 
-vi.mock("react/jsx-runtime", () => ({
-  Fragment: Symbol.for("Fragment"),
-  jsx: vi.fn(),
-  jsxs: vi.fn(),
+vi.mock("@opentui/solid", () => ({
+  createComponent: (component: (props: unknown) => unknown, props: unknown) => component(props),
+  createElement: vi.fn(),
+  createTextNode: vi.fn(),
+  effect: vi.fn(),
+  insert: vi.fn(),
+  insertNode: vi.fn(),
+  memo: (fn: () => unknown) => fn,
+  setProp: vi.fn(),
 }));
 
 async function exists(url: URL): Promise<boolean> {
@@ -23,8 +30,8 @@ async function exists(url: URL): Promise<boolean> {
 }
 
 describe("tui dist packaging", () => {
-  it("ships the raw tsx TUI entry and removes the jsx artifacts", async () => {
-    const distTui = new URL("../dist/tui.tsx", import.meta.url);
+  it("ships the precompiled TUI entry and removes stale jsx artifacts", async () => {
+    const distTui = new URL("../dist/tui.js", import.meta.url);
     const distJsx = new URL("../dist/tui.jsx", import.meta.url);
     const distJsxMap = new URL("../dist/tui.jsx.map", import.meta.url);
 
@@ -33,14 +40,16 @@ describe("tui dist packaging", () => {
     expect(await exists(distJsxMap)).toBe(false);
 
     const source = await readFile(distTui, "utf8");
+    expect(source).toContain("createComponent");
     expect(source).toContain("sidebar_content");
     expect(source).toContain("loadTuiSessionQuotaSurfaces");
     expect(source).toContain("resolveTuiSurfaceRegistration");
     expect(source).toContain("const pluginModule");
+    expect(source).not.toContain("jsx-dev-runtime");
   });
 
   it("can load the packaged TUI module", async () => {
-    const mod = await import("../dist/tui.tsx");
+    const mod = await import("../dist/tui.js");
 
     expect(mod.default).toMatchObject({
       id: "@slkiser/opencode-quota",


### PR DESCRIPTION
## Summary

Fix the opencode 1.17.14 compatibility issue where the opencode-quota TUI sidebar does not load.

This PR precompiles the TUI TSX entry to `dist/tui.js` and points the `./tui` export at that compiled JS file.

This avoids loading raw TSX/JSX runtime imports from the published package, which can prevent the opencode sidebar TUI from loading in opencode 1.17.14 and newer versions.

## Linked Issue

Fixes #146

## OpenCode Validation

- Current production released OpenCode version tested: opencode 1.17.14
- Why this version is relevant to the fix: opencode 1.17.14 TUI loading expects the plugin TUI entry to be loadable JavaScript, while the package previously exported raw `dist/tui.tsx`.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test`
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [x] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply: not applicable, this PR only changes TUI packaging.
- [x] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior: not applicable, this PR only changes TUI packaging.