### PR TITLE
fix(provider): refresh xAI OAuth for startup quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | OpenCode Go              | [Needs setup](docs/readme/providers.md#opencode-go)            | Dashboard scraping | Quota              |
 | OpenCode Zen             | [Needs setup](docs/readme/providers.md#opencode-zen)           | Dashboard scraping | Budget and balance |
 
+When xAI OAuth needs renewal, the plugin refreshes it before the quota request and atomically updates only the xAI record while preserving other `auth.json` credentials. This lets enabled quota panels populate on startup without sending an xAI model message.
+
 The quota view uses short labels such as `Day quota`, `5h quota`, `Day budget`, and `Balance`. Bar width varies by surface. JSON keeps the precise accounting type for scripts.
 
 ### Custom providers

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -39,6 +39,8 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | OpenCode Go              | [Needs setup](#opencode-go)            | Dashboard scraping | Quota              |
 | OpenCode Zen             | [Needs setup](#opencode-zen)           | Dashboard scraping | Budget and balance |
 
+When xAI OAuth needs renewal, the plugin refreshes it before the quota request and atomically updates only the xAI record while preserving other `auth.json` credentials. This lets enabled quota panels populate on startup without sending an xAI model message.
+
 The friendly `Quota` label covers quota and rate-limit windows; v4 JSON distinguishes them.
 
 xAI SuperGrok reads OpenCode's existing xAI OAuth login and reports its single Weekly quota window.

--- a/src/lib/atomic-json.ts
+++ b/src/lib/atomic-json.ts
@@ -4,6 +4,9 @@ import { stringifyWithComments } from "./jsonc.js";
 
 export interface WriteJsonAtomicOptions {
   trailingNewline?: boolean;
+  mode?: number;
+  /** Whether retryable rename errors may replace an existing destination. */
+  replaceOnRenameError?: boolean;
 }
 
 async function safeRm(target: string): Promise<void> {
@@ -21,15 +24,26 @@ export async function writeJsonAtomic(
 ): Promise<void> {
   // Use the comment-preserving stringifier here instead of JSON.stringify.
   const content = stringifyWithComments(data) + (opts.trailingNewline ? "\n" : "");
-  await writeTextAtomic(path, content);
+  await writeTextAtomic(path, content, {
+    mode: opts.mode,
+    replaceOnRenameError: opts.replaceOnRenameError,
+  });
 }
 
-export async function writeTextAtomic(path: string, content: string): Promise<void> {
+export async function writeTextAtomic(
+  path: string,
+  content: string,
+  opts: { mode?: number; replaceOnRenameError?: boolean } = {},
+): Promise<void> {
   const dir = dirname(path);
   const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
   await mkdir(dir, { recursive: true });
-  await writeFile(tmp, content, "utf-8");
+  await writeFile(
+    tmp,
+    content,
+    opts.mode === undefined ? "utf-8" : { encoding: "utf-8", mode: opts.mode },
+  );
 
   try {
     await rename(tmp, path);
@@ -39,7 +53,8 @@ export async function writeTextAtomic(path: string, content: string): Promise<vo
         ? String((err as { code?: unknown }).code)
         : "";
     const shouldRetryAsReplace =
-      code === "EPERM" || code === "EEXIST" || code === "EACCES" || code === "ENOTEMPTY";
+      opts.replaceOnRenameError !== false &&
+      (code === "EPERM" || code === "EEXIST" || code === "EACCES" || code === "ENOTEMPTY");
 
     if (!shouldRetryAsReplace) {
       await safeRm(tmp);

--- a/src/lib/opencode-auth.ts
+++ b/src/lib/opencode-auth.ts
@@ -9,7 +9,11 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 
-import { getOpencodeRuntimeDirCandidates, getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
+import { writeJsonAtomic } from "./atomic-json.js";
+import {
+  getOpencodeRuntimeDirCandidates,
+  getOpencodeRuntimeDirs,
+} from "./opencode-runtime-paths.js";
 
 import type { AuthData } from "./types.js";
 
@@ -22,6 +26,44 @@ type AuthCacheEntry = {
 };
 
 let authCache: AuthCacheEntry | null = null;
+
+type AuthFileSnapshot = {
+  path: string;
+  data: Record<string, unknown>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getAuthContentOverride(): Record<string, unknown> | null {
+  const content = process.env.OPENCODE_AUTH_CONTENT;
+  if (!content) return null;
+
+  try {
+    const data = JSON.parse(content);
+    return isRecord(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasOpenCodeAuthContentOverride(): boolean {
+  return getAuthContentOverride() !== null;
+}
+
+async function readAuthFileSnapshot(): Promise<AuthFileSnapshot | null> {
+  for (const path of getAuthPaths()) {
+    try {
+      const data = JSON.parse(await readFile(path, "utf-8"));
+      if (isRecord(data)) return { path, data };
+    } catch {
+      // Try next path.
+    }
+  }
+
+  return null;
+}
 
 /**
  * Get candidate auth.json paths in priority order.
@@ -42,18 +84,74 @@ export function getAuthPath(): string {
 }
 
 export async function readAuthFile(): Promise<AuthData | null> {
-  const paths = getAuthPaths();
+  const overridden = getAuthContentOverride();
+  if (overridden) return overridden as AuthData;
 
-  for (const path of paths) {
-    try {
-      const content = await readFile(path, "utf-8");
-      return JSON.parse(content) as AuthData;
-    } catch {
-      // Try next path
-    }
+  const snapshot = await readAuthFileSnapshot();
+  return snapshot ? (snapshot.data as AuthData) : null;
+}
+
+/**
+ * Checks that the on-disk xAI OAuth entry still matches the token used for a
+ * refresh. OPENCODE_AUTH_CONTENT is immutable from the plugin's perspective.
+ */
+export async function isCurrentXaiOAuth(params: {
+  access: string;
+  refresh: string;
+}): Promise<boolean> {
+  if (hasOpenCodeAuthContentOverride()) return false;
+
+  const snapshot = await readAuthFileSnapshot();
+  const xai = snapshot?.data.xai;
+  return (
+    isRecord(xai) &&
+    xai.type === "oauth" &&
+    xai.access === params.access &&
+    xai.refresh === params.refresh
+  );
+}
+
+/**
+ * Atomically replaces only the xAI OAuth entry while retaining every other
+ * auth.json record, including credentials unknown to OpenCode itself.
+ */
+export async function updateCurrentXaiOAuth(params: {
+  expectedAccess: string;
+  expectedRefresh: string;
+  access: string;
+  refresh: string;
+  expires: number;
+}): Promise<boolean> {
+  if (hasOpenCodeAuthContentOverride()) return false;
+
+  const snapshot = await readAuthFileSnapshot();
+  const current = snapshot?.data.xai;
+  if (
+    !snapshot ||
+    !isRecord(current) ||
+    current.type !== "oauth" ||
+    current.access !== params.expectedAccess ||
+    current.refresh !== params.expectedRefresh
+  ) {
+    return false;
   }
 
-  return null;
+  await writeJsonAtomic(
+    snapshot.path,
+    {
+      ...snapshot.data,
+      xai: {
+        ...current,
+        type: "oauth",
+        access: params.access,
+        refresh: params.refresh,
+        expires: params.expires,
+      },
+    },
+    { trailingNewline: true, mode: 0o600, replaceOnRenameError: false },
+  );
+  authCache = null;
+  return true;
 }
 
 /**

--- a/src/lib/xai.ts
+++ b/src/lib/xai.ts
@@ -1,23 +1,35 @@
 /**
  * xAI SuperGrok subscription quota fetcher.
  *
- * Uses OpenCode's read-only `xai` OAuth entry and queries the same shared
- * period meter exposed by Grok Build:
+ * Uses OpenCode's `xai` OAuth entry and queries the shared period meter
+ * exposed by Grok Build:
  * GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
  *
- * OpenCode remains the sole owner of OAuth refresh and auth.json persistence.
+ * Expired OAuth credentials are refreshed and then atomically saved back to
+ * the matching xAI entry without changing unrelated auth.json credentials.
  */
 
 import { sanitizeSingleLineDisplaySnippet } from "./display-sanitize.js";
 import { clampPercent } from "./format-utils.js";
 import { fetchWithTimeout } from "./http.js";
-import { readAuthFile, readAuthFileCached } from "./opencode-auth.js";
+import {
+  hasOpenCodeAuthContentOverride,
+  isCurrentXaiOAuth,
+  readAuthFile,
+  readAuthFileCached,
+  updateCurrentXaiOAuth,
+} from "./opencode-auth.js";
 import type { AuthData, QuotaError } from "./types.js";
 
 export const DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS = 5_000;
+export const XAI_ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000;
 
 const CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+const XAI_CONCURRENT_REFRESH_READ_ATTEMPTS = 3;
+const XAI_CONCURRENT_REFRESH_READ_DELAY_MS = 50;
 
 export type XaiPeriodKind = "weekly" | "monthly" | "daily" | "period";
 
@@ -41,8 +53,18 @@ export type ResolvedXaiOAuth =
   | {
       state: "configured";
       accessToken: string;
+      refreshToken?: string;
       expiresAt?: number;
     };
+
+type ConfiguredXaiOAuth = Extract<ResolvedXaiOAuth, { state: "configured" }>;
+type XaiOAuthRefreshResult = ConfiguredXaiOAuth | QuotaError;
+
+export interface QueryXaiQuotaOptions {
+  requestTimeoutMs?: number;
+}
+
+const xaiOAuthRefreshInFlight = new Map<string, Promise<XaiOAuthRefreshResult>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -91,6 +113,7 @@ export function resolveXaiOAuth(auth: AuthData | null | undefined): ResolvedXaiO
   return {
     state: "configured",
     accessToken,
+    refreshToken: getNonEmptyString(entry.refresh),
     expiresAt:
       typeof entry.expires === "number" && Number.isFinite(entry.expires)
         ? entry.expires
@@ -107,6 +130,179 @@ export async function hasXaiOAuthCached(params?: { maxAgeMs?: number }): Promise
     maxAgeMs: Math.max(0, params?.maxAgeMs ?? DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS),
   });
   return hasXaiOAuth(auth);
+}
+
+function accessTokenIsExpiring(accessToken: string): boolean {
+  const payload = accessToken.split(".")[1];
+  if (!payload) return false;
+
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: unknown;
+    };
+    return (
+      typeof claims.exp === "number" &&
+      Number.isFinite(claims.exp) &&
+      claims.exp * 1_000 <= Date.now() + XAI_ACCESS_TOKEN_REFRESH_SKEW_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+function needsXaiOAuthRefresh(auth: ConfiguredXaiOAuth): boolean {
+  // Preserve access-only credentials from older OpenCode/companion auth
+  // formats. Without a refresh token, querying the current bearer is safer
+  // than treating an absent stored expiry as an unrecoverable auth failure.
+  if (!auth.expiresAt && !auth.refreshToken) return false;
+
+  return (
+    !auth.expiresAt ||
+    auth.expiresAt - Date.now() <= XAI_ACCESS_TOKEN_REFRESH_SKEW_MS ||
+    accessTokenIsExpiring(auth.accessToken)
+  );
+}
+
+async function readUpdatedXaiOAuth(
+  auth: ConfiguredXaiOAuth,
+): Promise<ConfiguredXaiOAuth | undefined> {
+  for (let attempt = 0; attempt < XAI_CONCURRENT_REFRESH_READ_ATTEMPTS; attempt++) {
+    const updated = resolveXaiOAuth(await readAuthFile());
+    if (updated.state === "configured" && !needsXaiOAuthRefresh(updated)) {
+      const changed =
+        updated.accessToken !== auth.accessToken ||
+        updated.refreshToken !== auth.refreshToken ||
+        updated.expiresAt !== auth.expiresAt;
+      if (changed) return updated;
+    }
+
+    if (attempt + 1 < XAI_CONCURRENT_REFRESH_READ_ATTEMPTS) {
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, XAI_CONCURRENT_REFRESH_READ_DELAY_MS),
+      );
+    }
+  }
+
+  return undefined;
+}
+
+function refreshError(error: string): QuotaError {
+  return { success: false, error };
+}
+
+function isQuotaError(result: XaiOAuthRefreshResult): result is QuotaError {
+  return "success" in result && result.success === false;
+}
+
+async function refreshXaiOAuth(params: {
+  auth: ConfiguredXaiOAuth;
+  requestTimeoutMs?: number;
+}): Promise<XaiOAuthRefreshResult> {
+  const { auth, requestTimeoutMs } = params;
+  const refreshToken = auth.refreshToken;
+  if (!refreshToken) {
+    return refreshError("xAI OAuth token expired; reconnect xAI");
+  }
+  if (hasOpenCodeAuthContentOverride()) {
+    return refreshError("xAI OAuth token expired; update OPENCODE_AUTH_CONTENT or reconnect xAI");
+  }
+  const refreshKey = `${auth.accessToken}\u0000${refreshToken}`;
+  const existing = xaiOAuthRefreshInFlight.get(refreshKey);
+  if (existing) return existing;
+
+  const refreshPromise = (async (): Promise<XaiOAuthRefreshResult> => {
+    try {
+      if (!(await isCurrentXaiOAuth({ access: auth.accessToken, refresh: refreshToken }))) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError("xAI OAuth changed; retry or reconnect xAI")
+        );
+      }
+
+      const response = await fetchWithTimeout(
+        TOKEN_URL,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+            "User-Agent": USER_AGENT,
+          },
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: refreshToken,
+            client_id: XAI_CLIENT_ID,
+          }).toString(),
+        },
+        requestTimeoutMs,
+      );
+      if (!response.ok) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError(`xAI OAuth refresh failed (${response.status}); reconnect xAI`)
+        );
+      }
+
+      const payload = await response.json();
+      if (!isRecord(payload)) {
+        return refreshError("xAI OAuth refresh returned invalid credentials; reconnect xAI");
+      }
+
+      const access = getNonEmptyString(payload.access_token);
+      if (!access) {
+        return refreshError("xAI OAuth refresh returned invalid credentials; reconnect xAI");
+      }
+
+      const refresh = getNonEmptyString(payload.refresh_token) ?? refreshToken;
+      const expiresIn = payload.expires_in;
+      const expiresSeconds =
+        typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0
+          ? expiresIn
+          : 3_600;
+      const credentials = {
+        access,
+        refresh,
+        expires: Date.now() + expiresSeconds * 1_000,
+      };
+
+      const persisted = await updateCurrentXaiOAuth({
+        expectedAccess: auth.accessToken,
+        expectedRefresh: refreshToken,
+        ...credentials,
+      });
+      if (!persisted) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError("xAI OAuth changed during refresh; retry or reconnect xAI")
+        );
+      }
+
+      return {
+        state: "configured",
+        accessToken: credentials.access,
+        refreshToken: credentials.refresh,
+        expiresAt: credentials.expires,
+      };
+    } catch {
+      return (
+        (await readUpdatedXaiOAuth(auth)) ?? refreshError("xAI OAuth refresh failed; reconnect xAI")
+      );
+    }
+  })();
+
+  xaiOAuthRefreshInFlight.set(refreshKey, refreshPromise);
+  try {
+    return await refreshPromise;
+  } finally {
+    if (xaiOAuthRefreshInFlight.get(refreshKey) === refreshPromise) {
+      xaiOAuthRefreshInFlight.delete(refreshKey);
+    }
+  }
+}
+
+/** Test helper to clear an in-flight xAI OAuth refresh between test cases. */
+export function clearXaiOAuthRefreshForTests(): void {
+  xaiOAuthRefreshInFlight.clear();
 }
 
 function parseCreditsWindow(payload: unknown): XaiWindowValue | null {
@@ -147,20 +343,20 @@ function safeErrorText(message: string, accessToken: string): string {
   return sanitizeSingleLineDisplaySnippet(redacted, 160);
 }
 
-export async function queryXaiQuota(
-  options: { requestTimeoutMs?: number } = {},
-): Promise<XaiResult> {
+export async function queryXaiQuota(options: QueryXaiQuotaOptions = {}): Promise<XaiResult> {
   // OpenCode can replace this OAuth entry while servicing a model request.
   // Read the file directly so a post-request quota fetch cannot reuse the
   // token snapshot from before that refresh.
-  const resolvedAuth = resolveXaiOAuth(await readAuthFile());
+  let resolvedAuth = resolveXaiOAuth(await readAuthFile());
   if (resolvedAuth.state !== "configured") return null;
 
-  if (resolvedAuth.expiresAt !== undefined && resolvedAuth.expiresAt <= Date.now()) {
-    return {
-      success: false,
-      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
-    };
+  if (needsXaiOAuthRefresh(resolvedAuth)) {
+    const refreshed = await refreshXaiOAuth({
+      auth: resolvedAuth,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+    if (isQuotaError(refreshed)) return refreshed;
+    resolvedAuth = refreshed;
   }
 
   try {

--- a/tests/lib.atomic-json.test.ts
+++ b/tests/lib.atomic-json.test.ts
@@ -72,4 +72,19 @@ describe("atomic-json", () => {
     expect(fs.rm).toHaveBeenCalledWith(tmpPath, { force: true });
     expect(fs.rename).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the destination when replacement is disabled", async () => {
+    const fs = await import("fs/promises");
+    const { writeJsonAtomic } = await import("../src/lib/atomic-json.js");
+    const renameError = Object.assign(new Error("destination exists"), { code: "EPERM" });
+    (fs.rename as any).mockRejectedValueOnce(renameError);
+
+    await expect(
+      writeJsonAtomic("/tmp/opencode/auth.json", { ok: true }, { replaceOnRenameError: false }),
+    ).rejects.toThrow("destination exists");
+
+    const [tmpPath] = (fs.writeFile as any).mock.calls[0];
+    expect(fs.rm).toHaveBeenCalledWith(tmpPath, { force: true });
+    expect(fs.rm).not.toHaveBeenCalledWith("/tmp/opencode/auth.json", { force: true });
+  });
 });

--- a/tests/lib.opencode-auth.test.ts
+++ b/tests/lib.opencode-auth.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({ dataDir: "" }));
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({ dataDirs: [runtime.dataDir] }),
+  getOpencodeRuntimeDirs: () => ({ dataDir: runtime.dataDir }),
+}));
+
+import {
+  clearReadAuthFileCacheForTests,
+  isCurrentXaiOAuth,
+  readAuthFile,
+  updateCurrentXaiOAuth,
+} from "../src/lib/opencode-auth.js";
+
+describe("OpenCode auth updates", () => {
+  let tempDir: string;
+  let authFile: string;
+  let originalAuthContent: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-auth-"));
+    runtime.dataDir = join(tempDir, "data");
+    authFile = join(runtime.dataDir, "auth.json");
+    mkdirSync(runtime.dataDir, { recursive: true });
+    originalAuthContent = process.env.OPENCODE_AUTH_CONTENT;
+    delete process.env.OPENCODE_AUTH_CONTENT;
+    clearReadAuthFileCacheForTests();
+  });
+
+  afterEach(() => {
+    if (originalAuthContent === undefined) {
+      delete process.env.OPENCODE_AUTH_CONTENT;
+    } else {
+      process.env.OPENCODE_AUTH_CONTENT = originalAuthContent;
+    }
+    clearReadAuthFileCacheForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("atomically replaces only the matching xAI record", async () => {
+    writeFileSync(
+      authFile,
+      JSON.stringify({
+        companion: { type: "oauth", access: "companion-access", custom: "preserve-me" },
+        xai: {
+          type: "oauth",
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: 100,
+          accountId: "account-1",
+        },
+      }),
+      { encoding: "utf8", mode: 0o600 },
+    );
+
+    await expect(isCurrentXaiOAuth({ access: "old-access", refresh: "old-refresh" })).resolves.toBe(
+      true,
+    );
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "new-access",
+        refresh: "new-refresh",
+        expires: 200,
+      }),
+    ).resolves.toBe(true);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual({
+      companion: { type: "oauth", access: "companion-access", custom: "preserve-me" },
+      xai: {
+        type: "oauth",
+        access: "new-access",
+        refresh: "new-refresh",
+        expires: 200,
+        accountId: "account-1",
+      },
+    });
+    expect(statSync(authFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not overwrite an xAI record changed by OpenCode", async () => {
+    const original = {
+      xai: { type: "oauth", access: "newer-access", refresh: "newer-refresh", expires: 300 },
+    };
+    writeFileSync(authFile, JSON.stringify(original), { encoding: "utf8", mode: 0o600 });
+
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "refreshed-access",
+        refresh: "refreshed-refresh",
+        expires: 400,
+      }),
+    ).resolves.toBe(false);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual(original);
+  });
+
+  it("does not mutate file-backed auth when OPENCODE_AUTH_CONTENT is active", async () => {
+    const original = {
+      xai: { type: "oauth", access: "old-access", refresh: "old-refresh", expires: 100 },
+    };
+    writeFileSync(authFile, JSON.stringify(original), { encoding: "utf8", mode: 0o600 });
+    const environmentAuth = {
+      xai: { type: "oauth", access: "env-access", refresh: "env-refresh", expires: 200 },
+    };
+    process.env.OPENCODE_AUTH_CONTENT = JSON.stringify(environmentAuth);
+
+    await expect(readAuthFile()).resolves.toEqual(environmentAuth);
+
+    await expect(isCurrentXaiOAuth({ access: "old-access", refresh: "old-refresh" })).resolves.toBe(
+      false,
+    );
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "refreshed-access",
+        refresh: "refreshed-refresh",
+        expires: 200,
+      }),
+    ).resolves.toBe(false);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual(original);
+  });
+});

