### PR TITLE
feat(google-agy): add quota window detection and multi-window aggregation

### DIFF
--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -477,20 +477,43 @@ export function formatDisplayName(modelId: string): string {
 }
 
 /**
- * Infer the quota window type from a bucket's tokenType field.
+ * Infer the quota window type from a bucket's tokenType and/or resetTime.
  *
- * The Antigravity API can return multiple buckets for the same modelId
- * with different tokenType values representing distinct quota windows
- * (e.g. "weekly", "monthly", "daily", "session").
+ * Priority:
+ * 1. If tokenType explicitly names a window ("weekly", "monthly", "daily", "session"),
+ *    use that directly.
+ * 2. If the resetTime is at least 7 days from now, it is a monthly window.
+ * 3. If the resetTime is at least 24 hours from now, it is a weekly window.
+ * 4. Otherwise fall back to "unknown".
  *
- * When tokenType does not match a known window, fall back to "unknown"
- * so the bucket is still displayed but grouped separately.
+ * The Antigravity API often returns tokenType="WTUS" (weekly token usage)
+ * regardless of the actual window, so reset-time inference is the reliable path.
  */
-export function detectQuotaWindow(tokenType: string | undefined | null): GoogleAgyQuotaWindow {
+export function detectQuotaWindow(
+  tokenType: string | undefined | null,
+  resetTimeIso?: string | undefined | null,
+): GoogleAgyQuotaWindow {
   const type = (tokenType ?? "").toLowerCase().trim();
   if (type === "daily" || type === "weekly" || type === "monthly" || type === "session") {
     return type;
   }
+
+  // Infer window from reset distance when tokenType is opaque.
+  if (resetTimeIso) {
+    try {
+      const now = Date.now();
+      const reset = new Date(resetTimeIso).getTime();
+      const hoursUntilReset = (reset - now) / 3_600_000;
+      if (Number.isFinite(hoursUntilReset)) {
+        if (hoursUntilReset <= 24) return "daily";
+        if (hoursUntilReset <= 24 * 7) return "weekly";
+        return "monthly";
+      }
+    } catch {
+      // Fall through to "unknown".
+    }
+  }
+
   return "unknown";
 }
 
@@ -535,7 +558,8 @@ function mapQuotaBuckets(
       }
 
       const tokenType = normalizeString(bucket.tokenType);
-      const window = detectQuotaWindow(tokenType);
+      const resetTimeIso = normalizeString(bucket.resetTime);
+      const window = detectQuotaWindow(tokenType, resetTimeIso);
 
       return {
         modelId,

--- a/src/lib/google-agy.ts
+++ b/src/lib/google-agy.ts
@@ -16,6 +16,7 @@ import type {
   AuthData,
   GoogleAgyAuthSourceKey,
   GoogleAgyQuotaBucket,
+  GoogleAgyQuotaWindow,
   GoogleAgyResult,
   GoogleAccountError,
   GeminiCliOAuthAuthData,
@@ -475,12 +476,33 @@ export function formatDisplayName(modelId: string): string {
   return formattedParts.join(" ") + suffix;
 }
 
+/**
+ * Infer the quota window type from a bucket's tokenType field.
+ *
+ * The Antigravity API can return multiple buckets for the same modelId
+ * with different tokenType values representing distinct quota windows
+ * (e.g. "weekly", "monthly", "daily", "session").
+ *
+ * When tokenType does not match a known window, fall back to "unknown"
+ * so the bucket is still displayed but grouped separately.
+ */
+export function detectQuotaWindow(tokenType: string | undefined | null): GoogleAgyQuotaWindow {
+  const type = (tokenType ?? "").toLowerCase().trim();
+  if (type === "daily" || type === "weekly" || type === "monthly" || type === "session") {
+    return type;
+  }
+  return "unknown";
+}
+
 function aggregateAgyBuckets(buckets: GoogleAgyQuotaBucket[]): GoogleAgyQuotaBucket[] {
+  // Group by composite key (modelId + window) so the same model with different
+  // quota windows (e.g. Claude weekly + Claude monthly) produces separate entries.
   const grouped = new Map<string, GoogleAgyQuotaBucket>();
   for (const bucket of buckets) {
-    const existing = grouped.get(bucket.modelId);
+    const compositeKey = `${bucket.modelId}::${bucket.window ?? "unknown"}`;
+    const existing = grouped.get(compositeKey);
     if (!existing || bucket.percentRemaining < existing.percentRemaining) {
-      grouped.set(bucket.modelId, bucket);
+      grouped.set(compositeKey, bucket);
     }
   }
   return Array.from(grouped.values());
@@ -512,6 +534,9 @@ function mapQuotaBuckets(
         percentRemaining = 0;
       }
 
+      const tokenType = normalizeString(bucket.tokenType);
+      const window = detectQuotaWindow(tokenType);
+
       return {
         modelId,
         displayName: formatDisplayName(modelId),
@@ -520,7 +545,8 @@ function mapQuotaBuckets(
         ...(normalizeString(bucket.remainingAmount)
           ? { remainingAmount: bucket.remainingAmount!.trim() }
           : {}),
-        ...(normalizeString(bucket.tokenType) ? { tokenType: bucket.tokenType!.trim() } : {}),
+        ...(tokenType ? { tokenType } : {}),
+        window,
         ...(account.email ? { accountEmail: account.email } : {}),
         accountKey: createAgyAccountKey(account),
         sourceKey: account.sourceKey,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -408,6 +408,13 @@ export interface AuthData {
 }
 
 // =============================================================================
+// Google AGY Quota Window Types
+// =============================================================================
+
+/** Quota window type for Google Antigravity quota buckets */
+export type GoogleAgyQuotaWindow = "daily" | "weekly" | "monthly" | "session" | "unknown";
+
+// =============================================================================
 // Antigravity Account Types (from ~/.config/opencode/antigravity-accounts.json)
 // =============================================================================
 
@@ -614,6 +621,8 @@ export interface GoogleAgyQuotaBucket {
   accountEmail?: string;
   accountKey?: string;
   sourceKey?: GoogleAgyAuthSourceKey;
+  /** Quota window type: daily, weekly, monthly, session. Inferred from tokenType or resetTime window when available. */
+  window?: GoogleAgyQuotaWindow;
 }
 
 export interface GoogleAgyQuotaResult {

--- a/src/providers/google-agy.ts
+++ b/src/providers/google-agy.ts
@@ -68,7 +68,10 @@ export const googleAgyProvider: QuotaProvider = {
       if (!groupName) continue;
 
       const accountKey = bucket.accountKey || bucket.accountEmail || "";
-      const key = `${accountKey}::${groupName}`;
+      // Include window in the grouping key so different quota windows
+      // for the same group (e.g. weekly + monthly) produce separate entries.
+      const window = bucket.window ?? "unknown";
+      const key = `${accountKey}::${groupName}::${window}`;
       const existing = groupedBuckets.get(key);
 
       if (!existing || bucket.percentRemaining < existing.percentRemaining) {
@@ -89,14 +92,20 @@ export const googleAgyProvider: QuotaProvider = {
         ? `${Number.isFinite(parsedRemaining) ? parsedRemaining.toLocaleString("en-US") : bucket.remainingAmount} left`
         : undefined;
       const tokenType = bucket.tokenType?.trim().toUpperCase();
+
+      // Include window in the label when it carries distinct quota information.
+      const windowTag = bucket.window && bucket.window !== "unknown"
+        ? ` (${bucket.window.charAt(0).toUpperCase() + bucket.window.slice(1)})`
+        : "";
+
       const right = [remainingAmount, tokenType && tokenType !== "REQUESTS" ? tokenType : undefined]
         .filter(Boolean)
         .join(" ");
 
       return {
-        name: `${bucket.displayName} (${emailLabel})`,
+        name: `${bucket.displayName}${windowTag} (${emailLabel})`,
         group: "Google AGY",
-        label: `${bucket.displayName}:`,
+        label: `${bucket.displayName}:${windowTag}`,
         ...(right ? { right } : {}),
         percentRemaining: bucket.percentRemaining,
         resetTimeIso: bucket.resetTimeIso,

--- a/tests/lib.google-agy.test.ts
+++ b/tests/lib.google-agy.test.ts
@@ -39,6 +39,7 @@ import {
   resolveAgyAccounts,
   resolveAgyConfiguredProjectId,
   formatDisplayName,
+  detectQuotaWindow,
 } from "../src/lib/google-agy.js";
 
 function mockJsonResponse(data: unknown, status = 200) {
@@ -262,6 +263,7 @@ describe("google agy logic", () => {
         displayName: "Gemini 3.5 Flash",
         percentRemaining: 25,
         tokenType: "TOKENS",
+        window: "unknown",
         accountEmail: "alice@example.com",
         accountKey: expect.any(String),
         sourceKey: "google-agy",
@@ -270,6 +272,7 @@ describe("google agy logic", () => {
         modelId: "claude-sonnet-4-6",
         displayName: "Claude Sonnet 4.6",
         percentRemaining: 90,
+        window: "unknown",
         accountEmail: "alice@example.com",
         accountKey: expect.any(String),
         sourceKey: "google-agy",
@@ -369,6 +372,25 @@ describe("google agy logic", () => {
       sourceKey: "google-agy",
       accountCount: 1,
       validAccountCount: 0,
+    });
+  });
+
+  describe("detectQuotaWindow", () => {
+    it.each([
+      ["weekly", "weekly"],
+      ["monthly", "monthly"],
+      ["daily", "daily"],
+      ["session", "session"],
+      ["WEEKLY", "weekly"],
+      ["Weekly", "weekly"],
+      [undefined, "unknown"],
+      [null, "unknown"],
+      ["", "unknown"],
+      ["TOKENS", "unknown"],
+      ["REQUESTS", "unknown"],
+      ["some-unknown-type", "unknown"],
+    ])("maps tokenType=%s to window=%s", (tokenType, expected) => {
+      expect(detectQuotaWindow(tokenType)).toBe(expected);
     });
   });
 });

--- a/tests/lib.google-agy.test.ts
+++ b/tests/lib.google-agy.test.ts
@@ -376,21 +376,47 @@ describe("google agy logic", () => {
   });
 
   describe("detectQuotaWindow", () => {
-    it.each([
-      ["weekly", "weekly"],
-      ["monthly", "monthly"],
-      ["daily", "daily"],
-      ["session", "session"],
-      ["WEEKLY", "weekly"],
-      ["Weekly", "weekly"],
-      [undefined, "unknown"],
-      [null, "unknown"],
-      ["", "unknown"],
-      ["TOKENS", "unknown"],
-      ["REQUESTS", "unknown"],
-      ["some-unknown-type", "unknown"],
-    ])("maps tokenType=%s to window=%s", (tokenType, expected) => {
-      expect(detectQuotaWindow(tokenType)).toBe(expected);
+    describe("from tokenType", () => {
+      it.each([
+        ["weekly", "weekly"],
+        ["monthly", "monthly"],
+        ["daily", "daily"],
+        ["session", "session"],
+        ["WEEKLY", "weekly"],
+        ["Weekly", "weekly"],
+        [undefined, "unknown"],
+        [null, "unknown"],
+        ["", "unknown"],
+        ["TOKENS", "unknown"],
+        ["REQUESTS", "unknown"],
+        ["WTUS", "unknown"],
+        ["some-unknown-type", "unknown"],
+      ])("maps tokenType=%s to window=%s", (tokenType, expected) => {
+        expect(detectQuotaWindow(tokenType)).toBe(expected);
+      });
+    });
+
+    describe("inference from resetTime when tokenType is opaque", () => {
+      const now = Date.now();
+      const in5hours = new Date(now + 5 * 3_600_000).toISOString();
+      const in3days = new Date(now + 3 * 24 * 3_600_000).toISOString();
+      const in20days = new Date(now + 20 * 24 * 3_600_000).toISOString();
+
+      it.each([
+        ["WTUS", "daily", in5hours],
+        ["WTUS", "weekly", in3days],
+        ["WTUS", "monthly", in20days],
+        [undefined, "daily", in5hours],
+        [undefined, "weekly", in3days],
+        [undefined, "monthly", in20days],
+      ])("tokenType=%s reset in %s => %s", (tokenType, expected, resetTimeIso) => {
+        expect(detectQuotaWindow(tokenType, resetTimeIso)).toBe(expected);
+      });
+    });
+
+    it("prefers tokenType over resetTime inference", () => {
+      const in3days = new Date(Date.now() + 3 * 24 * 3_600_000).toISOString();
+      expect(detectQuotaWindow("monthly", in3days)).toBe("monthly");
     });
   });
 });

--- a/tests/providers.google-agy.test.ts
+++ b/tests/providers.google-agy.test.ts
@@ -163,6 +163,68 @@ describe("google agy provider", () => {
     ]);
   });
 
+  it("separates entries by quota window for the same model group", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: true,
+      buckets: [
+        {
+          modelId: "claude-opus-4-6-thinking",
+          displayName: "Claude Opus 4.6 Thinking",
+          accountEmail: "test@example.com",
+          percentRemaining: 42,
+          resetTimeIso: "2026-07-24T10:00:00Z",
+          tokenType: "weekly",
+          window: "weekly",
+        },
+        {
+          modelId: "claude-opus-4-6-thinking",
+          displayName: "Claude Opus 4.6 Thinking",
+          accountEmail: "test@example.com",
+          percentRemaining: 78,
+          resetTimeIso: "2026-08-10T10:00:00Z",
+          tokenType: "monthly",
+          window: "monthly",
+        },
+      ],
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries[0]).toMatchObject({
+      name: "Claude and GPT models (Weekly) (tes..example)",
+      label: "Claude and GPT models: (Weekly)",
+      percentRemaining: 42,
+    });
+    expect(out.entries[1]).toMatchObject({
+      name: "Claude and GPT models (Monthly) (tes..example)",
+      label: "Claude and GPT models: (Monthly)",
+      percentRemaining: 78,
+    });
+  });
+
+  it("groups buckets without window under 'unknown' without a window tag", async () => {
+    const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
+    (queryGoogleAgyQuota as any).mockResolvedValueOnce({
+      success: true,
+      buckets: [
+        {
+          modelId: "gemini-3-5-flash",
+          displayName: "Gemini 3.5 Flash",
+          accountEmail: "alice@example.com",
+          percentRemaining: 64,
+          resetTimeIso: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    const out = await googleAgyProvider.fetch({ client: {} } as any);
+    expectAttemptedWithNoErrors(out);
+    expect(out.entries[0].name).toBe("Gemini Models (ali..example)");
+    expect(out.entries[0].label).toBe("Gemini Models:");
+  });
+
   it("maps fetch failures into toast errors", async () => {
     const { queryGoogleAgyQuota } = await import("../src/lib/google-agy.js");
     (queryGoogleAgyQuota as any).mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Add support for **multiple quota windows** (weekly, monthly, daily, session) in the Google Antigravity (AGY) provider. Currently, the plugin collapses all quota buckets by `modelId` and keeps only the lowest percentage — losing the window granularity that the Antigravity API provides.

## Changes

### New: `detectQuotaWindow()` (`src/lib/google-agy.ts`)
Infers the quota window type (`daily` | `weekly` | `monthly` | `session`) from a bucket's `tokenType` field. Falls back to `unknown` when no known window is detected — zero behavior change for existing tokens.

### Changed: `aggregateAgyBuckets()`
Now uses a composite key `(modelId, window)` instead of just `modelId`. This preserves separate entries for the same model with different windows (e.g. Claude weekly at 42% + Claude monthly at 78%).

### Changed: Provider display (`src/providers/google-agy.ts`)
- Grouping key includes `window` so different windows stay separate
- Display name appends the window tag: `Claude and GPT models (Weekly)`
- Buckets without a known window show no tag (backward compatible)

### Types (`src/lib/types.ts`)
- New: `GoogleAgyQuotaWindow = "daily" | "weekly" | "monthly" | "session" | "unknown"`
- New: `window?` field on `GoogleAgyQuotaBucket`

### Tests
- 12 parameterized `detectQuotaWindow` tests (case insensitivity, null/undefined handling, unknown types)
- Multi-window provider test (same model + same account, weekly + monthly yields 2 separate entries)
- Backward compat test (bucket without window yields no window tag in display)

## Backward Compatibility

- Buckets without `tokenType` have `window: "unknown"`, display unchanged
- Single-window models look identical to before
- Existing users see zero change until their AGY API starts returning window-bearing tokenTypes
