### PR TITLE
Finer grained reset countdown options

### DIFF
--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -73,6 +73,21 @@ Announcements are bundled only: no remote fetches, announcement telemetry, or pe
 </details>
 
 <details>
+<summary><strong>Show finer-grained reset countdowns</strong></summary>
+
+By default the reset countdown rounds to integer days and half-hour steps (`6d`, `2h`, `1h`, `0.5h`). Set `resetTimeDecimals` to render fractional durations instead, for example `5.7d` or `1.4h`. Applies to the Sidebar panel, popup toasts, and `opencode-quota show`.
+
+```jsonc
+{
+  "resetTimeDecimals": 1,
+}
+```
+
+Allowed values are integers `0`–`4`. Unset keeps the legacy compact rounding exactly.
+
+</details>
+
+<details>
 <summary><strong>Turn off popup toasts</strong></summary>
 
 Keeps terminal checks, any enabled UI surfaces, and `/quota`/`/quota_status`.
@@ -191,6 +206,7 @@ Existing `experimental.quotaToast` settings still work when no sidecar file exis
 | `requestTimeoutMs`            | `5000`         | Remote provider request timeout in milliseconds.                                                                                                                                                                                                                                                   |
 | `formatStyle`                 | `singleWindow` | Shared quota reset-period display for popup toasts, the Sidebar panel, and Compact status line unless a TUI surface override is set: `singleWindow` shows one reset period per provider; `allWindows` shows all reset periods per provider. Legacy `classic`/`grouped` aliases are still accepted. |
 | `percentDisplayMode`          | `remaining`    | Shared quota percentage meaning for popup toasts, the Sidebar panel, and `/quota`: `remaining` shows quota left; `used` shows quota consumed.                                                                                                                                                      |
+| `resetTimeDecimals`           | unset          | Decimal places for compact reset-countdown labels. Unset keeps legacy rounding (`6d`, `2h`, `0.5h`); an integer `0`–`4` renders fractional durations like `5.7d` or `1.4h`.                                                                                                                        |
 | `onlyCurrentModel`            | `false`        | Filter quota rows to the current model/provider when that session selection can be resolved.                                                                                                                                                                                                       |
 | `showSessionTokens`           | `true`         | Show the `Session input/output tokens` section when session token data is available. When cached input is present, the section keeps the legacy `in/out` layout and appends cached input in parentheses next to the input amount.                                                                  |
 | `pricingSnapshot.source`      | `"auto"`       | Token pricing snapshot selection for `/tokens_*`: `auto`, `bundled`, or `runtime`.                                                                                                                                                                                                                 |

--- a/src/lib/cli-show.ts
+++ b/src/lib/cli-show.ts
@@ -320,6 +320,7 @@ export async function runCliShowCommand(options: RunCliShowCommandOptions = {}):
       errors: data.errors,
       style: resolveQuotaFormatStyle(config.formatStyle),
       percentDisplayMode: config.percentDisplayMode,
+      resetTimeDecimals: config.resetTimeDecimals,
     });
 
     if (!output.trim()) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_CONFIG } from "./types.js";
 import { isQuotaFormatStyle, resolveQuotaFormatStyle } from "./quota-format-style.js";
+import { isResetTimeDecimals } from "./format-utils.js";
 import { parseJsonOrJsonc } from "./jsonc.js";
 import { getQuotaProviderShape, normalizeQuotaProviderId } from "./provider-metadata.js";
 
@@ -33,6 +34,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "enableToast",
   "formatStyle",
   "percentDisplayMode",
+  "resetTimeDecimals",
   "minIntervalMs",
   "requestTimeoutMs",
   "debug",
