### PR TITLE
feat(provider): add xAI SuperGrok weekly quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | Zhipu Coding Plan        | OpenCode config                                                | Remote API         | Quota              |
 | NanoGPT                  | API key/config                                                 | Remote API         | Quota and balance  |
 | DeepSeek                 | API key/config                                                 | Remote API         | Balance and status |
+| xAI SuperGrok            | OpenCode OAuth (`/connect` xAI)                                | Remote API         | Weekly quota    |
 | Ollama Cloud             | [Needs setup](docs/readme/providers.md#ollama-cloud)           | Dashboard scraping | Quota              |
 | OpenCode Go              | [Needs setup](docs/readme/providers.md#opencode-go)            | Dashboard scraping | Quota              |
 

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -34,6 +34,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | Zhipu Coding Plan        | OpenCode config                        | Remote API         | Quota              |
 | NanoGPT                  | API key/config                         | Remote API         | Quota and balance  |
 | DeepSeek                 | API key/config                         | Remote API         | Balance and status |
+| xAI SuperGrok            | OpenCode OAuth (`/connect` xAI) | Remote API         | Weekly quota    |
 | Ollama Cloud             | [Needs setup](#ollama-cloud)           | Dashboard scraping | Quota              |
 | OpenCode Go              | [Needs setup](#opencode-go)            | Dashboard scraping | Quota              |
 

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -17,6 +17,7 @@ export type CanonicalQuotaProviderId =
   | "minimax-china-coding-plan"
   | "kimi-for-coding"
   | "deepseek"
+  | "xai"
   | "opencode-go"
   | "ollama-cloud"
   | "quota-providers";
@@ -73,6 +74,7 @@ export const QUOTA_PROVIDER_LABELS: Readonly<Record<string, string>> = {
   "kimi-for-coding": "Kimi Code",
   "kimi-code": "Kimi Code",
   deepseek: "DeepSeek",
+  xai: "xAI",
   "opencode-go": "OpenCode Go",
   "ollama-cloud": "Ollama Cloud",
   "quota-providers": "Quota providers",
@@ -98,6 +100,8 @@ export const QUOTA_PROVIDER_ID_SYNONYMS: Readonly<Record<string, string>> = {
   "kimi-for-code": "kimi-for-coding",
   "kimi-code": "kimi-for-coding",
   "deep-seek": "deepseek",
+  grok: "xai",
+  "x-ai": "xai",
   "opencode-go-subscription": "opencode-go",
   "gemini-cli": "google-gemini-cli",
   "google-gemini": "google-gemini-cli",
@@ -140,6 +144,7 @@ export const QUOTA_PROVIDER_RUNTIME_IDS: QuotaProviderRuntimeIds = {
   ],
   "kimi-for-coding": ["kimi-for-coding", "kimi", "kimi-code"],
   deepseek: ["deepseek"],
+  xai: ["xai", "grok"],
   "opencode-go": ["opencode-go"],
   "ollama-cloud": ["ollama-cloud"],
   "quota-providers": [],
@@ -277,6 +282,13 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     authentication: "opencode_auth_api_key",
     authFallbacks: ["env_api_key", "global_opencode_config"],
     quota: "remote_api",
+  },
+  {
+    id: "xai",
+    autoSetup: "yes",
+    authentication: "opencode_auth_oauth_token",
+    quota: "remote_api",
+    notes: "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
   },
   {
     id: "opencode-go",

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -288,7 +288,7 @@ export const QUOTA_PROVIDER_SHAPES: readonly QuotaProviderShape[] = [
     autoSetup: "yes",
     authentication: "opencode_auth_oauth_token",
     quota: "remote_api",
-    notes: "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
+    notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
   },
   {
     id: "opencode-go",

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -1536,6 +1536,16 @@ export async function buildQuotaStatusReport(params: {
   appendProviderCompactLiveProbeRows(deepSeekRows, "deepseek", params.providerLiveProbes);
   sections.push(createKvSection("deepseek", "deepseek:", deepSeekRows));
 
+  const xaiLiveProbeSection = createCompactLiveProbeOnlySection({
+    id: "xai",
+    title: "xai:",
+    providerId: "xai",
+    probes: params.providerLiveProbes,
+  });
+  if (xaiLiveProbeSection) {
+    sections.push(xaiLiveProbeSection);
+  }
+
   // === nanogpt ===
   const nanoGptDiag = await readApiKeyDiagnosticsWithAuthPaths(getNanoGptKeyDiagnostics);
   const nanoGptRows: ReportKvRow[] = [

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -274,6 +274,14 @@ export interface OpenAIOAuthData {
   [key: string]: unknown;
 }
 
+export interface XaiOAuthData {
+  type: string;
+  access?: string;
+  refresh?: string;
+  expires?: number;
+  [key: string]: unknown;
+}
+
 export interface GeminiCliOAuthAuthData {
   type: string;
   access?: string;
@@ -418,6 +426,7 @@ export interface AuthData {
   "minimax-cn-coding-plan"?: MiniMaxAuthData;
   "kimi-code"?: KimiAuthData;
   kimi?: KimiAuthData;
+  xai?: XaiOAuthData;
 }
 
 // =============================================================================

--- a/src/lib/xai.ts
+++ b/src/lib/xai.ts
@@ -1,40 +1,22 @@
 /**
  * xAI SuperGrok subscription quota fetcher.
  *
- * Uses OpenCode auth.json OAuth entry for `xai` and queries Grok Build billing:
- * - GET https://cli-chat-proxy.grok.com/v1/billing?format=credits  (period primary)
- * - GET https://cli-chat-proxy.grok.com/v1/billing               (monthly $ secondary)
- * - GET https://grok.com/rest/subscriptions                      (plan label)
+ * Uses OpenCode's read-only `xai` OAuth entry and queries the same shared
+ * period meter exposed by Grok Build:
+ * GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
  *
- * Management API prepaid balance is intentionally not used: OAuth tokens are
- * rejected there with oauth2-auth-forbidden.
+ * OpenCode remains the sole owner of OAuth refresh and auth.json persistence.
  */
 
-import { readFile } from "fs/promises";
-
-import type { AuthData, QuotaError, XaiOAuthData } from "./types.js";
-import { writeJsonAtomic } from "./atomic-json.js";
+import type { AuthData, QuotaError } from "./types.js";
 import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
 import { clampPercent } from "./format-utils.js";
 import { fetchWithTimeout } from "./http.js";
-import {
-  clearReadAuthFileCacheForTests,
-  getAuthPaths,
-  readAuthFileCached,
-} from "./opencode-auth.js";
+import { readAuthFileCached } from "./opencode-auth.js";
 
 export const DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS = 5_000;
-export const XAI_ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000;
-
-const XAI_AUTH_SOURCE_KEYS = ["xai"] as const;
-type XaiAuthSourceKey = (typeof XAI_AUTH_SOURCE_KEYS)[number];
 
 const CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
-const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing";
-const SUBSCRIPTIONS_URL = "https://grok.com/rest/subscriptions";
-const TOKEN_URL = "https://auth.x.ai/oauth2/token";
-// Same public Grok-CLI OAuth client used by OpenCode's xAI auth plugin.
-const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 const USER_AGENT = "OpenCode-Quota-Toast/1.0";
 
 export type XaiPeriodKind = "weekly" | "monthly" | "daily" | "period";
@@ -45,25 +27,11 @@ export interface XaiWindowValue {
   kind: XaiPeriodKind;
 }
 
-export interface XaiMonthlyAllowance {
-  limitUsd: number;
-  usedUsd: number;
-  remainingUsd: number;
-  percentRemaining: number;
-  resetTimeIso?: string;
-}
-
 export type XaiResult =
   | {
       success: true;
-      label: string;
-      /** True when Api/GrokChat share one weekly credit pool. */
-      unifiedBilling: boolean;
-      windows: {
-        primary?: XaiWindowValue;
-        products: Array<{ product: string; window: XaiWindowValue }>;
-      };
-      monthly?: XaiMonthlyAllowance;
+      label: "xAI SuperGrok";
+      window: XaiWindowValue;
     }
   | QuotaError
   | null;
@@ -72,9 +40,7 @@ export type ResolvedXaiOAuth =
   | { state: "none" }
   | {
       state: "configured";
-      sourceKey: XaiAuthSourceKey;
       accessToken: string;
-      refreshToken?: string;
       expiresAt?: number;
     };
 
@@ -84,18 +50,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function getNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function parseUsdCents(value: unknown): number | null {
-  if (!isRecord(value)) return null;
-  const raw = value.val;
-  const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
-  if (!Number.isFinite(n)) return null;
-  return n;
-}
-
-function centsToUsd(cents: number): number {
-  return Math.round(cents) / 100;
 }
 
 function isoOrUndefined(value: unknown): string | undefined {
@@ -126,50 +80,17 @@ export function periodKindLabel(kind: XaiPeriodKind): string {
   }
 }
 
-function accessTokenIsExpiring(
-  token: string | undefined,
-  skewMs = XAI_ACCESS_TOKEN_REFRESH_SKEW_MS,
-): boolean {
-  if (!token || typeof token !== "string") return false;
-  const parts = token.split(".");
-  if (parts.length < 2) return false;
-  try {
-    let payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
-    while (payload.length % 4 !== 0) payload += "=";
-    const claims = JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as { exp?: unknown };
-    if (typeof claims.exp !== "number" || !Number.isFinite(claims.exp)) return false;
-    return claims.exp * 1000 <= Date.now() + Math.max(0, skewMs);
-  } catch {
-    return false;
-  }
-}
-
-function getXaiOAuthEntry(
-  auth: AuthData | null | undefined,
-): { sourceKey: XaiAuthSourceKey; entry: XaiOAuthData; accessToken: string } | null {
-  for (const sourceKey of XAI_AUTH_SOURCE_KEYS) {
-    const entry = auth?.[sourceKey];
-    if (!entry || entry.type !== "oauth") continue;
-    const accessToken = typeof entry.access === "string" ? entry.access.trim() : "";
-    if (accessToken) {
-      return { sourceKey, entry, accessToken };
-    }
-  }
-  return null;
-}
-
 export function resolveXaiOAuth(auth: AuthData | null | undefined): ResolvedXaiOAuth {
-  const resolved = getXaiOAuthEntry(auth);
-  if (!resolved) return { state: "none" };
+  const entry = auth?.xai;
+  if (!entry || entry.type !== "oauth") return { state: "none" };
+
+  const accessToken = typeof entry.access === "string" ? entry.access.trim() : "";
+  if (!accessToken) return { state: "none" };
+
   return {
     state: "configured",
-    sourceKey: resolved.sourceKey,
-    accessToken: resolved.accessToken,
-    refreshToken:
-      typeof resolved.entry.refresh === "string" && resolved.entry.refresh.trim()
-        ? resolved.entry.refresh.trim()
-        : undefined,
-    expiresAt: typeof resolved.entry.expires === "number" ? resolved.entry.expires : undefined,
+    accessToken,
+    expiresAt: typeof entry.expires === "number" ? entry.expires : undefined,
   };
 }
 
@@ -184,321 +105,36 @@ export async function hasXaiOAuthCached(params?: { maxAgeMs?: number }): Promise
   return hasXaiOAuth(auth);
 }
 
-async function findAuthFilePathWithXai(): Promise<string | null> {
-  for (const path of getAuthPaths()) {
-    try {
-      const content = await readFile(path, "utf-8");
-      const parsed = JSON.parse(content) as AuthData;
-      if (resolveXaiOAuth(parsed).state === "configured") return path;
-    } catch {
-      // try next path
-    }
-  }
-  return null;
-}
-
-async function persistXaiOAuth(params: {
-  accessToken: string;
-  refreshToken: string;
-  expiresAt: number;
-}): Promise<void> {
-  const path = await findAuthFilePathWithXai();
-  if (!path) return;
-
-  try {
-    const content = await readFile(path, "utf-8");
-    const parsed = JSON.parse(content) as AuthData;
-    const existing = parsed.xai;
-    if (!existing || existing.type !== "oauth") return;
-
-    parsed.xai = {
-      ...existing,
-      type: "oauth",
-      access: params.accessToken,
-      refresh: params.refreshToken,
-      expires: params.expiresAt,
-    };
-    await writeJsonAtomic(path, parsed, { trailingNewline: true });
-    clearReadAuthFileCacheForTests();
-  } catch {
-    // Best-effort: in-memory refreshed token still works for this query.
-  }
-}
-
-async function refreshXaiAccessToken(
-  refreshToken: string,
-  requestTimeoutMs?: number,
-): Promise<
-  | { success: true; accessToken: string; refreshToken: string; expiresAt: number }
-  | { success: false; error: string }
-> {
-  try {
-    const resp = await fetchWithTimeout(
-      TOKEN_URL,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/x-www-form-urlencoded",
-          Accept: "application/json",
-          "User-Agent": USER_AGENT,
-        },
-        body: new URLSearchParams({
-          grant_type: "refresh_token",
-          refresh_token: refreshToken,
-          client_id: XAI_OAUTH_CLIENT_ID,
-        }).toString(),
-      },
-      requestTimeoutMs,
-    );
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      return {
-        success: false,
-        error: `xAI token refresh failed (${resp.status}): ${sanitizeDisplaySnippet(text, 120)}`,
-      };
-    }
-
-    const data = (await resp.json()) as {
-      access_token?: unknown;
-      refresh_token?: unknown;
-      expires_in?: unknown;
-    };
-    const accessToken = getNonEmptyString(data.access_token);
-    if (!accessToken) {
-      return { success: false, error: "xAI token refresh returned no access token" };
-    }
-
-    const nextRefresh = getNonEmptyString(data.refresh_token) ?? refreshToken;
-    const expiresIn =
-      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
-        ? data.expires_in
-        : 3600;
-
-    return {
-      success: true,
-      accessToken,
-      refreshToken: nextRefresh,
-      expiresAt: Date.now() + expiresIn * 1000,
-    };
-  } catch (err) {
-    return {
-      success: false,
-      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
-    };
-  }
-}
-
-async function ensureFreshXaiAccess(
-  resolved: Extract<ResolvedXaiOAuth, { state: "configured" }>,
-  requestTimeoutMs?: number,
-): Promise<{ success: true; accessToken: string } | { success: false; error: string }> {
-  const expiresSoon =
-    !resolved.expiresAt ||
-    resolved.expiresAt - Date.now() <= XAI_ACCESS_TOKEN_REFRESH_SKEW_MS ||
-    accessTokenIsExpiring(resolved.accessToken);
-
-  if (!expiresSoon) {
-    return { success: true, accessToken: resolved.accessToken };
-  }
-
-  if (!resolved.refreshToken) {
-    if (resolved.expiresAt && resolved.expiresAt < Date.now()) {
-      return { success: false, error: "Token expired" };
-    }
-    return { success: true, accessToken: resolved.accessToken };
-  }
-
-  const refreshed = await refreshXaiAccessToken(resolved.refreshToken, requestTimeoutMs);
-  if (!refreshed.success) {
-    if (resolved.expiresAt && resolved.expiresAt < Date.now()) {
-      return { success: false, error: refreshed.error };
-    }
-    // Prefer a still-valid access token over a refresh failure.
-    if (!accessTokenIsExpiring(resolved.accessToken, 0)) {
-      return { success: true, accessToken: resolved.accessToken };
-    }
-    return { success: false, error: refreshed.error };
-  }
-
-  await persistXaiOAuth({
-    accessToken: refreshed.accessToken,
-    refreshToken: refreshed.refreshToken,
-    expiresAt: refreshed.expiresAt,
-  });
-
-  return { success: true, accessToken: refreshed.accessToken };
-}
-
-function billingHeaders(accessToken: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${accessToken}`,
-    Accept: "application/json",
-    "User-Agent": USER_AGENT,
-    "x-grok-client-surface": "grok-build",
-    "x-grok-client-version": "1.0.0",
-  };
-}
-
-function deriveLabel(params: { tier?: string; productId?: string }): string {
-  const tier = params.tier ?? "";
-  const productId = params.productId ?? "";
-  if (productId === "grok.ultra" || /SUPER_GROK_PRO|HEAVY|ULTRA/i.test(tier)) {
-    return "xAI SuperGrok";
-  }
-  if (/SUPER_GROK/i.test(tier)) {
-    return "xAI SuperGrok";
-  }
-  return "xAI";
-}
-
-function percentFromUsed(usedPercent: number): number {
-  return clampPercent(100 - usedPercent);
-}
-
-function parseCreditsConfig(payload: unknown): {
-  primary?: XaiWindowValue;
-  products: Array<{ product: string; window: XaiWindowValue }>;
-  unifiedBilling: boolean;
-} {
+function parseCreditsWindow(payload: unknown): XaiWindowValue | null {
   if (!isRecord(payload) || !isRecord(payload.config)) {
     throw new Error("xAI credits response returned an unexpected response shape");
   }
 
   const config = payload.config;
   const period = isRecord(config.currentPeriod) ? config.currentPeriod : null;
-  const kind = periodKindFromType(period?.type);
-  const resetTimeIso = isoOrUndefined(period?.end) ?? isoOrUndefined(config.billingPeriodEnd);
-  const products: Array<{ product: string; window: XaiWindowValue }> = [];
-  const unifiedBilling = config.isUnifiedBillingUser === true;
+  const hasUsage = Object.prototype.hasOwnProperty.call(config, "creditUsagePercent");
+  const hasPeriod = Boolean(
+    getNonEmptyString(period?.type) ||
+    getNonEmptyString(period?.start) ||
+    getNonEmptyString(period?.end),
+  );
+  if (!hasPeriod && !hasUsage) return null;
 
-  // Protobuf JSON omits zero-valued fields. Presence of a period/product row
-  // without usagePercent means 0% used, not "missing quota".
-  let primary: XaiWindowValue | undefined;
-  const hasPeriodContext = Boolean(period) || typeof config.creditUsagePercent === "number";
-  if (hasPeriodContext) {
-    const used =
-      typeof config.creditUsagePercent === "number" && Number.isFinite(config.creditUsagePercent)
-        ? config.creditUsagePercent
-        : 0;
-    primary = {
-      percentRemaining: percentFromUsed(used),
-      resetTimeIso,
-      kind,
-    };
-  }
-
-  // Product rows (Api/GrokChat) are breakdowns of the same weekly pool under
-  // unified billing. Still parse them for diagnostics, but the provider UI
-  // suppresses them when unifiedBilling is true.
-  if (Array.isArray(config.productUsage)) {
-    for (const row of config.productUsage) {
-      if (!isRecord(row)) continue;
-      const product = getNonEmptyString(row.product);
-      if (!product) continue;
-      const used =
-        typeof row.usagePercent === "number" && Number.isFinite(row.usagePercent)
-          ? row.usagePercent
-          : 0;
-      products.push({
-        product,
-        window: {
-          percentRemaining: percentFromUsed(used),
-          resetTimeIso,
-          kind,
-        },
-      });
-    }
-  }
-
-  return { primary, products, unifiedBilling };
-}
-
-function parseMonthlyConfig(payload: unknown): XaiMonthlyAllowance | undefined {
-  if (!isRecord(payload) || !isRecord(payload.config)) return undefined;
-  const config = payload.config;
-  const limitCents = parseUsdCents(config.monthlyLimit);
-  const usedCents = parseUsdCents(config.used);
-  if (limitCents === null || usedCents === null || limitCents <= 0) return undefined;
-
-  const remainingCents = Math.max(0, limitCents - usedCents);
-  const percentRemaining = clampPercent((remainingCents / limitCents) * 100);
-  return {
-    limitUsd: centsToUsd(limitCents),
-    usedUsd: centsToUsd(usedCents),
-    remainingUsd: centsToUsd(remainingCents),
-    percentRemaining,
-    resetTimeIso: isoOrUndefined(config.billingPeriodEnd),
-  };
-}
-
-function parseSubscriptionLabel(payload: unknown): string {
   if (
-    !isRecord(payload) ||
-    !Array.isArray(payload.subscriptions) ||
-    payload.subscriptions.length === 0
+    hasUsage &&
+    (typeof config.creditUsagePercent !== "number" || !Number.isFinite(config.creditUsagePercent))
   ) {
-    return "xAI";
+    throw new Error("xAI credits response returned an invalid usage percentage");
   }
 
-  const active =
-    payload.subscriptions.find((item) => {
-      if (!isRecord(item)) return false;
-      const status = getNonEmptyString(item.status)?.toUpperCase() ?? "";
-      return status.includes("ACTIVE") || status.includes("TRIAL");
-    }) ?? payload.subscriptions[0];
-
-  if (!isRecord(active)) return "xAI";
-
-  const tier = getNonEmptyString(active.tier);
-  let productId: string | undefined;
-  for (const key of ["google", "apple", "stripe", "web"] as const) {
-    const provider = active[key];
-    if (isRecord(provider)) {
-      productId = getNonEmptyString(provider.productId) ?? productId;
-    }
-  }
-
-  return deriveLabel({ tier, productId });
-}
-
-async function fetchJson(
-  url: string,
-  accessToken: string,
-  requestTimeoutMs?: number,
-): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
-  try {
-    const resp = await fetchWithTimeout(
-      url,
-      {
-        method: "GET",
-        headers: billingHeaders(accessToken),
-      },
-      requestTimeoutMs,
-    );
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      return {
-        ok: false,
-        error: `xAI API error ${resp.status}: ${sanitizeDisplaySnippet(text, 120)}`,
-      };
-    }
-
-    return { ok: true, data: await resp.json() };
-  } catch (err) {
-    return {
-      ok: false,
-      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
-    };
-  }
-}
-
-export function formatXaiMonthlyValue(monthly: XaiMonthlyAllowance): string {
-  const remaining = monthly.remainingUsd.toFixed(2);
-  const used = monthly.usedUsd.toFixed(2);
-  const limit = monthly.limitUsd.toFixed(2);
-  return `$${remaining} left ($${used}/$${limit})`;
+  // Protobuf JSON omits zero-valued fields, so an absent percentage with a
+  // current period means 0% used rather than missing quota.
+  const usedPercent = hasUsage ? (config.creditUsagePercent as number) : 0;
+  return {
+    percentRemaining: clampPercent(100 - usedPercent),
+    resetTimeIso: isoOrUndefined(period?.end) ?? isoOrUndefined(config.billingPeriodEnd),
+    kind: periodKindFromType(period?.type),
+  };
 }
 
 export async function queryXaiQuota(
@@ -510,42 +146,41 @@ export async function queryXaiQuota(
   const resolvedAuth = resolveXaiOAuth(auth);
   if (resolvedAuth.state !== "configured") return null;
 
-  const fresh = await ensureFreshXaiAccess(resolvedAuth, options.requestTimeoutMs);
-  if (!fresh.success) {
-    return { success: false, error: fresh.error };
+  if (resolvedAuth.expiresAt && resolvedAuth.expiresAt < Date.now()) {
+    return {
+      success: false,
+      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
+    };
   }
 
   try {
-    // Keep the primary credits request independent of optional endpoints so a
-    // subscription/label timeout cannot discard valid weekly quota data.
-    const creditsResult = await fetchJson(CREDITS_URL, fresh.accessToken, options.requestTimeoutMs);
-    if (!creditsResult.ok) {
-      return { success: false, error: creditsResult.error };
-    }
-
-    const [billingResult, subsResult] = await Promise.all([
-      fetchJson(BILLING_URL, fresh.accessToken, options.requestTimeoutMs),
-      fetchJson(SUBSCRIPTIONS_URL, fresh.accessToken, options.requestTimeoutMs),
-    ]);
-
-    const credits = parseCreditsConfig(creditsResult.data);
-    const monthly = billingResult.ok ? parseMonthlyConfig(billingResult.data) : undefined;
-    const label = subsResult.ok ? parseSubscriptionLabel(subsResult.data) : "xAI";
-
-    if (!credits.primary && credits.products.length === 0 && !monthly) {
-      return { success: false, error: "No quota data" };
-    }
-
-    return {
-      success: true,
-      label,
-      unifiedBilling: credits.unifiedBilling,
-      windows: {
-        primary: credits.primary,
-        products: credits.products,
+    const resp = await fetchWithTimeout(
+      CREDITS_URL,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${resolvedAuth.accessToken}`,
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+          "x-grok-client-surface": "grok-build",
+          "x-grok-client-version": "1.0.0",
+        },
       },
-      monthly,
-    };
+      options.requestTimeoutMs,
+    );
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        success: false,
+        error: `xAI API error ${resp.status}: ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    const window = parseCreditsWindow(await resp.json());
+    if (!window) return { success: false, error: "No weekly quota data" };
+
+    return { success: true, label: "xAI SuperGrok", window };
   } catch (err) {
     return {
       success: false,

--- a/src/lib/xai.ts
+++ b/src/lib/xai.ts
@@ -1,0 +1,555 @@
+/**
+ * xAI SuperGrok subscription quota fetcher.
+ *
+ * Uses OpenCode auth.json OAuth entry for `xai` and queries Grok Build billing:
+ * - GET https://cli-chat-proxy.grok.com/v1/billing?format=credits  (period primary)
+ * - GET https://cli-chat-proxy.grok.com/v1/billing               (monthly $ secondary)
+ * - GET https://grok.com/rest/subscriptions                      (plan label)
+ *
+ * Management API prepaid balance is intentionally not used: OAuth tokens are
+ * rejected there with oauth2-auth-forbidden.
+ */
+
+import { readFile } from "fs/promises";
+
+import type { AuthData, QuotaError, XaiOAuthData } from "./types.js";
+import { writeJsonAtomic } from "./atomic-json.js";
+import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
+import { clampPercent } from "./format-utils.js";
+import { fetchWithTimeout } from "./http.js";
+import {
+  clearReadAuthFileCacheForTests,
+  getAuthPaths,
+  readAuthFileCached,
+} from "./opencode-auth.js";
+
+export const DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS = 5_000;
+export const XAI_ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000;
+
+const XAI_AUTH_SOURCE_KEYS = ["xai"] as const;
+type XaiAuthSourceKey = (typeof XAI_AUTH_SOURCE_KEYS)[number];
+
+const CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const BILLING_URL = "https://cli-chat-proxy.grok.com/v1/billing";
+const SUBSCRIPTIONS_URL = "https://grok.com/rest/subscriptions";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+// Same public Grok-CLI OAuth client used by OpenCode's xAI auth plugin.
+const XAI_OAUTH_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
+const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+
+export type XaiPeriodKind = "weekly" | "monthly" | "daily" | "period";
+
+export interface XaiWindowValue {
+  percentRemaining: number;
+  resetTimeIso?: string;
+  kind: XaiPeriodKind;
+}
+
+export interface XaiMonthlyAllowance {
+  limitUsd: number;
+  usedUsd: number;
+  remainingUsd: number;
+  percentRemaining: number;
+  resetTimeIso?: string;
+}
+
+export type XaiResult =
+  | {
+      success: true;
+      label: string;
+      /** True when Api/GrokChat share one weekly credit pool. */
+      unifiedBilling: boolean;
+      windows: {
+        primary?: XaiWindowValue;
+        products: Array<{ product: string; window: XaiWindowValue }>;
+      };
+      monthly?: XaiMonthlyAllowance;
+    }
+  | QuotaError
+  | null;
+
+export type ResolvedXaiOAuth =
+  | { state: "none" }
+  | {
+      state: "configured";
+      sourceKey: XaiAuthSourceKey;
+      accessToken: string;
+      refreshToken?: string;
+      expiresAt?: number;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseUsdCents(value: unknown): number | null {
+  if (!isRecord(value)) return null;
+  const raw = value.val;
+  const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+  if (!Number.isFinite(n)) return null;
+  return n;
+}
+
+function centsToUsd(cents: number): number {
+  return Math.round(cents) / 100;
+}
+
+function isoOrUndefined(value: unknown): string | undefined {
+  const raw = getNonEmptyString(value);
+  if (!raw) return undefined;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function periodKindFromType(value: unknown): XaiPeriodKind {
+  const raw = getNonEmptyString(value)?.toUpperCase() ?? "";
+  if (raw.includes("WEEK")) return "weekly";
+  if (raw.includes("MONTH")) return "monthly";
+  if (raw.includes("DAY")) return "daily";
+  return "period";
+}
+
+export function periodKindLabel(kind: XaiPeriodKind): string {
+  switch (kind) {
+    case "weekly":
+      return "Weekly";
+    case "monthly":
+      return "Monthly";
+    case "daily":
+      return "Daily";
+    default:
+      return "Period";
+  }
+}
+
+function accessTokenIsExpiring(
+  token: string | undefined,
+  skewMs = XAI_ACCESS_TOKEN_REFRESH_SKEW_MS,
+): boolean {
+  if (!token || typeof token !== "string") return false;
+  const parts = token.split(".");
+  if (parts.length < 2) return false;
+  try {
+    let payload = parts[1]!.replace(/-/g, "+").replace(/_/g, "/");
+    while (payload.length % 4 !== 0) payload += "=";
+    const claims = JSON.parse(Buffer.from(payload, "base64").toString("utf8")) as { exp?: unknown };
+    if (typeof claims.exp !== "number" || !Number.isFinite(claims.exp)) return false;
+    return claims.exp * 1000 <= Date.now() + Math.max(0, skewMs);
+  } catch {
+    return false;
+  }
+}
+
+function getXaiOAuthEntry(
+  auth: AuthData | null | undefined,
+): { sourceKey: XaiAuthSourceKey; entry: XaiOAuthData; accessToken: string } | null {
+  for (const sourceKey of XAI_AUTH_SOURCE_KEYS) {
+    const entry = auth?.[sourceKey];
+    if (!entry || entry.type !== "oauth") continue;
+    const accessToken = typeof entry.access === "string" ? entry.access.trim() : "";
+    if (accessToken) {
+      return { sourceKey, entry, accessToken };
+    }
+  }
+  return null;
+}
+
+export function resolveXaiOAuth(auth: AuthData | null | undefined): ResolvedXaiOAuth {
+  const resolved = getXaiOAuthEntry(auth);
+  if (!resolved) return { state: "none" };
+  return {
+    state: "configured",
+    sourceKey: resolved.sourceKey,
+    accessToken: resolved.accessToken,
+    refreshToken:
+      typeof resolved.entry.refresh === "string" && resolved.entry.refresh.trim()
+        ? resolved.entry.refresh.trim()
+        : undefined,
+    expiresAt: typeof resolved.entry.expires === "number" ? resolved.entry.expires : undefined,
+  };
+}
+
+export function hasXaiOAuth(auth: AuthData | null | undefined): boolean {
+  return resolveXaiOAuth(auth).state === "configured";
+}
+
+export async function hasXaiOAuthCached(params?: { maxAgeMs?: number }): Promise<boolean> {
+  const auth = await readAuthFileCached({
+    maxAgeMs: Math.max(0, params?.maxAgeMs ?? DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS),
+  });
+  return hasXaiOAuth(auth);
+}
+
+async function findAuthFilePathWithXai(): Promise<string | null> {
+  for (const path of getAuthPaths()) {
+    try {
+      const content = await readFile(path, "utf-8");
+      const parsed = JSON.parse(content) as AuthData;
+      if (resolveXaiOAuth(parsed).state === "configured") return path;
+    } catch {
+      // try next path
+    }
+  }
+  return null;
+}
+
+async function persistXaiOAuth(params: {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+}): Promise<void> {
+  const path = await findAuthFilePathWithXai();
+  if (!path) return;
+
+  try {
+    const content = await readFile(path, "utf-8");
+    const parsed = JSON.parse(content) as AuthData;
+    const existing = parsed.xai;
+    if (!existing || existing.type !== "oauth") return;
+
+    parsed.xai = {
+      ...existing,
+      type: "oauth",
+      access: params.accessToken,
+      refresh: params.refreshToken,
+      expires: params.expiresAt,
+    };
+    await writeJsonAtomic(path, parsed, { trailingNewline: true });
+    clearReadAuthFileCacheForTests();
+  } catch {
+    // Best-effort: in-memory refreshed token still works for this query.
+  }
+}
+
+async function refreshXaiAccessToken(
+  refreshToken: string,
+  requestTimeoutMs?: number,
+): Promise<
+  | { success: true; accessToken: string; refreshToken: string; expiresAt: number }
+  | { success: false; error: string }
+> {
+  try {
+    const resp = await fetchWithTimeout(
+      TOKEN_URL,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+          "User-Agent": USER_AGENT,
+        },
+        body: new URLSearchParams({
+          grant_type: "refresh_token",
+          refresh_token: refreshToken,
+          client_id: XAI_OAUTH_CLIENT_ID,
+        }).toString(),
+      },
+      requestTimeoutMs,
+    );
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        success: false,
+        error: `xAI token refresh failed (${resp.status}): ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    const data = (await resp.json()) as {
+      access_token?: unknown;
+      refresh_token?: unknown;
+      expires_in?: unknown;
+    };
+    const accessToken = getNonEmptyString(data.access_token);
+    if (!accessToken) {
+      return { success: false, error: "xAI token refresh returned no access token" };
+    }
+
+    const nextRefresh = getNonEmptyString(data.refresh_token) ?? refreshToken;
+    const expiresIn =
+      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+        ? data.expires_in
+        : 3600;
+
+    return {
+      success: true,
+      accessToken,
+      refreshToken: nextRefresh,
+      expiresAt: Date.now() + expiresIn * 1000,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+async function ensureFreshXaiAccess(
+  resolved: Extract<ResolvedXaiOAuth, { state: "configured" }>,
+  requestTimeoutMs?: number,
+): Promise<{ success: true; accessToken: string } | { success: false; error: string }> {
+  const expiresSoon =
+    !resolved.expiresAt ||
+    resolved.expiresAt - Date.now() <= XAI_ACCESS_TOKEN_REFRESH_SKEW_MS ||
+    accessTokenIsExpiring(resolved.accessToken);
+
+  if (!expiresSoon) {
+    return { success: true, accessToken: resolved.accessToken };
+  }
+
+  if (!resolved.refreshToken) {
+    if (resolved.expiresAt && resolved.expiresAt < Date.now()) {
+      return { success: false, error: "Token expired" };
+    }
+    return { success: true, accessToken: resolved.accessToken };
+  }
+
+  const refreshed = await refreshXaiAccessToken(resolved.refreshToken, requestTimeoutMs);
+  if (!refreshed.success) {
+    if (resolved.expiresAt && resolved.expiresAt < Date.now()) {
+      return { success: false, error: refreshed.error };
+    }
+    // Prefer a still-valid access token over a refresh failure.
+    if (!accessTokenIsExpiring(resolved.accessToken, 0)) {
+      return { success: true, accessToken: resolved.accessToken };
+    }
+    return { success: false, error: refreshed.error };
+  }
+
+  await persistXaiOAuth({
+    accessToken: refreshed.accessToken,
+    refreshToken: refreshed.refreshToken,
+    expiresAt: refreshed.expiresAt,
+  });
+
+  return { success: true, accessToken: refreshed.accessToken };
+}
+
+function billingHeaders(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    Accept: "application/json",
+    "User-Agent": USER_AGENT,
+    "x-grok-client-surface": "grok-build",
+    "x-grok-client-version": "1.0.0",
+  };
+}
+
+function deriveLabel(params: { tier?: string; productId?: string }): string {
+  const tier = params.tier ?? "";
+  const productId = params.productId ?? "";
+  if (productId === "grok.ultra" || /SUPER_GROK_PRO|HEAVY|ULTRA/i.test(tier)) {
+    return "xAI SuperGrok";
+  }
+  if (/SUPER_GROK/i.test(tier)) {
+    return "xAI SuperGrok";
+  }
+  return "xAI";
+}
+
+function percentFromUsed(usedPercent: number): number {
+  return clampPercent(100 - usedPercent);
+}
+
+function parseCreditsConfig(payload: unknown): {
+  primary?: XaiWindowValue;
+  products: Array<{ product: string; window: XaiWindowValue }>;
+  unifiedBilling: boolean;
+} {
+  if (!isRecord(payload) || !isRecord(payload.config)) {
+    throw new Error("xAI credits response returned an unexpected response shape");
+  }
+
+  const config = payload.config;
+  const period = isRecord(config.currentPeriod) ? config.currentPeriod : null;
+  const kind = periodKindFromType(period?.type);
+  const resetTimeIso = isoOrUndefined(period?.end) ?? isoOrUndefined(config.billingPeriodEnd);
+  const products: Array<{ product: string; window: XaiWindowValue }> = [];
+  const unifiedBilling = config.isUnifiedBillingUser === true;
+
+  // Protobuf JSON omits zero-valued fields. Presence of a period/product row
+  // without usagePercent means 0% used, not "missing quota".
+  let primary: XaiWindowValue | undefined;
+  const hasPeriodContext = Boolean(period) || typeof config.creditUsagePercent === "number";
+  if (hasPeriodContext) {
+    const used =
+      typeof config.creditUsagePercent === "number" && Number.isFinite(config.creditUsagePercent)
+        ? config.creditUsagePercent
+        : 0;
+    primary = {
+      percentRemaining: percentFromUsed(used),
+      resetTimeIso,
+      kind,
+    };
+  }
+
+  // Product rows (Api/GrokChat) are breakdowns of the same weekly pool under
+  // unified billing. Still parse them for diagnostics, but the provider UI
+  // suppresses them when unifiedBilling is true.
+  if (Array.isArray(config.productUsage)) {
+    for (const row of config.productUsage) {
+      if (!isRecord(row)) continue;
+      const product = getNonEmptyString(row.product);
+      if (!product) continue;
+      const used =
+        typeof row.usagePercent === "number" && Number.isFinite(row.usagePercent)
+          ? row.usagePercent
+          : 0;
+      products.push({
+        product,
+        window: {
+          percentRemaining: percentFromUsed(used),
+          resetTimeIso,
+          kind,
+        },
+      });
+    }
+  }
+
+  return { primary, products, unifiedBilling };
+}
+
+function parseMonthlyConfig(payload: unknown): XaiMonthlyAllowance | undefined {
+  if (!isRecord(payload) || !isRecord(payload.config)) return undefined;
+  const config = payload.config;
+  const limitCents = parseUsdCents(config.monthlyLimit);
+  const usedCents = parseUsdCents(config.used);
+  if (limitCents === null || usedCents === null || limitCents <= 0) return undefined;
+
+  const remainingCents = Math.max(0, limitCents - usedCents);
+  const percentRemaining = clampPercent((remainingCents / limitCents) * 100);
+  return {
+    limitUsd: centsToUsd(limitCents),
+    usedUsd: centsToUsd(usedCents),
+    remainingUsd: centsToUsd(remainingCents),
+    percentRemaining,
+    resetTimeIso: isoOrUndefined(config.billingPeriodEnd),
+  };
+}
+
+function parseSubscriptionLabel(payload: unknown): string {
+  if (
+    !isRecord(payload) ||
+    !Array.isArray(payload.subscriptions) ||
+    payload.subscriptions.length === 0
+  ) {
+    return "xAI";
+  }
+
+  const active =
+    payload.subscriptions.find((item) => {
+      if (!isRecord(item)) return false;
+      const status = getNonEmptyString(item.status)?.toUpperCase() ?? "";
+      return status.includes("ACTIVE") || status.includes("TRIAL");
+    }) ?? payload.subscriptions[0];
+
+  if (!isRecord(active)) return "xAI";
+
+  const tier = getNonEmptyString(active.tier);
+  let productId: string | undefined;
+  for (const key of ["google", "apple", "stripe", "web"] as const) {
+    const provider = active[key];
+    if (isRecord(provider)) {
+      productId = getNonEmptyString(provider.productId) ?? productId;
+    }
+  }
+
+  return deriveLabel({ tier, productId });
+}
+
+async function fetchJson(
+  url: string,
+  accessToken: string,
+  requestTimeoutMs?: number,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  try {
+    const resp = await fetchWithTimeout(
+      url,
+      {
+        method: "GET",
+        headers: billingHeaders(accessToken),
+      },
+      requestTimeoutMs,
+    );
+
+    if (!resp.ok) {
+      const text = await resp.text();
+      return {
+        ok: false,
+        error: `xAI API error ${resp.status}: ${sanitizeDisplaySnippet(text, 120)}`,
+      };
+    }
+
+    return { ok: true, data: await resp.json() };
+  } catch (err) {
+    return {
+      ok: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}
+
+export function formatXaiMonthlyValue(monthly: XaiMonthlyAllowance): string {
+  const remaining = monthly.remainingUsd.toFixed(2);
+  const used = monthly.usedUsd.toFixed(2);
+  const limit = monthly.limitUsd.toFixed(2);
+  return `$${remaining} left ($${used}/$${limit})`;
+}
+
+export async function queryXaiQuota(
+  options: { requestTimeoutMs?: number } = {},
+): Promise<XaiResult> {
+  const auth = await readAuthFileCached({
+    maxAgeMs: DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS,
+  });
+  const resolvedAuth = resolveXaiOAuth(auth);
+  if (resolvedAuth.state !== "configured") return null;
+
+  const fresh = await ensureFreshXaiAccess(resolvedAuth, options.requestTimeoutMs);
+  if (!fresh.success) {
+    return { success: false, error: fresh.error };
+  }
+
+  try {
+    // Keep the primary credits request independent of optional endpoints so a
+    // subscription/label timeout cannot discard valid weekly quota data.
+    const creditsResult = await fetchJson(CREDITS_URL, fresh.accessToken, options.requestTimeoutMs);
+    if (!creditsResult.ok) {
+      return { success: false, error: creditsResult.error };
+    }
+
+    const [billingResult, subsResult] = await Promise.all([
+      fetchJson(BILLING_URL, fresh.accessToken, options.requestTimeoutMs),
+      fetchJson(SUBSCRIPTIONS_URL, fresh.accessToken, options.requestTimeoutMs),
+    ]);
+
+    const credits = parseCreditsConfig(creditsResult.data);
+    const monthly = billingResult.ok ? parseMonthlyConfig(billingResult.data) : undefined;
+    const label = subsResult.ok ? parseSubscriptionLabel(subsResult.data) : "xAI";
+
+    if (!credits.primary && credits.products.length === 0 && !monthly) {
+      return { success: false, error: "No quota data" };
+    }
+
+    return {
+      success: true,
+      label,
+      unifiedBilling: credits.unifiedBilling,
+      windows: {
+        primary: credits.primary,
+        products: credits.products,
+      },
+      monthly,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      error: sanitizeDisplayText(err instanceof Error ? err.message : String(err)),
+    };
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,6 +26,7 @@ import {
 import { opencodeGoProvider } from "./opencode-go.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
+import { xaiProvider } from "./xai.js";
 import { ollamaCloudProvider } from "./ollama-cloud.js";
 import { quotaProvidersProvider } from "./quota-providers.js";
 
@@ -50,6 +51,7 @@ export function getProviders(): QuotaProvider[] {
     minimaxChinaCodingPlanProvider,
     kimiCodeProvider,
     deepseekProvider,
+    xaiProvider,
     opencodeGoProvider,
     ollamaCloudProvider,
     quotaProvidersProvider,

--- a/src/providers/xai.ts
+++ b/src/providers/xai.ts
@@ -1,0 +1,89 @@
+/**
+ * xAI SuperGrok provider wrapper.
+ */
+
+import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import {
+  DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS,
+  hasXaiOAuthCached,
+  periodKindLabel,
+  queryXaiQuota,
+} from "../lib/xai.js";
+import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
+import { modelProviderMatchesRuntimeId } from "../lib/provider-model-matching.js";
+import {
+  attemptedResult,
+  groupedPercentWindowEntries,
+  mapNullableProviderResult,
+} from "./result-helpers.js";
+
+export const xaiProvider: QuotaProvider = {
+  id: "xai",
+
+  async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
+    const availableByProviderId = await isCanonicalProviderAvailable({
+      ctx,
+      providerId: "xai",
+      fallbackOnError: true,
+    });
+    if (availableByProviderId) return true;
+    return hasXaiOAuthCached({ maxAgeMs: DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS });
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    // Exact runtime provider ids only (`xai`, `grok`). Avoid matching bare
+    // model ids like `grok-code-fast-1` on Copilot/OpenRouter sessions.
+    return modelProviderMatchesRuntimeId(model, "xai");
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const result = await queryXaiQuota({ requestTimeoutMs: ctx.config?.requestTimeoutMs });
+
+    return mapNullableProviderResult(result, {
+      errorLabel: "xAI",
+      onSuccess: (result) => {
+        const primaryLabel = result.windows.primary
+          ? periodKindLabel(result.windows.primary.kind)
+          : "Weekly";
+
+        // Under unified SuperGrok billing, Api/GrokChat share one weekly pool.
+        // Showing product rows (e.g. "GrokChat 100%") looks like a separate
+        // quota and confuses the main Weekly meter. Only expand products when
+        // the account is not on unified billing.
+        const productWindows = result.unifiedBilling
+          ? []
+          : result.windows.products
+              .filter((product) => {
+                if (!result.windows.primary) return true;
+                return product.window.percentRemaining !== result.windows.primary.percentRemaining;
+              })
+              .map((product) => ({
+                window: product.window,
+                suffix: product.product,
+                label: `${product.product}:`,
+              }));
+
+        // SuperGrok UI only surfaces the shared weekly credit meter (matches
+        // grok.com). Monthly $ allowance is intentionally not displayed.
+        const entries = groupedPercentWindowEntries({
+          group: result.label,
+          windows: [
+            result.windows.primary
+              ? {
+                  window: result.windows.primary,
+                  suffix: primaryLabel,
+                  label: `${primaryLabel}:`,
+                }
+              : { window: undefined, suffix: primaryLabel, label: `${primaryLabel}:` },
+            ...productWindows,
+          ],
+          fallbackWhenEmpty: true,
+        });
+
+        return attemptedResult(entries, [], {
+          singleWindowDisplayName: result.label,
+        });
+      },
+    });
+  },
+};

--- a/src/providers/xai.ts
+++ b/src/providers/xai.ts
@@ -2,7 +2,12 @@
  * xAI SuperGrok provider wrapper.
  */
 
-import type { QuotaProvider, QuotaProviderContext, QuotaProviderResult } from "../lib/entries.js";
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderMatchContext,
+  QuotaProviderResult,
+} from "../lib/entries.js";
 import {
   DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS,
   hasXaiOAuthCached,
@@ -11,28 +16,26 @@ import {
 } from "../lib/xai.js";
 import { isCanonicalProviderAvailable } from "../lib/provider-availability.js";
 import { modelProviderMatchesRuntimeId } from "../lib/provider-model-matching.js";
-import {
-  attemptedResult,
-  groupedPercentWindowEntries,
-  mapNullableProviderResult,
-} from "./result-helpers.js";
+import { normalizeQuotaProviderId } from "../lib/provider-metadata.js";
+import { attemptedResult, mapNullableProviderResult } from "./result-helpers.js";
 
 export const xaiProvider: QuotaProvider = {
   id: "xai",
 
   async isAvailable(ctx: QuotaProviderContext): Promise<boolean> {
-    const availableByProviderId = await isCanonicalProviderAvailable({
+    const providerAvailable = await isCanonicalProviderAvailable({
       ctx,
       providerId: "xai",
-      fallbackOnError: true,
+      fallbackOnError: false,
     });
-    if (availableByProviderId) return true;
+    if (providerAvailable) return hasXaiOAuthCached({ maxAgeMs: 0 });
     return hasXaiOAuthCached({ maxAgeMs: DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS });
   },
 
-  matchesCurrentModel(model: string): boolean {
-    // Exact runtime provider ids only (`xai`, `grok`). Avoid matching bare
-    // model ids like `grok-code-fast-1` on Copilot/OpenRouter sessions.
+  matchesCurrentModel(model: string, context?: QuotaProviderMatchContext): boolean {
+    if (context?.currentProviderID) {
+      return normalizeQuotaProviderId(context.currentProviderID) === "xai";
+    }
     return modelProviderMatchesRuntimeId(model, "xai");
   },
 
@@ -42,47 +45,20 @@ export const xaiProvider: QuotaProvider = {
     return mapNullableProviderResult(result, {
       errorLabel: "xAI",
       onSuccess: (result) => {
-        const primaryLabel = result.windows.primary
-          ? periodKindLabel(result.windows.primary.kind)
-          : "Weekly";
-
-        // Under unified SuperGrok billing, Api/GrokChat share one weekly pool.
-        // Showing product rows (e.g. "GrokChat 100%") looks like a separate
-        // quota and confuses the main Weekly meter. Only expand products when
-        // the account is not on unified billing.
-        const productWindows = result.unifiedBilling
-          ? []
-          : result.windows.products
-              .filter((product) => {
-                if (!result.windows.primary) return true;
-                return product.window.percentRemaining !== result.windows.primary.percentRemaining;
-              })
-              .map((product) => ({
-                window: product.window,
-                suffix: product.product,
-                label: `${product.product}:`,
-              }));
-
-        // SuperGrok UI only surfaces the shared weekly credit meter (matches
-        // grok.com). Monthly $ allowance is intentionally not displayed.
-        const entries = groupedPercentWindowEntries({
-          group: result.label,
-          windows: [
-            result.windows.primary
-              ? {
-                  window: result.windows.primary,
-                  suffix: primaryLabel,
-                  label: `${primaryLabel}:`,
-                }
-              : { window: undefined, suffix: primaryLabel, label: `${primaryLabel}:` },
-            ...productWindows,
+        const period = periodKindLabel(result.window.kind);
+        return attemptedResult(
+          [
+            {
+              name: `${result.label} ${period}`,
+              group: result.label,
+              label: `${period}:`,
+              percentRemaining: result.window.percentRemaining,
+              resetTimeIso: result.window.resetTimeIso,
+            },
           ],
-          fallbackWhenEmpty: true,
-        });
-
-        return attemptedResult(entries, [], {
-          singleWindowDisplayName: result.label,
-        });
+          [],
+          { singleWindowDisplayName: result.label },
+        );
       },
     });
   },

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -144,8 +144,7 @@ describe("provider-metadata", () => {
         autoSetup: "yes",
         authentication: "opencode_auth_oauth_token",
         quota: "remote_api",
-        notes:
-          "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
+        notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
       },
       {
         id: "opencode-go",
@@ -344,8 +343,7 @@ describe("provider-metadata", () => {
       autoSetup: "yes",
       authentication: "opencode_auth_oauth_token",
       quota: "remote_api",
-      notes:
-        "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
+      notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
     });
     expect(getQuotaProviderShape("not-a-provider")).toBeUndefined();
   });

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -140,6 +140,14 @@ describe("provider-metadata", () => {
         quota: "remote_api",
       },
       {
+        id: "xai",
+        autoSetup: "yes",
+        authentication: "opencode_auth_oauth_token",
+        quota: "remote_api",
+        notes:
+          "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
+      },
+      {
         id: "opencode-go",
         autoSetup: "needs_quick_setup",
         authentication: "state_only",
@@ -233,6 +241,7 @@ describe("provider-metadata", () => {
     ]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.deepseek).toEqual(["deepseek"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS["quota-providers"]).toEqual([]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS.xai).toEqual(["xai", "grok"]);
   });
 
   it("keeps runtime ids distinct from broad normalization aliases", () => {
@@ -284,6 +293,7 @@ describe("provider-metadata", () => {
     ]);
     expect(getQuotaProviderRuntimeIds("kimi")).toEqual(["kimi-for-coding", "kimi", "kimi-code"]);
     expect(getQuotaProviderRuntimeIds("deep-seek")).toEqual(["deepseek"]);
+    expect(getQuotaProviderRuntimeIds("grok")).toEqual(["xai", "grok"]);
     expect(getQuotaProviderRuntimeIds("not-a-provider")).toEqual([]);
   });
 
@@ -329,6 +339,14 @@ describe("provider-metadata", () => {
       authFallbacks: ["env_api_key", "global_opencode_config"],
       quota: "remote_api",
     });
+    expect(getQuotaProviderShape("grok")).toEqual({
+      id: "xai",
+      autoSetup: "yes",
+      authentication: "opencode_auth_oauth_token",
+      quota: "remote_api",
+      notes:
+        "SuperGrok OAuth via OpenCode /connect; weekly credits plus optional monthly allowance",
+    });
     expect(getQuotaProviderShape("not-a-provider")).toBeUndefined();
   });
 
@@ -351,6 +369,8 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("kimi")).toBe("Kimi Code");
     expect(getQuotaProviderDisplayLabel("deep-seek")).toBe("DeepSeek");
     expect(getQuotaProviderDisplayLabel("quota-providers")).toBe("Quota providers");
+    expect(getQuotaProviderDisplayLabel("xai")).toBe("xAI");
+    expect(getQuotaProviderDisplayLabel("grok")).toBe("xAI");
     expect(getQuotaProviderDisplayLabel("something-else")).toBe("something-else");
   });
 });

--- a/tests/lib.xai.test.ts
+++ b/tests/lib.xai.test.ts
@@ -1,0 +1,344 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  formatXaiMonthlyValue,
+  hasXaiOAuth,
+  periodKindLabel,
+  queryXaiQuota,
+  resolveXaiOAuth,
+} from "../src/lib/xai.js";
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: vi.fn(),
+  getAuthPaths: vi.fn(() => []),
+  clearReadAuthFileCacheForTests: vi.fn(),
+}));
+
+vi.mock("../src/lib/atomic-json.js", () => ({
+  writeJsonAtomic: vi.fn(),
+}));
+
+describe("xai auth resolution", () => {
+  it("resolves oauth access tokens from auth.json", () => {
+    expect(
+      resolveXaiOAuth({
+        xai: { type: "oauth", access: "token-1", refresh: "refresh-1", expires: 123 },
+      }),
+    ).toEqual({
+      state: "configured",
+      sourceKey: "xai",
+      accessToken: "token-1",
+      refreshToken: "refresh-1",
+      expiresAt: 123,
+    });
+    expect(hasXaiOAuth({ xai: { type: "api", key: "xai-key" } as any })).toBe(false);
+    expect(hasXaiOAuth({})).toBe(false);
+  });
+});
+
+describe("queryXaiQuota", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when not configured", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({});
+    await expect(queryXaiQuota()).resolves.toBeNull();
+  });
+
+  it("refreshes an expired access token before querying", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: {
+        type: "oauth",
+        access: "old-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/oauth2/token")) {
+        return new Response(
+          JSON.stringify({
+            access_token: "new-token",
+            refresh_token: "refresh-2",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        );
+      }
+      if (String(url).includes("format=credits")) {
+        return new Response(
+          JSON.stringify({
+            config: {
+              currentPeriod: {
+                type: "USAGE_PERIOD_TYPE_WEEKLY",
+                end: "2026-07-20T02:24:00.983423+00:00",
+              },
+              creditUsagePercent: 1,
+              productUsage: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ config: {} }), { status: 200 });
+    }) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await queryXaiQuota();
+    expect(out && out.success ? out.windows.primary?.percentRemaining : null).toBe(99);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://auth.x.ai/oauth2/token",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer new-token",
+        }),
+      }),
+    );
+  });
+
+  it("returns token expired when expired and refresh is missing", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() - 1_000 },
+    });
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "Token expired",
+    });
+  });
+
+  it("maps weekly credits, zero-omitted product rows, monthly allowance, and subscription label", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
+    });
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("format=credits")) {
+        return new Response(
+          JSON.stringify({
+            config: {
+              currentPeriod: {
+                type: "USAGE_PERIOD_TYPE_WEEKLY",
+                start: "2026-07-13T02:24:00.983423+00:00",
+                end: "2026-07-20T02:24:00.983423+00:00",
+              },
+              creditUsagePercent: 1,
+              isUnifiedBillingUser: true,
+              productUsage: [{ product: "Api", usagePercent: 1 }, { product: "GrokChat" }],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      if (String(url).includes("/v1/billing")) {
+        return new Response(
+          JSON.stringify({
+            config: {
+              monthlyLimit: { val: 150000 },
+              used: { val: 426 },
+              billingPeriodEnd: "2026-08-01T00:00:00+00:00",
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(
+        JSON.stringify({
+          subscriptions: [
+            {
+              tier: "SUBSCRIPTION_TIER_SUPER_GROK_PRO",
+              status: "SUBSCRIPTION_STATUS_ACTIVE",
+              google: { productId: "grok.ultra" },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const out = await queryXaiQuota({ requestTimeoutMs: 3210 });
+
+    expect(out).toEqual({
+      success: true,
+      label: "xAI SuperGrok",
+      unifiedBilling: true,
+      windows: {
+        primary: {
+          percentRemaining: 99,
+          resetTimeIso: "2026-07-20T02:24:00.983Z",
+          kind: "weekly",
+        },
+        products: [
+          {
+            product: "Api",
+            window: {
+              percentRemaining: 99,
+              resetTimeIso: "2026-07-20T02:24:00.983Z",
+              kind: "weekly",
+            },
+          },
+          {
+            product: "GrokChat",
+            window: {
+              percentRemaining: 100,
+              resetTimeIso: "2026-07-20T02:24:00.983Z",
+              kind: "weekly",
+            },
+          },
+        ],
+      },
+      monthly: {
+        limitUsd: 1500,
+        usedUsd: 4.26,
+        remainingUsd: 1495.74,
+        percentRemaining: 100,
+        resetTimeIso: "2026-08-01T00:00:00.000Z",
+      },
+    });
+  });
+
+  it("treats omitted creditUsagePercent as 0% used when period exists", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("format=credits")) {
+          return new Response(
+            JSON.stringify({
+              config: {
+                currentPeriod: {
+                  type: "USAGE_PERIOD_TYPE_WEEKLY",
+                  end: "2026-07-20T02:24:00.983423+00:00",
+                },
+                productUsage: [{ product: "Api" }],
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        return new Response(JSON.stringify({}), { status: 200 });
+      }) as any,
+    );
+
+    const out = await queryXaiQuota();
+    expect(out && out.success ? out.windows.primary : null).toEqual({
+      percentRemaining: 100,
+      resetTimeIso: "2026-07-20T02:24:00.983Z",
+      kind: "weekly",
+    });
+    expect(out && out.success ? out.unifiedBilling : null).toBe(false);
+    expect(out && out.success ? out.windows.products : null).toEqual([
+      {
+        product: "Api",
+        window: {
+          percentRemaining: 100,
+          resetTimeIso: "2026-07-20T02:24:00.983Z",
+          kind: "weekly",
+        },
+      },
+    ]);
+  });
+
+  it("keeps primary credits when optional endpoints fail", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("format=credits")) {
+          return new Response(
+            JSON.stringify({
+              config: {
+                currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-07-20T00:00:00Z" },
+                creditUsagePercent: 10,
+              },
+            }),
+            { status: 200 },
+          );
+        }
+        throw new Error("network down");
+      }) as any,
+    );
+
+    const out = await queryXaiQuota();
+    expect(out).toEqual({
+      success: true,
+      label: "xAI",
+      unifiedBilling: false,
+      windows: {
+        primary: {
+          percentRemaining: 90,
+          resetTimeIso: "2026-07-20T00:00:00.000Z",
+          kind: "weekly",
+        },
+        products: [],
+      },
+      monthly: undefined,
+    });
+  });
+
+  it("returns API errors from the primary credits endpoint", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (String(url).includes("format=credits")) {
+          return new Response("nope", { status: 401 });
+        }
+        return new Response("{}", { status: 200 });
+      }) as any,
+    );
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI API error 401: nope",
+    });
+  });
+});
+
+describe("format helpers", () => {
+  it("formats remaining monthly allowance", () => {
+    expect(
+      formatXaiMonthlyValue({
+        limitUsd: 1500,
+        usedUsd: 4.26,
+        remainingUsd: 1495.74,
+        percentRemaining: 100,
+      }),
+    ).toBe("$1495.74 left ($4.26/$1500.00)");
+  });
+
+  it("labels period kinds", () => {
+    expect(periodKindLabel("weekly")).toBe("Weekly");
+    expect(periodKindLabel("monthly")).toBe("Monthly");
+    expect(periodKindLabel("daily")).toBe("Daily");
+    expect(periodKindLabel("period")).toBe("Period");
+  });
+});