--- a/tests/lib.xai.test.ts
+++ b/tests/lib.xai.test.ts
@@ -1,34 +1,74 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import superGrokWeeklyFixture from "./fixtures/xai/supergrok-weekly.json";
-import { hasXaiOAuth, periodKindLabel, queryXaiQuota, resolveXaiOAuth } from "../src/lib/xai.js";
 
-vi.mock("../src/lib/opencode-auth.js", () => ({
+const mocks = vi.hoisted(() => ({
+  hasOpenCodeAuthContentOverride: vi.fn(),
+  isCurrentXaiOAuth: vi.fn(),
   readAuthFile: vi.fn(),
   readAuthFileCached: vi.fn(),
+  updateCurrentXaiOAuth: vi.fn(),
 }));
 
-async function mockConfiguredAuth(overrides: Record<string, unknown> = {}): Promise<void> {
-  const { readAuthFile } = await import("../src/lib/opencode-auth.js");
-  (readAuthFile as any).mockResolvedValueOnce({
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  hasOpenCodeAuthContentOverride: mocks.hasOpenCodeAuthContentOverride,
+  isCurrentXaiOAuth: mocks.isCurrentXaiOAuth,
+  readAuthFile: mocks.readAuthFile,
+  readAuthFileCached: mocks.readAuthFileCached,
+  updateCurrentXaiOAuth: mocks.updateCurrentXaiOAuth,
+}));
+
+import {
+  clearXaiOAuthRefreshForTests,
+  hasXaiOAuth,
+  periodKindLabel,
+  queryXaiQuota,
+  resolveXaiOAuth,
+} from "../src/lib/xai.js";
+
+function configureAuth(overrides: Record<string, unknown> = {}): void {
+  mocks.readAuthFile.mockResolvedValueOnce({
     xai: {
       type: "oauth",
       access: "token-1",
-      expires: Date.now() + 60_000,
+      expires: Date.now() + 10 * 60_000,
       ...overrides,
     },
   });
 }
 
+function quotaResponse(): Response {
+  return new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.hasOpenCodeAuthContentOverride.mockReturnValue(false);
+  mocks.isCurrentXaiOAuth.mockReset();
+  mocks.readAuthFile.mockReset();
+  mocks.readAuthFileCached.mockReset();
+  mocks.updateCurrentXaiOAuth.mockReset();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  clearXaiOAuthRefreshForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  clearXaiOAuthRefreshForTests();
+});
+
 describe("xAI auth resolution", () => {
-  it("resolves only the read-only xai OAuth access token", () => {
+  it("resolves only the xAI OAuth access and refresh tokens", () => {
     expect(
       resolveXaiOAuth({
-        xai: { type: "oauth", access: " token-1 ", refresh: "ignored", expires: 123 },
+        xai: { type: "oauth", access: " token-1 ", refresh: " refresh-1 ", expires: 123 },
       }),
     ).toEqual({
       state: "configured",
       accessToken: "token-1",
+      refreshToken: "refresh-1",
       expiresAt: 123,
     });
 
@@ -47,25 +87,15 @@ describe("xAI auth resolution", () => {
     ).toEqual({
       state: "configured",
       accessToken: "token-1",
+      refreshToken: undefined,
       expiresAt: undefined,
     });
   });
 });
 
 describe("queryXaiQuota", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllGlobals();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
-  });
-
   it("returns null for missing, wrong-type, and incomplete auth", async () => {
-    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
-    (readAuthFile as any)
+    mocks.readAuthFile
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ xai: { type: "api", key: "xai-key" } })
       .mockResolvedValueOnce({ xai: { type: "oauth", refresh: "refresh-only" } });
@@ -75,9 +105,10 @@ describe("queryXaiQuota", () => {
     await expect(queryXaiQuota()).resolves.toBeNull();
   });
 
-  it("does not refresh, fetch, or write an expired token", async () => {
-    const { readAuthFile, readAuthFileCached } = await import("../src/lib/opencode-auth.js");
-    (readAuthFile as any).mockResolvedValueOnce({
+  it("refreshes expired OAuth, persists it, then queries quota", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T00:00:00.000Z"));
+    mocks.readAuthFile.mockResolvedValueOnce({
       xai: {
         type: "oauth",
         access: "expired-token",
@@ -85,28 +116,19 @@ describe("queryXaiQuota", () => {
         expires: Date.now() - 1_000,
       },
     });
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(queryXaiQuota()).resolves.toEqual({
-      success: false,
-      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
-    });
-    expect(readAuthFile).toHaveBeenCalledOnce();
-    expect(readAuthFileCached).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("reads the refreshed OAuth entry instead of a stale cached token", async () => {
-    const { readAuthFile, readAuthFileCached } = await import("../src/lib/opencode-auth.js");
-    (readAuthFileCached as any).mockResolvedValueOnce({
-      xai: { type: "oauth", access: "stale-token", expires: Date.now() - 1_000 },
-    });
-    (readAuthFile as any).mockResolvedValueOnce({
-      xai: { type: "oauth", access: "fresh-token", expires: Date.now() + 60_000 },
-    });
-    const fetchMock = vi.fn(
-      async () => new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 }),
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(true);
+    mocks.updateCurrentXaiOAuth.mockResolvedValueOnce(true);
+    const fetchMock = vi.fn(async (url: string) =>
+      url === "https://auth.x.ai/oauth2/token"
+        ? new Response(
+            JSON.stringify({
+              access_token: "refreshed-access",
+              refresh_token: "refreshed-refresh",
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          )
+        : quotaResponse(),
     ) as any;
     vi.stubGlobal("fetch", fetchMock);
 
@@ -114,8 +136,169 @@ describe("queryXaiQuota", () => {
       success: true,
       window: { percentRemaining: 95, kind: "weekly" },
     });
-    expect(readAuthFile).toHaveBeenCalledOnce();
-    expect(readAuthFileCached).not.toHaveBeenCalled();
+    expect(mocks.updateCurrentXaiOAuth).toHaveBeenCalledWith({
+      expectedAccess: "expired-token",
+      expectedRefresh: "refresh-1",
+      access: "refreshed-access",
+      refresh: "refreshed-refresh",
+      expires: Date.parse("2026-07-23T01:00:00.000Z"),
+    });
+    const refreshRequest = fetchMock.mock.calls[0]![1] as RequestInit;
+    expect(refreshRequest).toMatchObject({
+      method: "POST",
+      headers: expect.objectContaining({ "Content-Type": "application/x-www-form-urlencoded" }),
+    });
+    expect(new URLSearchParams(String(refreshRequest.body)).get("grant_type")).toBe(
+      "refresh_token",
+    );
+    expect(new URLSearchParams(String(refreshRequest.body)).get("refresh_token")).toBe("refresh-1");
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer refreshed-access" }),
+      }),
+    );
+  });
+
+  it("does not use a rotated refresh token when persistence detects changed auth", async () => {
+    const expiredAuth = {
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    };
+    mocks.readAuthFile.mockResolvedValue(expiredAuth);
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(true);
+    mocks.updateCurrentXaiOAuth.mockResolvedValueOnce(false);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "refreshed-access",
+              refresh_token: "refreshed-refresh",
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI OAuth changed during refresh; retry or reconnect xAI",
+    });
+  });
+
+  it("uses an xAI credential refreshed by another plugin context", async () => {
+    const expiredAuth = {
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    };
+    mocks.readAuthFile
+      .mockResolvedValueOnce(expiredAuth)
+      .mockResolvedValueOnce(expiredAuth)
+      .mockResolvedValueOnce({
+        xai: {
+          type: "oauth",
+          access: "other-context-access",
+          refresh: "other-context-refresh",
+          expires: Date.now() + 10 * 60_000,
+        },
+      });
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(false);
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer other-context-access" }),
+      }),
+    );
+    expect(mocks.updateCurrentXaiOAuth).not.toHaveBeenCalled();
+  });
+
+  it("does not consume a refresh token when OPENCODE_AUTH_CONTENT owns credentials", async () => {
+    mocks.readAuthFile.mockResolvedValueOnce({
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    });
+    mocks.hasOpenCodeAuthContentOverride.mockReturnValue(true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI OAuth token expired; update OPENCODE_AUTH_CONTENT or reconnect xAI",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shares one OAuth refresh between concurrent quota requests", async () => {
+    const expiredAuth = {
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    };
+    mocks.readAuthFile.mockResolvedValue(expiredAuth);
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(true);
+    mocks.updateCurrentXaiOAuth.mockResolvedValueOnce(true);
+    let resolveRefresh: ((response: Response) => void) | undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const fetchMock = vi.fn(async (url: string) =>
+      url === "https://auth.x.ai/oauth2/token" ? refreshResponse : quotaResponse(),
+    ) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = queryXaiQuota();
+    const second = queryXaiQuota();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    resolveRefresh?.(
+      new Response(
+        JSON.stringify({ access_token: "refreshed-access", refresh_token: "refreshed-refresh" }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ success: true }),
+      expect.objectContaining({ success: true }),
+    ]);
+    expect(mocks.isCurrentXaiOAuth).toHaveBeenCalledOnce();
+    expect(mocks.updateCurrentXaiOAuth).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("reads the current auth file instead of a stale cached token", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      xai: { type: "oauth", access: "stale-token", expires: Date.now() - 1_000 },
+    });
+    configureAuth({ access: "fresh-token" });
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({
+      success: true,
+      window: { percentRemaining: 95, kind: "weekly" },
+    });
+    expect(mocks.readAuthFileCached).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
       expect.objectContaining({
@@ -125,11 +308,8 @@ describe("queryXaiQuota", () => {
   });
 
   it("maps the exact PR fixture through one fixed authenticated GET", async () => {
-    await mockConfiguredAuth();
-
-    const fetchMock = vi.fn(
-      async () => new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 }),
-    ) as any;
+    configureAuth();
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(queryXaiQuota({ requestTimeoutMs: 3_210 })).resolves.toEqual({
@@ -142,7 +322,6 @@ describe("queryXaiQuota", () => {
       },
     });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://cli-chat-proxy.grok.com/v1/billing?format=credits");
     expect(init).toEqual({
@@ -159,8 +338,25 @@ describe("queryXaiQuota", () => {
     expect(init).not.toHaveProperty("body");
   });
 
+  it("uses a fresh access-only credential without forcing a refresh", async () => {
+    mocks.readAuthFile.mockResolvedValueOnce({
+      xai: { type: "oauth", access: "access-only-token" },
+    });
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer access-only-token" }),
+      }),
+    );
+    expect(mocks.isCurrentXaiOAuth).not.toHaveBeenCalled();
+  });
+
   it("treats an omitted protobuf percentage as 0% used when a period exists", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -191,7 +387,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("uses the exact billingPeriodEnd reset fallback from the PR", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -221,8 +417,8 @@ describe("queryXaiQuota", () => {
   });
 
   it("rejects malformed percentages and response shapes", async () => {
-    await mockConfiguredAuth();
-    await mockConfiguredAuth();
+    configureAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi
@@ -252,7 +448,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("reports missing period data instead of inventing quota", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -268,7 +464,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("bounds and sanitizes HTTP errors without exposing the bearer token", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -288,7 +484,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("sanitizes network errors without exposing the bearer token", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -304,8 +500,7 @@ describe("queryXaiQuota", () => {
 
   it("returns the normalized timeout error", async () => {
     vi.useFakeTimers();
-    await mockConfiguredAuth();
-
+    configureAuth();
     const fetchMock = vi.fn((_url: string, init: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {
         init.signal?.addEventListener("abort", () => {


### PR DESCRIPTION
## Summary
- Refresh expired or near-expiry xAI OAuth before startup quota requests.
- Persist only the refreshed xAI auth entry atomically, preserving unrelated entries.
- Cover environment overrides, concurrent refreshes, and safe write failures.

## Validation
- pnpm test
- pnpm run build:check
- node dist/bin/opencode-quota.js show --provider xai