### PR TITLE
ci: update artifact actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           pnpm pack --pack-destination package-artifacts
 
       - name: Upload package tarball
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: package-tarball
           path: package-artifacts/*.tgz
@@ -61,7 +61,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Download package tarball
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: package-tarball
           path: package-artifacts


### PR DESCRIPTION
## Summary

Describe the change and why it is needed.

## Linked Issue

Use `Fixes #...` or `Refs #...` when available.  
If no issue exists, include a short rationale/scope summary.

## OpenCode Validation

- Current production released OpenCode version tested:
- Why this version is relevant to the fix:

## Quality Checklist

- [ ] I ran `pnpm run typecheck`
- [ ] I ran `pnpm test`
- [ ] I ran `pnpm run build`
- [ ] This is the smallest safe root-cause fix (no unnecessary hook/output mutation logic)
- [ ] I preserved behavioral invariants and updated/added boundary tests as needed
- [ ] I updated docs for user-facing workflow/command/config changes (`README.md` and `CONTRIBUTING.md` when applicable)
- [ ] For new API-key/token providers, I started from `contributing/provider-template/` or explained why the template does not apply
- [ ] For provider setup/auth wording changes, I checked the relevant dummy `.ts` template in `contributing/provider-template/` and verified `README.md` against `src/lib/provider-metadata.ts` (`authentication`/`authFallbacks`) and provider auth resolver/diagnostics behavior