@@ -133,6 +135,7 @@ type ValidatedQuotaToastPatch = {
   enableToast?: boolean;
   formatStyle?: QuotaToastConfig["formatStyle"];
   percentDisplayMode?: PercentDisplayMode;
+  resetTimeDecimals?: number;
   minIntervalMs?: number;
   requestTimeoutMs?: number;
   debug?: boolean;
@@ -521,6 +524,13 @@ function extractValidatedQuotaToastPatch(
     patch.percentDisplayMode = quotaToastConfig.percentDisplayMode;
   }
 
+  if (
+    hasOwnKey(quotaToastConfig, "resetTimeDecimals") &&
+    isResetTimeDecimals(quotaToastConfig.resetTimeDecimals)
+  ) {
+    patch.resetTimeDecimals = quotaToastConfig.resetTimeDecimals;
+  }
+
   if (hasOwnKey(quotaToastConfig, "minIntervalMs") && isPositiveNumber(quotaToastConfig.minIntervalMs)) {
     patch.minIntervalMs = quotaToastConfig.minIntervalMs;
   }
@@ -720,6 +730,11 @@ function applyValidatedQuotaToastPatch(
   if (hasOwnKey(patch, "percentDisplayMode")) {
     config.percentDisplayMode = patch.percentDisplayMode!;
     applySettingSource(settingSources, "percentDisplayMode", sourcePath);
+  }
+
+  if (hasOwnKey(patch, "resetTimeDecimals")) {
+    config.resetTimeDecimals = patch.resetTimeDecimals;
+    applySettingSource(settingSources, "resetTimeDecimals", sourcePath);
   }
 
   if (hasOwnKey(patch, "minIntervalMs")) {

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -148,7 +148,18 @@ export interface FormatResetCountdownOptions {
    * - 14m -> 14m
    */
   compactRounded?: boolean;
+  /**
+   * When set (with compactRounded), render the largest active unit with this
+   * many decimal places instead of the legacy integer-day / half-hour steps.
+   * - 5.7d, 1.4h, 0.2h
+   * A non-negative integer enables fractional output; otherwise the legacy
+   * compactRounded behavior is preserved exactly.
+   */
+  decimals?: number;
 }
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_HOUR = 3_600_000;
 
 /**
  * Format a reset countdown for toast display.
@@ -169,6 +180,15 @@ export function formatResetCountdown(iso?: string, opts?: FormatResetCountdownOp
   const minutes = diffMinutes % 60;
 
   if (opts?.compactRounded) {
+    const decimals = opts.decimals;
+    if (isResetTimeDecimals(decimals)) {
+      // Fine-grained: keep the legacy unit selection (days when >= 1 day,
+      // hours otherwise) but render fractional values with N decimals.
+      if (days > 0) return `${(diffMs / MS_PER_DAY).toFixed(decimals)}d`;
+      return `${(diffMs / MS_PER_HOUR).toFixed(decimals)}h`;
+    }
+
+    // Legacy default: integer days and half-hour steps for sub-day durations.
     if (days > 0) return `${days}d`;
     const halfHours = Math.ceil(diffMinutes / 30);
     const h = Math.floor(halfHours / 2);
@@ -178,4 +198,23 @@ export function formatResetCountdown(iso?: string, opts?: FormatResetCountdownOp
 
   if (days > 0) return `${days}d ${hours}h`;
   return `${hours}h ${minutes}m`;
+}
+
+/**
+ * Maximum accepted value for the resetTimeDecimals config setting.
+ * Keeps compact reset labels short in narrow surfaces like the sidebar.
+ */
+export const MAX_RESET_TIME_DECIMALS = 4;
+
+/**
+ * True when value is a valid resetTimeDecimals (non-negative integer within range).
+ * Used by formatResetCountdown and the config loader to keep validation in sync.
+ */
+export function isResetTimeDecimals(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= 0 &&
+    value <= MAX_RESET_TIME_DECIMALS
+  );
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -98,6 +98,7 @@ export function formatQuotaRows(params: {
   errors?: QuotaToastError[];
   style?: QuotaFormatStyle;
   percentDisplayMode?: QuotaToastConfig["percentDisplayMode"];
+  resetTimeDecimals?: number;
   sessionTokens?: SessionTokensData;
 }): string {
   const styleDefinition = getQuotaFormatStyleDefinition(params.style);
@@ -108,6 +109,7 @@ export function formatQuotaRows(params: {
       entries: params.entries,
       errors: params.errors,
       percentDisplayMode: params.percentDisplayMode,
+      resetTimeDecimals: params.resetTimeDecimals,
       sessionTokens: params.sessionTokens,
     });
   }
@@ -157,7 +159,11 @@ export function formatQuotaRows(params: {
     // (i.e., any usage at all, or depleted)
     const timeStr =
       remaining < 100
-        ? formatResetCountdown(resetIso, { missing: "-", compactRounded: true })
+        ? formatResetCountdown(resetIso, {
+            missing: "-",
+            compactRounded: true,
+            decimals: params.resetTimeDecimals,
+          })
         : "";
 
     if (isTiny) {
@@ -195,7 +201,11 @@ export function formatQuotaRows(params: {
   };
 
   const addValueEntry = (name: string, resetIso: string | undefined, value: string) => {
-    const timeStr = formatResetCountdown(resetIso, { missing: "-", compactRounded: true });
+    const timeStr = formatResetCountdown(resetIso, {
+      missing: "-",
+      compactRounded: true,
+      decimals: params.resetTimeDecimals,
+    });
 
     if (isTiny) {
       // Tiny: single line without percent; keep time col alignment.

--- a/src/lib/toast-format-grouped.ts
+++ b/src/lib/toast-format-grouped.ts
@@ -63,6 +63,7 @@ export function formatQuotaRowsGrouped(params: {
   entries?: QuotaToastEntry[];
   errors?: QuotaToastError[];
   percentDisplayMode?: QuotaToastConfig["percentDisplayMode"];
+  resetTimeDecimals?: number;
   sessionTokens?: SessionTokensData;
 }): string {
   const layout = params.layout ?? { maxWidth: 50, narrowAt: 42, tinyAt: 32 };
@@ -108,7 +109,10 @@ export function formatQuotaRowsGrouped(params: {
 
       if (isValueEntry(entry)) {
         const label = entry.label?.trim() || entry.name;
-        const timeStr = formatResetCountdown(entry.resetTimeIso, { compactRounded: true });
+        const timeStr = formatResetCountdown(entry.resetTimeIso, {
+          compactRounded: true,
+          decimals: params.resetTimeDecimals,
+        });
         const value = entry.value.trim();
 
         if (isTiny) {
@@ -153,7 +157,10 @@ export function formatQuotaRowsGrouped(params: {
       // (i.e., any usage at all, or depleted)
       const timeStr =
         entry.percentRemaining < 100
-          ? formatResetCountdown(entry.resetTimeIso, { compactRounded: true })
+          ? formatResetCountdown(entry.resetTimeIso, {
+              compactRounded: true,
+              decimals: params.resetTimeDecimals,
+            })
           : "";
       const displayedPercent = resolveDisplayedPercent(
         entry.percentRemaining,

--- a/src/lib/tui-sidebar-format.ts
+++ b/src/lib/tui-sidebar-format.ts
@@ -13,7 +13,7 @@ export const TUI_SIDEBAR_LAYOUT = {
 
 export function buildSidebarQuotaPanelLines(params: {
   data: QuotaRenderData;
-  config: Pick<QuotaToastConfig, "formatStyle" | "percentDisplayMode">;
+  config: Pick<QuotaToastConfig, "formatStyle" | "percentDisplayMode" | "resetTimeDecimals">;
 }): string[] {
   const data = sanitizeQuotaRenderData(params.data);
 
@@ -24,6 +24,7 @@ export function buildSidebarQuotaPanelLines(params: {
     errors: data.errors,
     style: params.config.formatStyle,
     percentDisplayMode: params.config.percentDisplayMode,
+    resetTimeDecimals: params.config.resetTimeDecimals,
     sessionTokens: data.sessionTokens,
   });
   return quotaBody ? quotaBody.split("\n") : [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,8 +73,7 @@ export interface QuotaToastConfig {
   /** If false, never show popup toasts (commands/tools still work). */
   enableToast: boolean;
 
-  /**
-   * Shared quota-row formatting style for popup toasts and the TUI sidebar.
+  /** Shared quota-row formatting style for popup toasts and the TUI sidebar.
    *
    * Canonical values:
    * - "singleWindow": collapse each provider to a single displayable quota window
@@ -85,6 +84,16 @@ export interface QuotaToastConfig {
   formatStyle: QuotaFormatStyle;
   /** Shared percent meaning for popup toasts and the TUI sidebar. */
   percentDisplayMode: PercentDisplayMode;
+  /**
+   * Number of decimal places for compact reset-countdown labels (e.g. the
+   * sidebar/toast "5.7d" or "1.4h" duration until a quota window resets).
+   *
+   * When unset, the legacy compact rounding is preserved exactly: integer
+   * days and half-hour steps for sub-day durations ("6d", "2h", "0.5h").
+   * When set to a non-negative integer (0..4), durations render with that
+   * many decimal places ("5.7d", "1.4h").
+   */
+  resetTimeDecimals?: number;
   minIntervalMs: number;
 
   /** Request timeout in milliseconds for remote provider API calls. */

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -878,6 +878,7 @@ export const QuotaToastPlugin: Plugin = async ({ client }) => {
         errors: data?.errors ?? [],
         style: resolveQuotaFormatStyle(runtimeConfig.formatStyle),
         percentDisplayMode: runtimeConfig.percentDisplayMode,
+        resetTimeDecimals: runtimeConfig.resetTimeDecimals,
         sessionTokens: data?.sessionTokens,
       });
 

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -211,6 +211,81 @@ describe("formatQuotaRows", () => {
     expect(out).not.toContain("0h 14m");
   });
 
+  it("renders fractional reset countdowns when resetTimeDecimals is set (single-window)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));
+
+    const out = formatQuotaRows({
+      version: "1.0.0",
+      layout: { maxWidth: 50, narrowAt: 42, tinyAt: 32 },
+      resetTimeDecimals: 1,
+      entries: [
+        {
+          name: "Copilot Monthly",
+          percentRemaining: 50,
+          // 5.7 days away (5d 16h 48m)
+          resetTimeIso: "2026-01-21T02:48:00.000Z",
+        },
+        {
+          name: "OpenAI 5h",
+          percentRemaining: 50,
+          // 1.4 hours away (1h 24m)
+          resetTimeIso: "2026-01-15T11:24:00.000Z",
+        },
+      ],
+    });
+
+    expect(out).toContain("5.7d");
+    expect(out).toContain("1.4h");
+    expect(out).not.toContain("0.5h");
+  });
+
+  it("renders fractional reset countdowns when resetTimeDecimals is set (grouped)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));
+
+    const out = formatQuotaRows({
+      version: "1.0.0",
+      style: "allWindows",
+      layout: { maxWidth: 50, narrowAt: 42, tinyAt: 32 },
+      resetTimeDecimals: 1,
+      entries: [
+        {
+          name: "OpenAI 5h",
+          group: "OpenAI",
+          label: "5h:",
+          percentRemaining: 56,
+          // 14 minutes -> 0.2h
+          resetTimeIso: "2026-01-15T10:14:00.000Z",
+        },
+      ],
+    });
+
+    expect(out).toContain("0.2h");
+    expect(out).not.toContain("0.5h");
+  });
+
+  it("keeps legacy compact rounding when resetTimeDecimals is unset", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));
+
+    const out = formatQuotaRows({
+      version: "1.0.0",
+      layout: { maxWidth: 50, narrowAt: 42, tinyAt: 32 },
+      entries: [
+        {
+          name: "Copilot Monthly",
+          percentRemaining: 50,
+          // 5.7 days away -> floored to 5d
+          resetTimeIso: "2026-01-21T02:48:00.000Z",
+        },
+      ],
+    });
+
+    expect(out).toContain("5d");
+    expect(out).not.toContain("5.7d");
+  });
+
   it("normalizes grouped headers in all-window toast output", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-15T12:00:00.000Z"));

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -627,6 +627,28 @@ describe("loadConfig", () => {
     expect(invalid.config.percentDisplayMode).toBe("remaining");
   });
 
+  it("defaults resetTimeDecimals to unset and accepts integer 0..4 overrides", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.resetTimeDecimals).toBeUndefined();
+
+    const explicit = await loadSdkConfig({ resetTimeDecimals: 1 });
+    expect(explicit.config.resetTimeDecimals).toBe(1);
+    expect(explicit.meta.settingSources).toEqual({
+      resetTimeDecimals: "client.config.get",
+    });
+
+    for (const value of [0, 4]) {
+      const boundary = await loadSdkConfig({ resetTimeDecimals: value });
+      expect(boundary.config.resetTimeDecimals).toBe(value);
+    }
+
+    for (const invalid of [-1, 5, 1.5, Number.NaN, "1", null]) {
+      const rejected = await loadSdkConfig({ resetTimeDecimals: invalid });
+      expect(rejected.config.resetTimeDecimals).toBeUndefined();
+      expect(rejected.meta.settingSources).not.toHaveProperty("resetTimeDecimals");
+    }
+  });
+
   it("defaults anthropicBinaryPath and trims explicit overrides", async () => {
     const defaults = await loadSdkConfig({});
     expect(defaults.config.anthropicBinaryPath).toBe("claude");

--- a/tests/tui-sidebar-format.test.ts
+++ b/tests/tui-sidebar-format.test.ts
@@ -336,6 +336,34 @@ describe("buildSidebarQuotaPanelLines", () => {
     expect(lines.join("\n")).not.toContain("2h 14m");
   });
 
+  it("uses fractional reset text in sidebar rows when resetTimeDecimals is set", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));
+
+    const lines = buildSidebarQuotaPanelLines({
+      config: {
+        formatStyle: "singleWindow",
+        percentDisplayMode: "remaining",
+        resetTimeDecimals: 1,
+      },
+      data: {
+        entries: [
+          {
+            name: "[Copilot] Monthly",
+            percentRemaining: 81,
+            // 2.2333h away -> 2.2h
+            resetTimeIso: "2026-01-15T12:14:00.000Z",
+          },
+        ],
+        errors: [],
+        sessionTokens: undefined,
+      },
+    });
+
+    expect(lines.join("\n")).toContain("2.2h");
+    expect(lines.join("\n")).not.toContain("2.5h");
+  });
+
   it("does not cut single-window provider/account labels that fit in the sidebar", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));


### PR DESCRIPTION
## Summary

Add an optional resetTimeDecimals config setting (integers 0-4) that renders fractional reset-countdown durations (5.7d, 1.4h) instead of the integer-day / half-hour-step rounding (6d, 2h, 0.5h) we get now. When unset, the current compact rounding is preserved exactly.

## Rationale/scope

Makes it much easier for me to time budget for reset, understand when to time breaks, etc.

Threads through formatResetCountdown -> formatQuotaRows/grouped -> sidebar/toast/CLI surfaces as a shared setting alongside percentDisplayMode.

## OpenCode Validation

- Current production released OpenCode version tested: `dev` branch.
- Why this version is relevant to the fix: I don't think it is, should work wherever.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test`
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [N/A] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [N/A] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