--- a/tests/lib.xai.test.ts
+++ b/tests/lib.xai.test.ts
@@ -1,34 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  formatXaiMonthlyValue,
-  hasXaiOAuth,
-  periodKindLabel,
-  queryXaiQuota,
-  resolveXaiOAuth,
-} from "../src/lib/xai.js";
+import { hasXaiOAuth, periodKindLabel, queryXaiQuota, resolveXaiOAuth } from "../src/lib/xai.js";
 
 vi.mock("../src/lib/opencode-auth.js", () => ({
   readAuthFileCached: vi.fn(),
-  getAuthPaths: vi.fn(() => []),
-  clearReadAuthFileCacheForTests: vi.fn(),
-}));
-
-vi.mock("../src/lib/atomic-json.js", () => ({
-  writeJsonAtomic: vi.fn(),
 }));
 
 describe("xai auth resolution", () => {
-  it("resolves oauth access tokens from auth.json", () => {
+  it("resolves a read-only oauth access token", () => {
     expect(
       resolveXaiOAuth({
         xai: { type: "oauth", access: "token-1", refresh: "refresh-1", expires: 123 },
       }),
     ).toEqual({
       state: "configured",
-      sourceKey: "xai",
       accessToken: "token-1",
-      refreshToken: "refresh-1",
       expiresAt: 123,
     });
     expect(hasXaiOAuth({ xai: { type: "api", key: "xai-key" } as any })).toBe(false);
@@ -46,90 +32,42 @@ describe("queryXaiQuota", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns null when not configured", async () => {
+  it("returns null when oauth is not configured", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({});
+
     await expect(queryXaiQuota()).resolves.toBeNull();
   });
 
-  it("refreshes an expired access token before querying", async () => {
+  it("does not refresh or write an expired token", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({
       xai: {
         type: "oauth",
-        access: "old-token",
+        access: "expired-token",
         refresh: "refresh-1",
         expires: Date.now() - 1_000,
       },
     });
-
-    const fetchMock = vi.fn(async (url: string) => {
-      if (String(url).includes("/oauth2/token")) {
-        return new Response(
-          JSON.stringify({
-            access_token: "new-token",
-            refresh_token: "refresh-2",
-            expires_in: 3600,
-          }),
-          { status: 200 },
-        );
-      }
-      if (String(url).includes("format=credits")) {
-        return new Response(
-          JSON.stringify({
-            config: {
-              currentPeriod: {
-                type: "USAGE_PERIOD_TYPE_WEEKLY",
-                end: "2026-07-20T02:24:00.983423+00:00",
-              },
-              creditUsagePercent: 1,
-              productUsage: [],
-            },
-          }),
-          { status: 200 },
-        );
-      }
-      return new Response(JSON.stringify({ config: {} }), { status: 200 });
-    }) as any;
+    const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
-
-    const out = await queryXaiQuota();
-    expect(out && out.success ? out.windows.primary?.percentRemaining : null).toBe(99);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://auth.x.ai/oauth2/token",
-      expect.objectContaining({ method: "POST" }),
-    );
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
-      expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: "Bearer new-token",
-        }),
-      }),
-    );
-  });
-
-  it("returns token expired when expired and refresh is missing", async () => {
-    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
-    (readAuthFileCached as any).mockResolvedValueOnce({
-      xai: { type: "oauth", access: "token-1", expires: Date.now() - 1_000 },
-    });
 
     await expect(queryXaiQuota()).resolves.toEqual({
       success: false,
-      error: "Token expired",
+      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
     });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("maps weekly credits, zero-omitted product rows, monthly allowance, and subscription label", async () => {
+  it("maps the shared weekly meter with one authenticated request", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({
       xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
     });
 
-    const fetchMock = vi.fn(async (url: string) => {
-      if (String(url).includes("format=credits")) {
-        return new Response(
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(
           JSON.stringify({
             config: {
               currentPeriod: {
@@ -137,184 +75,118 @@ describe("queryXaiQuota", () => {
                 start: "2026-07-13T02:24:00.983423+00:00",
                 end: "2026-07-20T02:24:00.983423+00:00",
               },
-              creditUsagePercent: 1,
+              creditUsagePercent: 5,
               isUnifiedBillingUser: true,
-              productUsage: [{ product: "Api", usagePercent: 1 }, { product: "GrokChat" }],
+              productUsage: [{ product: "Api", usagePercent: 5 }, { product: "GrokChat" }],
             },
           }),
           { status: 200 },
-        );
-      }
-      if (String(url).includes("/v1/billing")) {
-        return new Response(
-          JSON.stringify({
-            config: {
-              monthlyLimit: { val: 150000 },
-              used: { val: 426 },
-              billingPeriodEnd: "2026-08-01T00:00:00+00:00",
-            },
-          }),
-          { status: 200 },
-        );
-      }
-      return new Response(
-        JSON.stringify({
-          subscriptions: [
-            {
-              tier: "SUBSCRIPTION_TIER_SUPER_GROK_PRO",
-              status: "SUBSCRIPTION_STATUS_ACTIVE",
-              google: { productId: "grok.ultra" },
-            },
-          ],
-        }),
-        { status: 200 },
-      );
-    }) as any;
+        ),
+    ) as any;
     vi.stubGlobal("fetch", fetchMock);
 
-    const out = await queryXaiQuota({ requestTimeoutMs: 3210 });
-
-    expect(out).toEqual({
+    await expect(queryXaiQuota({ requestTimeoutMs: 3210 })).resolves.toEqual({
       success: true,
       label: "xAI SuperGrok",
-      unifiedBilling: true,
-      windows: {
-        primary: {
-          percentRemaining: 99,
-          resetTimeIso: "2026-07-20T02:24:00.983Z",
-          kind: "weekly",
-        },
-        products: [
-          {
-            product: "Api",
-            window: {
-              percentRemaining: 99,
-              resetTimeIso: "2026-07-20T02:24:00.983Z",
-              kind: "weekly",
-            },
-          },
-          {
-            product: "GrokChat",
-            window: {
-              percentRemaining: 100,
-              resetTimeIso: "2026-07-20T02:24:00.983Z",
-              kind: "weekly",
-            },
-          },
-        ],
-      },
-      monthly: {
-        limitUsd: 1500,
-        usedUsd: 4.26,
-        remainingUsd: 1495.74,
-        percentRemaining: 100,
-        resetTimeIso: "2026-08-01T00:00:00.000Z",
+      window: {
+        percentRemaining: 95,
+        resetTimeIso: "2026-07-20T02:24:00.983Z",
+        kind: "weekly",
       },
     });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-1",
+          "x-grok-client-surface": "grok-build",
+        }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
   });
 
-  it("treats omitted creditUsagePercent as 0% used when period exists", async () => {
+  it("treats an omitted protobuf percentage as 0% used when a period exists", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({
       xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
     });
-
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string) => {
-        if (String(url).includes("format=credits")) {
-          return new Response(
+      vi.fn(
+        async () =>
+          new Response(
             JSON.stringify({
               config: {
                 currentPeriod: {
                   type: "USAGE_PERIOD_TYPE_WEEKLY",
                   end: "2026-07-20T02:24:00.983423+00:00",
                 },
-                productUsage: [{ product: "Api" }],
               },
             }),
             { status: 200 },
-          );
-        }
-        return new Response(JSON.stringify({}), { status: 200 });
-      }) as any,
+          ),
+      ) as any,
     );
 
     const out = await queryXaiQuota();
-    expect(out && out.success ? out.windows.primary : null).toEqual({
-      percentRemaining: 100,
-      resetTimeIso: "2026-07-20T02:24:00.983Z",
-      kind: "weekly",
-    });
-    expect(out && out.success ? out.unifiedBilling : null).toBe(false);
-    expect(out && out.success ? out.windows.products : null).toEqual([
-      {
-        product: "Api",
-        window: {
-          percentRemaining: 100,
-          resetTimeIso: "2026-07-20T02:24:00.983Z",
-          kind: "weekly",
-        },
-      },
-    ]);
+    expect(out && out.success ? out.window.percentRemaining : null).toBe(100);
   });
 
-  it("keeps primary credits when optional endpoints fail", async () => {
+  it("rejects a present malformed percentage", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({
       xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
     });
-
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string) => {
-        if (String(url).includes("format=credits")) {
-          return new Response(
+      vi.fn(
+        async () =>
+          new Response(
             JSON.stringify({
               config: {
-                currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY", end: "2026-07-20T00:00:00Z" },
-                creditUsagePercent: 10,
+                currentPeriod: { type: "USAGE_PERIOD_TYPE_WEEKLY" },
+                creditUsagePercent: "100",
               },
             }),
             { status: 200 },
-          );
-        }
-        throw new Error("network down");
-      }) as any,
+          ),
+      ) as any,
     );
 
-    const out = await queryXaiQuota();
-    expect(out).toEqual({
-      success: true,
-      label: "xAI",
-      unifiedBilling: false,
-      windows: {
-        primary: {
-          percentRemaining: 90,
-          resetTimeIso: "2026-07-20T00:00:00.000Z",
-          kind: "weekly",
-        },
-        products: [],
-      },
-      monthly: undefined,
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI credits response returned an invalid usage percentage",
     });
   });
 
-  it("returns API errors from the primary credits endpoint", async () => {
+  it("reports missing period data instead of synthesizing 0% remaining", async () => {
     const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
     (readAuthFileCached as any).mockResolvedValueOnce({
       xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
     });
-
     vi.stubGlobal(
       "fetch",
-      vi.fn(async (url: string) => {
-        if (String(url).includes("format=credits")) {
-          return new Response("nope", { status: 401 });
-        }
-        return new Response("{}", { status: 200 });
-      }) as any,
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ config: { currentPeriod: {} } }), { status: 200 }),
+      ) as any,
     );
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "No weekly quota data",
+    });
+  });
+
+  it("returns sanitized API errors", async () => {
+    const { readAuthFileCached } = await import("../src/lib/opencode-auth.js");
+    (readAuthFileCached as any).mockResolvedValueOnce({
+      xai: { type: "oauth", access: "token-1", expires: Date.now() + 60_000 },
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("nope", { status: 401 })) as any);
 
     await expect(queryXaiQuota()).resolves.toEqual({
       success: false,
@@ -323,19 +195,8 @@ describe("queryXaiQuota", () => {
   });
 });
 
-describe("format helpers", () => {
-  it("formats remaining monthly allowance", () => {
-    expect(
-      formatXaiMonthlyValue({
-        limitUsd: 1500,
-        usedUsd: 4.26,
-        remainingUsd: 1495.74,
-        percentRemaining: 100,
-      }),
-    ).toBe("$1495.74 left ($4.26/$1500.00)");
-  });
-
-  it("labels period kinds", () => {
+describe("periodKindLabel", () => {
+  it("labels supported period kinds", () => {
     expect(periodKindLabel("weekly")).toBe("Weekly");
     expect(periodKindLabel("monthly")).toBe("Monthly");
     expect(periodKindLabel("daily")).toBe("Daily");

--- a/tests/providers.xai.test.ts
+++ b/tests/providers.xai.test.ts
@@ -11,18 +11,7 @@ import { xaiProvider } from "../src/providers/xai.js";
 vi.mock("../src/lib/xai.js", () => ({
   DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS: 5_000,
   hasXaiOAuthCached: vi.fn(),
-  periodKindLabel: vi.fn((kind: string) => {
-    switch (kind) {
-      case "weekly":
-        return "Weekly";
-      case "monthly":
-        return "Monthly";
-      case "daily":
-        return "Daily";
-      default:
-        return "Period";
-    }
-  }),
+  periodKindLabel: vi.fn((kind: string) => (kind === "weekly" ? "Weekly" : "Period")),
   queryXaiQuota: vi.fn(),
 }));
 
@@ -36,7 +25,7 @@ describe("xai provider", () => {
     expect(queryXaiQuota).toHaveBeenCalledWith({ requestTimeoutMs: 12000 });
   });
 
-  it("returns attempted:false when not configured", async () => {
+  it("returns attempted:false when oauth is not configured", async () => {
     const { queryXaiQuota } = await import("../src/lib/xai.js");
     (queryXaiQuota as any).mockResolvedValueOnce(null);
 
@@ -44,43 +33,15 @@ describe("xai provider", () => {
     expectNotAttempted(out);
   });
 
-  it("shows only the shared weekly meter for unified billing", async () => {
+  it("maps exactly one shared weekly row", async () => {
     const { queryXaiQuota } = await import("../src/lib/xai.js");
     (queryXaiQuota as any).mockResolvedValueOnce({
       success: true,
       label: "xAI SuperGrok",
-      unifiedBilling: true,
-      windows: {
-        primary: {
-          percentRemaining: 99,
-          resetTimeIso: "2026-07-20T02:24:00.983Z",
-          kind: "weekly",
-        },
-        products: [
-          {
-            product: "Api",
-            window: {
-              percentRemaining: 99,
-              resetTimeIso: "2026-07-20T02:24:00.983Z",
-              kind: "weekly",
-            },
-          },
-          {
-            product: "GrokChat",
-            window: {
-              percentRemaining: 100,
-              resetTimeIso: "2026-07-20T02:24:00.983Z",
-              kind: "weekly",
-            },
-          },
-        ],
-      },
-      monthly: {
-        limitUsd: 1500,
-        usedUsd: 4.26,
-        remainingUsd: 1495.74,
-        percentRemaining: 100,
-        resetTimeIso: "2026-08-01T00:00:00.000Z",
+      window: {
+        percentRemaining: 95,
+        resetTimeIso: "2026-07-20T02:24:00.983Z",
+        kind: "weekly",
       },
     });
 
@@ -91,43 +52,11 @@ describe("xai provider", () => {
         name: "xAI SuperGrok Weekly",
         group: "xAI SuperGrok",
         label: "Weekly:",
-        percentRemaining: 99,
+        percentRemaining: 95,
         resetTimeIso: "2026-07-20T02:24:00.983Z",
       },
     ]);
-    expect(out.presentation).toEqual({
-      singleWindowDisplayName: "xAI SuperGrok",
-    });
-  });
-
-  it("shows non-unified product rows when remaining differs", async () => {
-    const { queryXaiQuota } = await import("../src/lib/xai.js");
-    (queryXaiQuota as any).mockResolvedValueOnce({
-      success: true,
-      label: "xAI",
-      unifiedBilling: false,
-      windows: {
-        primary: {
-          percentRemaining: 80,
-          resetTimeIso: "2026-07-20T02:24:00.983Z",
-          kind: "weekly",
-        },
-        products: [
-          {
-            product: "Api",
-            window: {
-              percentRemaining: 50,
-              resetTimeIso: "2026-07-20T02:24:00.983Z",
-              kind: "weekly",
-            },
-          },
-        ],
-      },
-    });
-
-    const out = await xaiProvider.fetch({} as any);
-    expectAttemptedWithNoErrors(out);
-    expect(out.entries.map((e) => e.label)).toEqual(["Weekly:", "Api:"]);
+    expect(out.presentation).toEqual({ singleWindowDisplayName: "xAI SuperGrok" });
   });
 
   it("maps errors into toast errors", async () => {
@@ -141,30 +70,38 @@ describe("xai provider", () => {
     expectAttemptedWithErrorLabel(out, "xAI");
   });
 
-  it("matches only xai/grok provider ids, not bare grok model names", () => {
-    expect(xaiProvider.matchesCurrentModel?.("xai/grok-4")).toBe(true);
-    expect(xaiProvider.matchesCurrentModel?.("grok/grok-4")).toBe(true);
-    expect(xaiProvider.matchesCurrentModel?.("grok-code-fast-1")).toBe(false);
-    expect(xaiProvider.matchesCurrentModel?.("github-copilot/grok-code-fast-1")).toBe(false);
-    expect(xaiProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  it("uses currentProviderID to distinguish direct xAI from Copilot Grok", () => {
+    expect(
+      xaiProvider.matchesCurrentModel?.("grok-4", {
+        enabledProviders: "auto",
+        currentProviderID: "xai",
+      }),
+    ).toBe(true);
+    expect(
+      xaiProvider.matchesCurrentModel?.("grok-code-fast-1", {
+        enabledProviders: "auto",
+        currentProviderID: "github-copilot",
+      }),
+    ).toBe(false);
+    expect(xaiProvider.matchesCurrentModel?.("xai/grok-4", { enabledProviders: "auto" })).toBe(
+      true,
+    );
   });
 
-  it("is available when provider ids include xai or oauth is cached", async () => {
+  it("requires both the xai runtime provider and oauth, or oauth fallback", async () => {
     const { hasXaiOAuthCached } = await import("../src/lib/xai.js");
-    (hasXaiOAuthCached as any).mockResolvedValue(false);
 
+    (hasXaiOAuthCached as any).mockResolvedValue(false);
     await expect(
       xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: ["xai"] })),
-    ).resolves.toBe(true);
+    ).resolves.toBe(false);
 
     (hasXaiOAuthCached as any).mockResolvedValue(true);
     await expect(
-      xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: [] })),
+      xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: ["xai"] })),
     ).resolves.toBe(true);
-
-    (hasXaiOAuthCached as any).mockResolvedValue(false);
     await expect(
       xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: [] })),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
   });
 });

--- a/tests/providers.xai.test.ts
+++ b/tests/providers.xai.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+} from "./helpers/provider-assertions.js";
+import { createProviderAvailabilityContext } from "./helpers/provider-test-harness.js";
+import { xaiProvider } from "../src/providers/xai.js";
+
+vi.mock("../src/lib/xai.js", () => ({
+  DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS: 5_000,
+  hasXaiOAuthCached: vi.fn(),
+  periodKindLabel: vi.fn((kind: string) => {
+    switch (kind) {
+      case "weekly":
+        return "Weekly";
+      case "monthly":
+        return "Monthly";
+      case "daily":
+        return "Daily";
+      default:
+        return "Period";
+    }
+  }),
+  queryXaiQuota: vi.fn(),
+}));
+
+describe("xai provider", () => {
+  it("passes configured requestTimeoutMs to the query", async () => {
+    const { queryXaiQuota } = await import("../src/lib/xai.js");
+    (queryXaiQuota as any).mockResolvedValueOnce(null);
+
+    await xaiProvider.fetch({ config: { requestTimeoutMs: 12000 } } as any);
+
+    expect(queryXaiQuota).toHaveBeenCalledWith({ requestTimeoutMs: 12000 });
+  });
+
+  it("returns attempted:false when not configured", async () => {
+    const { queryXaiQuota } = await import("../src/lib/xai.js");
+    (queryXaiQuota as any).mockResolvedValueOnce(null);
+
+    const out = await xaiProvider.fetch({} as any);
+    expectNotAttempted(out);
+  });
+
+  it("shows only the shared weekly meter for unified billing", async () => {
+    const { queryXaiQuota } = await import("../src/lib/xai.js");
+    (queryXaiQuota as any).mockResolvedValueOnce({
+      success: true,
+      label: "xAI SuperGrok",
+      unifiedBilling: true,
+      windows: {
+        primary: {
+          percentRemaining: 99,
+          resetTimeIso: "2026-07-20T02:24:00.983Z",
+          kind: "weekly",
+        },
+        products: [
+          {
+            product: "Api",
+            window: {
+              percentRemaining: 99,
+              resetTimeIso: "2026-07-20T02:24:00.983Z",
+              kind: "weekly",
+            },
+          },
+          {
+            product: "GrokChat",
+            window: {
+              percentRemaining: 100,
+              resetTimeIso: "2026-07-20T02:24:00.983Z",
+              kind: "weekly",
+            },
+          },
+        ],
+      },
+      monthly: {
+        limitUsd: 1500,
+        usedUsd: 4.26,
+        remainingUsd: 1495.74,
+        percentRemaining: 100,
+        resetTimeIso: "2026-08-01T00:00:00.000Z",
+      },
+    });
+
+    const out = await xaiProvider.fetch({} as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toEqual([
+      {
+        name: "xAI SuperGrok Weekly",
+        group: "xAI SuperGrok",
+        label: "Weekly:",
+        percentRemaining: 99,
+        resetTimeIso: "2026-07-20T02:24:00.983Z",
+      },
+    ]);
+    expect(out.presentation).toEqual({
+      singleWindowDisplayName: "xAI SuperGrok",
+    });
+  });
+
+  it("shows non-unified product rows when remaining differs", async () => {
+    const { queryXaiQuota } = await import("../src/lib/xai.js");
+    (queryXaiQuota as any).mockResolvedValueOnce({
+      success: true,
+      label: "xAI",
+      unifiedBilling: false,
+      windows: {
+        primary: {
+          percentRemaining: 80,
+          resetTimeIso: "2026-07-20T02:24:00.983Z",
+          kind: "weekly",
+        },
+        products: [
+          {
+            product: "Api",
+            window: {
+              percentRemaining: 50,
+              resetTimeIso: "2026-07-20T02:24:00.983Z",
+              kind: "weekly",
+            },
+          },
+        ],
+      },
+    });
+
+    const out = await xaiProvider.fetch({} as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries.map((e) => e.label)).toEqual(["Weekly:", "Api:"]);
+  });
+
+  it("maps errors into toast errors", async () => {
+    const { queryXaiQuota } = await import("../src/lib/xai.js");
+    (queryXaiQuota as any).mockResolvedValueOnce({
+      success: false,
+      error: "Token expired",
+    });
+
+    const out = await xaiProvider.fetch({} as any);
+    expectAttemptedWithErrorLabel(out, "xAI");
+  });
+
+  it("matches only xai/grok provider ids, not bare grok model names", () => {
+    expect(xaiProvider.matchesCurrentModel?.("xai/grok-4")).toBe(true);
+    expect(xaiProvider.matchesCurrentModel?.("grok/grok-4")).toBe(true);
+    expect(xaiProvider.matchesCurrentModel?.("grok-code-fast-1")).toBe(false);
+    expect(xaiProvider.matchesCurrentModel?.("github-copilot/grok-code-fast-1")).toBe(false);
+    expect(xaiProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+
+  it("is available when provider ids include xai or oauth is cached", async () => {
+    const { hasXaiOAuthCached } = await import("../src/lib/xai.js");
+    (hasXaiOAuthCached as any).mockResolvedValue(false);
+
+    await expect(
+      xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: ["xai"] })),
+    ).resolves.toBe(true);
+
+    (hasXaiOAuthCached as any).mockResolvedValue(true);
+    await expect(
+      xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: [] })),
+    ).resolves.toBe(true);
+
+    (hasXaiOAuthCached as any).mockResolvedValue(false);
+    await expect(
+      xaiProvider.isAvailable(createProviderAvailabilityContext({ providerIds: [] })),
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an `xai` quota provider for OpenCode's SuperGrok OAuth login.

- Reads the existing `auth.json` `xai` OAuth access token without modifying auth state
- Queries only Grok Build's shared period credit endpoint
- Displays exactly one Weekly quota row, matching the meter shown on grok.com
- Treats protobuf-omitted zero usage as 0% used
- Rejects malformed/missing quota data instead of synthesizing a depleted meter
- Uses `currentProviderID` to distinguish direct xAI from Copilot-hosted Grok models
- Adds xAI provider metadata, `/quota_status` live-probe output, docs, and boundary tests

OpenCode remains the sole owner of OAuth refresh and `auth.json` persistence. This provider does not query monthly billing, subscriptions, product breakdowns, or the Management API prepaid-balance path.

The contributing API-key provider template does not apply because this is an OAuth-only provider using OpenCode-managed auth.

## Linked Issue

No existing issue. SuperGrok OAuth users currently see no xAI quota in OpenCode Quota after `/connect` xAI.

## OpenCode Validation

- Current production released OpenCode version tested: `1.17.18`
- Why this version is relevant to the fix: this release stores xAI SuperGrok OAuth in `auth.json` and is used with `@slkiser/opencode-quota`
- Live result: one `xAI SuperGrok Weekly` row; `auth.json` remains mode `0600`

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm test` (122 files, 1,215 tests)
- [x] I ran `pnpm run build`
- [x] This is the smallest safe root-cause fix (one read-only quota request)
- [x] I preserved behavioral invariants and updated/added boundary tests as needed
- [x] I updated docs for the user-facing provider addition
- [x] I explained why the API-key provider template does not apply
- [x] Provider metadata uses `authentication: opencode_auth_oauth_token`

## Notes for reviewers

- Live CLI check with SuperGrok OAuth: `opencode-quota show --provider xai` returns a single Weekly row
- The quota plugin never refreshes or persists xAI credentials; expired auth directs users back through OpenCode
- Management API prepaid balance is intentionally not used because OAuth tokens are rejected there