### PR TITLE
feat(telemetry): expose cached quota gauges

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,13 @@ More ways to use it:
 
 - Check quota from a terminal with `opencode-quota show`
 - Use JSON output in scripts, status bars, CI checks, and other tools
+- Publish opt-in OpenTelemetry quota and cache-age gauges through a host-managed global metrics provider
 - Run the same slash commands in the TUI, Web, and Desktop
 - Tune reset countdown precision without changing the default compact display
 - Choose current-session or descendant-tree token totals across `/quota`, toasts, the sidebar, and the compact input line
 - Diagnose authentication, quota sources, pricing, and maintainer notices
+
+OpenTelemetry metrics are disabled by default and never configure an SDK, exporter, timer, or extra provider request. Stock OpenCode 1.18.4 configures OTLP logs/traces but not a global metrics provider, so see [External integration](docs/readme/external-integration.md#option-3-publish-opentelemetry-metrics) for the required host setup and privacy contract.
 
 See [Configuration](docs/readme/configuration.md) for UI options and [Manual install](docs/readme/manual-install.md) for setup details.
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -363,4 +363,12 @@ Xiaomi MiMo has no `quota-toast.json` credential or endpoint setting. Use `MIMO_
 | `export.enabled` | `false` | Write a JSON export file after each TUI background refresh.                                                                 |
 | `export.path`    | `""`    | Export file path. Empty string uses the XDG default: `$XDG_CACHE_HOME/opencode/quota-export.json`. Supports `~/` expansion. |
 
+### Telemetry settings
+
+| Option              | Default | Meaning                                                                                                                         |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `telemetry.enabled` | `false` | Publish quota consumption and cache-age gauges through the host's global OpenTelemetry `MeterProvider`; adds no provider calls. |
+
+See [External integration](external-integration.md#option-3-publish-opentelemetry-metrics) for metric names, attributes, setup, and privacy behavior.
+
 </details>

--- a/docs/readme/external-integration.md
+++ b/docs/readme/external-integration.md
@@ -6,12 +6,13 @@ Use this page when a script, status bar, or CI job needs quota data.
 
 Choose one source:
 
-| Source                       | Best for                                              |
-| ---------------------------- | ----------------------------------------------------- |
-| `opencode-quota show --json` | Reading the latest cached data from a command         |
-| Export file                  | Reading the same data often without running a command |
+| Source                       | Best for                                                |
+| ---------------------------- | ------------------------------------------------------- |
+| `opencode-quota show --json` | Reading the latest cached data from a command           |
+| Export file                  | Reading the same data often without running a command   |
+| OpenTelemetry metrics        | Monitoring quota consumption and freshness in a backend |
 
-Both read OpenCode Quota's local cache. They do not contact providers.
+All three reuse normalized quota data already collected by OpenCode Quota. They do not add provider requests.
 
 ## JSON export v2
 
@@ -74,6 +75,44 @@ Usually that means:
 ```
 
 The TUI updates this file after each home-bottom background refresh, about every 60 seconds. Write errors are logged as warnings and never break TUI rendering.
+
+## Option 3: publish OpenTelemetry metrics
+
+Use this when the OpenCode host already configures an OpenTelemetry SDK and exporter. OpenCode Quota reuses the global `MeterProvider`; it does not install an SDK, configure OTLP, own an exporter, or add a refresh timer.
+
+Add this to `opencode-quota/quota-toast.json`:
+
+```jsonc
+{
+  "telemetry": {
+    "enabled": true,
+  },
+}
+```
+
+Telemetry is disabled by default. The host must make `@opentelemetry/api` available and register its global `MeterProvider`. If the API or a provider is unavailable, OpenCode Quota continues normally and emits no metrics.
+
+OpenCode Quota publishes observable gauges from the latest normalized cache snapshot:
+
+| Metric                     | Unit | Meaning                                                                                                       |
+| -------------------------- | ---- | ------------------------------------------------------------------------------------------------------------- |
+| `opencode.quota.consumed`  | `1`  | Consumed ratio derived from `percentRemaining`: `(100 - percentRemaining) / 100`, with a lower bound of zero. |
+| `opencode.quota.cache.age` | `s`  | Seconds since that normalized provider snapshot was fetched; the timestamp is preserved across cache hits.    |
+
+`opencode.quota.consumed` is `0` when unused and `1` at 100% consumed. It can exceed `1` when a provider reports quota below zero. Human-readable value rows such as balances are not converted into metrics.
+
+Both gauges use the same bounded attributes:
+
+- `quota.provider`
+- `quota.result_type`
+- `quota.window`
+- `quota.acquisition_method`
+- `quota.ownership`
+- `quota.authority`
+
+Raw row labels are reduced to a bounded window classification such as `five_hour`, `day`, `week`, or `month`; unclassified rows use `unspecified`. Display names, account identifiers, configured source IDs, credentials, URLs, paths, models, errors, and raw provider responses are never metric attributes. When multiple rows have identical safe attributes, the gauge reports the highest consumed ratio.
+
+Metric callbacks only read in-memory snapshots. They never contact a provider or read the cache, and telemetry failures never affect collection, commands, exports, or UI behavior.
 
 ## Copy-paste examples
 

--- a/docs/readme/external-integration.md
+++ b/docs/readme/external-integration.md
@@ -12,7 +12,7 @@ Choose one source:
 | Export file                  | Reading the same data often without running a command   |
 | OpenTelemetry metrics        | Monitoring quota consumption and freshness in a backend |
 
-All three reuse normalized quota data already collected by OpenCode Quota. They do not add provider requests.
+All three reuse normalized quota data collected during normal OpenCode Quota activity. They do not add provider requests.
 
 ## JSON export v2
 
@@ -78,7 +78,7 @@ The TUI updates this file after each home-bottom background refresh, about every
 
 ## Option 3: publish OpenTelemetry metrics
 
-Use this when the OpenCode host already configures an OpenTelemetry SDK and exporter. OpenCode Quota reuses the global `MeterProvider`; it does not install an SDK, configure OTLP, own an exporter, or add a refresh timer.
+Use this when the OpenCode host already configures an OpenTelemetry metrics SDK, global `MeterProvider`, reader, and exporter. OpenCode Quota reuses that global provider; it does not install an SDK, configure OTLP, own an exporter, or add a refresh timer.
 
 Add this to `opencode-quota/quota-toast.json`:
 
@@ -90,29 +90,30 @@ Add this to `opencode-quota/quota-toast.json`:
 }
 ```
 
-Telemetry is disabled by default. The host must make `@opentelemetry/api` available and register its global `MeterProvider`. If the API or a provider is unavailable, OpenCode Quota continues normally and emits no metrics.
+Telemetry is disabled by default. `@opentelemetry/api` is an optional peer dependency, so a host can omit it safely. If the API or global metrics provider is unavailable, OpenCode Quota continues normally and emits no metrics.
 
-OpenCode Quota publishes observable gauges from the latest normalized cache snapshot:
+OpenCode 1.18.4 includes OpenTelemetry API support and can configure OTLP logs and traces, but its built-in OTLP path does not register a global metrics `MeterProvider`. On that version, these gauges remain a no-op unless another host integration configures global OpenTelemetry metrics before OpenCode Quota is enabled.
 
-| Metric                     | Unit | Meaning                                                                                                       |
-| -------------------------- | ---- | ------------------------------------------------------------------------------------------------------------- |
-| `opencode.quota.consumed`  | `1`  | Consumed ratio derived from `percentRemaining`: `(100 - percentRemaining) / 100`, with a lower bound of zero. |
-| `opencode.quota.cache.age` | `s`  | Seconds since that normalized provider snapshot was fetched; the timestamp is preserved across cache hits.    |
+OpenCode Quota publishes observable gauges from normalized results seen during normal quota activity:
 
-`opencode.quota.consumed` is `0` when unused and `1` at 100% consumed. It can exceed `1` when a provider reports quota below zero. Human-readable value rows such as balances are not converted into metrics.
+| Metric                     | Unit | Meaning                                                                                            |
+| -------------------------- | ---- | -------------------------------------------------------------------------------------------------- |
+| `opencode.quota.consumed`  | `1`  | Consumed ratio derived from finite percentage rows: `clamp((100 - percentRemaining) / 100, 0, 1)`. |
+| `opencode.quota.cache.age` | `s`  | Nonnegative seconds since the original stored cache timestamp; uncached results do not report age. |
 
-Both gauges use the same bounded attributes:
+`opencode.quota.consumed` is `0` when unused and `1` at or above 100% consumed. Human-readable value rows such as balances and non-finite percentages are not converted into metrics.
+
+Consumed-quota series use only these bounded attributes:
 
 - `quota.provider`
 - `quota.result_type`
 - `quota.window`
-- `quota.acquisition_method`
-- `quota.ownership`
-- `quota.authority`
 
-Raw row labels are reduced to a bounded window classification such as `five_hour`, `day`, `week`, or `month`; unclassified rows use `unspecified`. Display names, account identifiers, configured source IDs, credentials, URLs, paths, models, errors, and raw provider responses are never metric attributes. When multiple rows have identical safe attributes, the gauge reports the highest consumed ratio.
+Cache-age series use only `quota.provider`. Built-in provider IDs map to the maintained canonical catalog, configured aggregate sources map to `custom`, and unknown IDs map to `other`. Windows map to `rpm`, `five_hour`, `hour`, `day`, `week`, `month`, `year`, `mcp`, `code_review`, or `unknown`. Result types are limited to `quota`, `rate_limit`, `usage`, `spend`, `budget`, `balance`, or `status`.
 
-Metric callbacks only read in-memory snapshots. They never contact a provider or read the cache, and telemetry failures never affect collection, commands, exports, or UI behavior.
+Display names, account identifiers, configured source IDs, credentials, URLs, paths, models, errors, diagnostic fields, and raw provider responses are never metric attributes. When privacy-safe dimensions collapse several rows, sources, or project scopes, the gauges report the maximum consumed ratio or maximum cache age. Series are emitted in deterministic order.
+
+Metric callbacks only read in-memory snapshots populated by normal quota work. They never contact a provider, perform provider discovery, or read cache files. Telemetry failures never affect collection, commands, exports, cache schema, or UI behavior, and telemetry state is not added to JSON output.
 
 ## Copy-paste examples
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-typescript": "^7.27.1",
     "@opencode-ai/plugin": "1.18.1",
+    "@opentelemetry/api": "^1.9.1",
     "@types/node": "^22.0.0",
     "babel-preset-solid": "^1.9.12",
     "husky": "^9.1.7",
@@ -104,7 +105,13 @@
     "better-sqlite3": "^12.10.0"
   },
   "peerDependencies": {
-    "@opencode-ai/plugin": "^1.4.3"
+    "@opencode-ai/plugin": "^1.4.3",
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@opencode-ai/plugin':
         specifier: 1.18.1
         version: 1.18.1(@opentui/core@0.4.3(typescript@5.9.3)(web-tree-sitter@0.25.10))(@opentui/solid@0.4.3(solid-js@1.9.12)(typescript@5.9.3)(web-tree-sitter@0.25.10))
+      '@opentelemetry/api':
+        specifier: ^1.9.1
+        version: 1.9.1
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.6
@@ -59,7 +62,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.17
-        version: 4.0.17(@types/node@22.19.6)(yaml@2.8.3)
+        version: 4.0.17(@opentelemetry/api@1.9.1)(@types/node@22.19.6)(yaml@2.8.3)
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
@@ -432,6 +435,10 @@ packages:
 
   '@opencode-ai/sdk@1.18.1':
     resolution: {integrity: sha512-2mX9SXSDVtZ9i2yCOiXDXKx981EJp/ObUtaThUNn16jkjfwX/1j8r+UR/BKUmBLYq+zle7TtpXreXuO+gtVjKA==}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@opentui/core-darwin-arm64@0.4.3':
     resolution: {integrity: sha512-p5+7AAxpxGuDGagyQfewKtmTFnN7THvTVY4FyKqUtJomNaHdQXPHztapNNzMx0DGWbwOUbVKzpL+yc3CZY3chQ==}
@@ -1810,6 +1817,8 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@opentelemetry/api@1.9.1': {}
+
   '@opentui/core-darwin-arm64@0.4.3':
     optional: true
 
@@ -2715,7 +2724,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.8.3
 
-  vitest@4.0.17(@types/node@22.19.6)(yaml@2.8.3):
+  vitest@4.0.17(@opentelemetry/api@1.9.1)(@types/node@22.19.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.17
       '@vitest/mocker': 4.0.17(vite@7.3.2(@types/node@22.19.6)(yaml@2.8.3))
@@ -2738,6 +2747,7 @@ snapshots:
       vite: 7.3.2(@types/node@22.19.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 22.19.6
     transitivePeerDependencies:
       - jiti

--- a/scripts/smoke-packed-package.mjs
+++ b/scripts/smoke-packed-package.mjs
@@ -46,12 +46,15 @@ const workdir = await mkdtemp(path.join(tmpdir(), "opencode-quota-package-smoke-
 try {
   run("npm", ["init", "-y"], workdir);
   run("npm", ["install", "--omit=dev", tarball], workdir);
+  run("npm", ["install", "--omit=dev", "@opentelemetry/api@1.9.0"], workdir);
 
   const moduleSmoke = `
     import assert from "node:assert/strict";
     import { readFile } from "node:fs/promises";
-    import { fileURLToPath } from "node:url";
+    import path from "node:path";
+    import { fileURLToPath, pathToFileURL } from "node:url";
 
+    const rootExportUrl = import.meta.resolve("@slkiser/opencode-quota");
     await import("@slkiser/opencode-quota");
     await import("@slkiser/opencode-quota/server");
 
@@ -68,9 +71,56 @@ try {
       await readFile("node_modules/@slkiser/opencode-quota/package.json", "utf8"),
     );
     assert.equal(pkg.engines?.node, ">=22.0.0");
+    assert.equal(pkg.peerDependencies?.["@opentelemetry/api"], "^1.9.0");
+    assert.equal(pkg.peerDependenciesMeta?.["@opentelemetry/api"]?.optional, true);
+
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(rootExportUrl)), "..");
+    const telemetry = await import(
+      pathToFileURL(path.join(packageRoot, "dist", "lib", "quota-telemetry.js"))
+    );
+    assert.ok(
+      telemetry.configureQuotaTelemetry({
+        owner: {},
+        enabled: true,
+        identity: "packed-present",
+      }),
+    );
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
   `;
 
   run(process.execPath, ["--input-type=module", "--eval", moduleSmoke], workdir);
+
+  await rm(path.join(workdir, "node_modules", "@opentelemetry", "api"), {
+    recursive: true,
+    force: true,
+  });
+  const absentOptionalDependencySmoke = `
+    import assert from "node:assert/strict";
+    import { readFile } from "node:fs/promises";
+    import path from "node:path";
+    import { fileURLToPath, pathToFileURL } from "node:url";
+
+    await assert.rejects(import("@opentelemetry/api"));
+    const rootExportUrl = import.meta.resolve("@slkiser/opencode-quota");
+    await import("@slkiser/opencode-quota");
+    await import("@slkiser/opencode-quota/server");
+    const tuiExportPath = fileURLToPath(import.meta.resolve("@slkiser/opencode-quota/tui"));
+    assert.ok((await readFile(tuiExportPath, "utf8")).includes("@slkiser/opencode-quota"));
+
+    const packageRoot = path.resolve(path.dirname(fileURLToPath(rootExportUrl)), "..");
+    const telemetry = await import(
+      pathToFileURL(path.join(packageRoot, "dist", "lib", "quota-telemetry.js"))
+    );
+    assert.ok(
+      telemetry.configureQuotaTelemetry({
+        owner: {},
+        enabled: true,
+        identity: "packed-absent",
+      }),
+    );
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+  `;
+  run(process.execPath, ["--input-type=module", "--eval", absentOptionalDependencySmoke], workdir);
 
   const cliPath = path.join(
     workdir,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -82,6 +82,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "layout.tinyAt",
   "export.enabled",
   "export.path",
+  "telemetry.enabled",
 ] as const;
 
 export type QuotaToastSettingSourceKey = (typeof QUOTA_TOAST_SETTING_SOURCE_KEYS)[number];
@@ -141,6 +142,7 @@ type TuiCompactStatusPatch = Partial<QuotaToastConfig["tuiCompactStatus"]>;
 type MaintainerAnnouncementsPatch = Partial<QuotaToastConfig["maintainerAnnouncements"]>;
 type LayoutPatch = Partial<QuotaToastConfig["layout"]>;
 type ExportConfigPatch = Partial<QuotaToastConfig["export"]>;
+type TelemetryConfigPatch = Partial<QuotaToastConfig["telemetry"]>;
 
 type ValidatedQuotaToastPatch = {
   enabled?: boolean;
@@ -175,6 +177,7 @@ type ValidatedQuotaToastPatch = {
   maintainerAnnouncements?: MaintainerAnnouncementsPatch;
   layout?: LayoutPatch;
   export?: ExportConfigPatch;
+  telemetry?: TelemetryConfigPatch;
 };
 
 type ConfigLayerScope = "global" | "workspace";
@@ -326,6 +329,7 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
     maintainerAnnouncements: { ...config.maintainerAnnouncements },
     layout: { ...config.layout },
     export: { ...config.export },
+    telemetry: { ...config.telemetry },
   };
 }
 
@@ -524,6 +528,20 @@ function extractExportConfigPatch(value: unknown): ExportConfigPatch | undefined
 
   if (hasOwnKey(value, "path") && typeof value.path === "string") {
     patch.path = value.path;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
+}
+
+function extractTelemetryConfigPatch(value: unknown): TelemetryConfigPatch | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const patch: TelemetryConfigPatch = {};
+
+  if (hasOwnKey(value, "enabled") && typeof value.enabled === "boolean") {
+    patch.enabled = value.enabled;
   }
 
   return Object.keys(patch).length > 0 ? patch : undefined;
@@ -751,6 +769,13 @@ function extractValidatedQuotaToastPatch(
     const exportConfig = extractExportConfigPatch(quotaToastConfig.export);
     if (exportConfig) {
       patch.export = exportConfig;
+    }
+  }
+
+  if (hasOwnKey(quotaToastConfig, "telemetry")) {
+    const telemetry = extractTelemetryConfigPatch(quotaToastConfig.telemetry);
+    if (telemetry) {
+      patch.telemetry = telemetry;
     }
   }
 
@@ -999,6 +1024,11 @@ function applyValidatedQuotaToastPatch(
       config.export.path = patch.export.path!;
       applySettingSource(settingSources, "export.path", sourcePath);
     }
+  }
+
+  if (patch.telemetry && hasOwnKey(patch.telemetry, "enabled")) {
+    config.telemetry.enabled = patch.telemetry.enabled!;
+    applySettingSource(settingSources, "telemetry.enabled", sourcePath);
   }
 }
 

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -1,6 +1,7 @@
 import type { CursorQuotaPlan, OpenCodeGoWindowKey } from "./types.js";
 import type { QuotaProviderDefinition } from "./quota-providers.js";
 import type { RuntimeProviderIdResolver } from "./runtime-provider-ids.js";
+import type { QuotaTelemetryToken } from "./quota-telemetry.js";
 
 /**
  * Normalized quota output model.
@@ -223,8 +224,7 @@ export interface QuotaProviderContext {
     currentProviderID?: string;
     enabledProviders: string[] | "auto";
     quotaProviders?: QuotaProviderDefinition[];
-    telemetryEnabled?: boolean;
-    telemetryGeneration?: number;
+    telemetryToken?: QuotaTelemetryToken;
   };
 }
 

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -223,6 +223,8 @@ export interface QuotaProviderContext {
     currentProviderID?: string;
     enabledProviders: string[] | "auto";
     quotaProviders?: QuotaProviderDefinition[];
+    telemetryEnabled?: boolean;
+    telemetryGeneration?: number;
   };
 }
 

--- a/src/lib/quota-export.ts
+++ b/src/lib/quota-export.ts
@@ -48,6 +48,7 @@ export function createExportProviderContext(runtime: QuotaRuntimeContext): Quota
       showSessionTokens: false,
     },
     session: {},
+    configureTelemetry: false,
   });
 }
 

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -17,6 +17,7 @@ import { fetchSessionTokensForDisplay } from "./session-tokens.js";
 import { getQuotaProviderDisplayLabel, normalizeQuotaProviderId } from "./provider-metadata.js";
 import { isCursorProviderId } from "./cursor-pricing.js";
 import { fetchQuotaProviderResult } from "./quota-state.js";
+import { configureQuotaTelemetry, retainQuotaTelemetryProviders } from "./quota-telemetry.js";
 import { createQuotaProviderRuntimeContext } from "./quota-runtime-context.js";
 import {
   createRuntimeProviderIdResolver,
@@ -164,6 +165,7 @@ export async function resolveQuotaRenderSelection(params: {
   resolveRuntimeProviderIds?: RuntimeProviderIdResolver;
 }): Promise<QuotaRenderSelection | null> {
   const { client, config, request } = params;
+  configureQuotaTelemetry(config.enabled && config.telemetry?.enabled === true);
   if (!config.enabled) return null;
 
   const allProviders = params.providers ?? getProviders();
@@ -637,6 +639,7 @@ export async function collectQuotaRenderData(params: {
   );
 
   const active = availability.filter((item) => item.ok).map((item) => item.provider);
+  retainQuotaTelemetryProviders(active.map((provider) => provider.id));
   const explicitProviderIssues = buildExplicitProviderIssues({
     selection,
     availability,

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -17,7 +17,7 @@ import { fetchSessionTokensForDisplay } from "./session-tokens.js";
 import { getQuotaProviderDisplayLabel, normalizeQuotaProviderId } from "./provider-metadata.js";
 import { isCursorProviderId } from "./cursor-pricing.js";
 import { fetchQuotaProviderResult } from "./quota-state.js";
-import { configureQuotaTelemetry, retainQuotaTelemetryProviders } from "./quota-telemetry.js";
+import { retainQuotaTelemetryProviders } from "./quota-telemetry.js";
 import { createQuotaProviderRuntimeContext } from "./quota-runtime-context.js";
 import {
   createRuntimeProviderIdResolver,
@@ -165,16 +165,6 @@ export async function resolveQuotaRenderSelection(params: {
   resolveRuntimeProviderIds?: RuntimeProviderIdResolver;
 }): Promise<QuotaRenderSelection | null> {
   const { client, config, request } = params;
-  configureQuotaTelemetry(config.enabled && config.telemetry?.enabled === true);
-  if (!config.enabled) return null;
-
-  const allProviders = params.providers ?? getProviders();
-  const isAutoMode = config.enabledProviders === "auto";
-  const providers = isAutoMode
-    ? allProviders
-    : allProviders.filter((provider) => config.enabledProviders.includes(provider.id));
-  if (!isAutoMode && providers.length === 0) return null;
-
   let currentModel: string | undefined;
   let currentProviderID: string | undefined;
   if (config.onlyCurrentModel && request?.sessionMeta) {
@@ -195,6 +185,20 @@ export async function resolveQuotaRenderSelection(params: {
       },
     },
   });
+  if (!config.enabled) return null;
+
+  const allProviders = params.providers ?? getProviders();
+  const isAutoMode = config.enabledProviders === "auto";
+  const providers = isAutoMode
+    ? allProviders
+    : allProviders.filter((provider) => config.enabledProviders.includes(provider.id));
+  if (!isAutoMode && providers.length === 0) {
+    retainQuotaTelemetryProviders({
+      token: ctx.config.telemetryToken,
+      providerIds: [],
+    });
+    return null;
+  }
 
   const hasCurrentSelection = hasCurrentQuotaSelection({ currentModel, currentProviderID });
   const filteringByCurrentSelection = config.onlyCurrentModel && hasCurrentSelection;
@@ -619,6 +623,10 @@ export async function collectQuotaRenderData(params: {
   }
 
   if (selection.waitingForCurrentSelection) {
+    retainQuotaTelemetryProviders({
+      token: selection.ctx.config.telemetryToken,
+      providerIds: [],
+    });
     return {
       selection,
       availability: [],
@@ -639,7 +647,10 @@ export async function collectQuotaRenderData(params: {
   );
 
   const active = availability.filter((item) => item.ok).map((item) => item.provider);
-  retainQuotaTelemetryProviders(active.map((provider) => provider.id));
+  retainQuotaTelemetryProviders({
+    token: selection.ctx.config.telemetryToken,
+    providerIds: active.map((provider) => provider.id),
+  });
   const explicitProviderIssues = buildExplicitProviderIssues({
     selection,
     availability,

--- a/src/lib/quota-runtime-context.ts
+++ b/src/lib/quota-runtime-context.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { LoadConfigMeta } from "./config.js";
 import type { QuotaProvider, QuotaProviderContext } from "./entries.js";
 import type { QuotaToastConfig } from "./types.js";
@@ -31,6 +33,7 @@ export interface ResolveQuotaRuntimeContextParams {
   includeSessionMeta?: boolean | ((config: QuotaToastConfig) => boolean);
   configMeta?: LoadConfigMeta;
   providers?: QuotaProvider[];
+  configureTelemetry?: boolean;
 }
 
 export interface QuotaRuntimeContext {
@@ -67,8 +70,6 @@ export async function resolveQuotaRuntimeContext(
     (await loadConfig(params.client, configMeta, {
       configRootDir: roots.configRoot,
     }));
-  configureQuotaTelemetry(config.enabled && config.telemetry?.enabled === true);
-
   let sessionMeta = params.sessionMeta;
   if (
     !sessionMeta &&
@@ -80,6 +81,13 @@ export async function resolveQuotaRuntimeContext(
     })
   ) {
     sessionMeta = await params.resolveSessionMeta(params.sessionID);
+  }
+  if (params.configureTelemetry !== false) {
+    configureRuntimeTelemetry({
+      client: params.client,
+      config,
+      session: { sessionMeta },
+    });
   }
 
   return {
@@ -112,9 +120,10 @@ export function createQuotaProviderRuntimeContext(runtime: {
   session: QuotaRuntimeContext["session"];
   resolveRuntimeProviderIds: RuntimeProviderIdResolver;
   configMeta?: Pick<LoadConfigMeta, "settingSources">;
+  configureTelemetry?: boolean;
 }): QuotaProviderContext {
-  const telemetryEnabled = runtime.config.enabled && runtime.config.telemetry?.enabled === true;
-  const telemetryGeneration = configureQuotaTelemetry(telemetryEnabled);
+  const telemetryToken =
+    runtime.configureTelemetry === false ? undefined : configureRuntimeTelemetry(runtime);
 
   return {
     client: runtime.client,
@@ -134,10 +143,45 @@ export function createQuotaProviderRuntimeContext(runtime: {
       enabledProviders:
         runtime.config.enabledProviders === "auto" ? "auto" : [...runtime.config.enabledProviders],
       quotaProviders: cloneQuotaProviders(runtime.config.quotaProviders),
-      telemetryEnabled,
-      telemetryGeneration,
+      telemetryToken,
       currentModel: runtime.session.sessionMeta?.modelID,
       currentProviderID: runtime.session.sessionMeta?.providerID,
     },
   };
+}
+
+function configureRuntimeTelemetry(runtime: {
+  client: QuotaRuntimeClient;
+  config: QuotaToastConfig;
+  session: QuotaRuntimeContext["session"];
+}) {
+  const telemetryEnabled = runtime.config.enabled && runtime.config.telemetry?.enabled === true;
+  const telemetryIdentity = createHash("sha256")
+    .update(
+      JSON.stringify([
+        "quota-telemetry-config-v1",
+        runtime.config.enabled,
+        runtime.config.telemetry?.enabled === true,
+        runtime.config.enabledProviders === "auto"
+          ? "auto"
+          : [...runtime.config.enabledProviders].sort(),
+        runtime.config.quotaProviders,
+        runtime.config.googleModels,
+        runtime.config.anthropicBinaryPath,
+        runtime.config.cursorPlan,
+        runtime.config.cursorIncludedApiUsd,
+        runtime.config.cursorBillingCycleStartDay,
+        runtime.config.opencodeGoWindows,
+        runtime.config.opencodeMonthlyLimit,
+        runtime.config.onlyCurrentModel,
+        runtime.session.sessionMeta?.providerID,
+        runtime.session.sessionMeta?.modelID,
+      ]),
+    )
+    .digest("hex");
+  return configureQuotaTelemetry({
+    owner: runtime.client,
+    enabled: telemetryEnabled,
+    identity: telemetryIdentity,
+  });
 }

--- a/src/lib/quota-runtime-context.ts
+++ b/src/lib/quota-runtime-context.ts
@@ -7,6 +7,7 @@ import { createLoadConfigMeta, loadConfig } from "./config.js";
 import { getProviders } from "../providers/registry.js";
 import { resolveRuntimeContextRoots } from "./config-file-utils.js";
 import { cloneQuotaProviders } from "./quota-providers.js";
+import { configureQuotaTelemetry } from "./quota-telemetry.js";
 import {
   createRuntimeProviderIdResolver,
   type RuntimeProviderIdResolver,
@@ -66,6 +67,7 @@ export async function resolveQuotaRuntimeContext(
     (await loadConfig(params.client, configMeta, {
       configRootDir: roots.configRoot,
     }));
+  configureQuotaTelemetry(config.enabled && config.telemetry?.enabled === true);
 
   let sessionMeta = params.sessionMeta;
   if (
@@ -111,6 +113,9 @@ export function createQuotaProviderRuntimeContext(runtime: {
   resolveRuntimeProviderIds: RuntimeProviderIdResolver;
   configMeta?: Pick<LoadConfigMeta, "settingSources">;
 }): QuotaProviderContext {
+  const telemetryEnabled = runtime.config.enabled && runtime.config.telemetry?.enabled === true;
+  const telemetryGeneration = configureQuotaTelemetry(telemetryEnabled);
+
   return {
     client: runtime.client,
     resolveRuntimeProviderIds: runtime.resolveRuntimeProviderIds,
@@ -129,6 +134,8 @@ export function createQuotaProviderRuntimeContext(runtime: {
       enabledProviders:
         runtime.config.enabledProviders === "auto" ? "auto" : [...runtime.config.enabledProviders],
       quotaProviders: cloneQuotaProviders(runtime.config.quotaProviders),
+      telemetryEnabled,
+      telemetryGeneration,
       currentModel: runtime.session.sessionMeta?.modelID,
       currentProviderID: runtime.session.sessionMeta?.providerID,
     },

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -13,6 +13,7 @@ import {
   selectEligibleQuotaProviderDefinitions,
 } from "./quota-providers.js";
 import { getPackageVersion } from "./version.js";
+import { updateQuotaTelemetrySnapshot } from "./quota-telemetry.js";
 
 const QUOTA_PROVIDER_CACHE_VERSION = 2 as const;
 const QUOTA_PROVIDER_CACHE_PACKAGE_VERSION_FALLBACK = "unknown";
@@ -509,6 +510,21 @@ async function resolveRuntimeEligibleQuotaProviders(
   }
 }
 
+function publishQuotaTelemetry(params: {
+  ctx: QuotaProviderContext;
+  providerId: string;
+  result: QuotaProviderResult;
+  timestamp: number;
+}): void {
+  updateQuotaTelemetrySnapshot({
+    enabled: params.ctx.config.telemetryEnabled === true,
+    generation: params.ctx.config.telemetryGeneration,
+    providerId: params.providerId,
+    result: params.result,
+    timestamp: params.timestamp,
+  });
+}
+
 export async function fetchQuotaProviderResult(params: {
   provider: QuotaProvider;
   ctx: QuotaProviderContext;
@@ -517,8 +533,19 @@ export async function fetchQuotaProviderResult(params: {
 }): Promise<QuotaProviderResult> {
   const { provider, ctx, ttlMs, bypassCache = false } = params;
 
-  if (bypassCache || isLiveLocalUsageProviderId(provider.id)) {
+  if (bypassCache) {
     return fetchValidatedProviderResult(provider, ctx);
+  }
+
+  if (isLiveLocalUsageProviderId(provider.id)) {
+    const snapshot = await fetchValidatedProviderResult(provider, ctx);
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      result: snapshot,
+      timestamp: Date.now(),
+    });
+    return snapshot;
   }
 
   const runtimeEligibleQuotaProviders = await resolveRuntimeEligibleQuotaProviders(
@@ -526,7 +553,14 @@ export async function fetchQuotaProviderResult(params: {
     ctx,
   );
   if (runtimeEligibleQuotaProviders === null) {
-    return fetchValidatedProviderResult(provider, ctx);
+    const snapshot = await fetchValidatedProviderResult(provider, ctx);
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      result: snapshot,
+      timestamp: Date.now(),
+    });
+    return snapshot;
   }
   const forceAggregateRefresh =
     provider.id === QUOTA_PROVIDERS_AGGREGATE_ID &&
@@ -546,12 +580,25 @@ export async function fetchQuotaProviderResult(params: {
     ttlMs > 0 &&
     now - inMemory.timestamp < ttlMs
   ) {
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      result: inMemory.result,
+      timestamp: inMemory.timestamp,
+    });
     return cloneQuotaProviderResult(inMemory.result);
   }
 
   const inFlight = inFlightByKey.get(key);
   if (inFlight) {
-    return cloneQuotaProviderResult(await inFlight);
+    const snapshot = await inFlight;
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      result: snapshot,
+      timestamp: inMemoryCache.get(key)?.timestamp ?? Date.now(),
+    });
+    return cloneQuotaProviderResult(snapshot);
   }
 
   const persisted = forceAggregateRefresh
@@ -567,6 +614,12 @@ export async function fetchQuotaProviderResult(params: {
     inMemoryCache.set(key, {
       ...persisted,
       result: cloneQuotaProviderResult(persisted.result),
+    });
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      result: persisted.result,
+      timestamp: persisted.timestamp,
     });
     return cloneQuotaProviderResult(persisted.result);
   }
@@ -600,7 +653,14 @@ export async function fetchQuotaProviderResult(params: {
   });
 
   inFlightByKey.set(key, fetchPromise);
-  return cloneQuotaProviderResult(await fetchPromise);
+  const snapshot = await fetchPromise;
+  publishQuotaTelemetry({
+    ctx,
+    providerId: provider.id,
+    result: snapshot,
+    timestamp: inMemoryCache.get(key)?.timestamp ?? Date.now(),
+  });
+  return cloneQuotaProviderResult(snapshot);
 }
 
 export type CachedProviderRead =
@@ -627,6 +687,12 @@ export async function readCachedProviderResult(params: {
   // Check in-memory cache first.
   const inMemory = inMemoryCache.get(key);
   if (inMemory) {
+    publishQuotaTelemetry({
+      ctx: params.ctx,
+      providerId: params.provider.id,
+      result: inMemory.result,
+      timestamp: inMemory.timestamp,
+    });
     return {
       hit: true,
       result: cloneQuotaProviderResult(inMemory.result),
@@ -650,6 +716,12 @@ export async function readCachedProviderResult(params: {
     inMemoryCache.set(key, {
       ...persisted,
       result: cloneQuotaProviderResult(persisted.result),
+    });
+    publishQuotaTelemetry({
+      ctx: params.ctx,
+      providerId: params.provider.id,
+      result: persisted.result,
+      timestamp: persisted.timestamp,
     });
     return {
       hit: true,

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -513,15 +513,17 @@ async function resolveRuntimeEligibleQuotaProviders(
 function publishQuotaTelemetry(params: {
   ctx: QuotaProviderContext;
   providerId: string;
+  snapshotId: string;
   result: QuotaProviderResult;
-  timestamp: number;
+  cacheTimestamp?: number;
 }): void {
+  if (!params.ctx.config.telemetryToken) return;
   updateQuotaTelemetrySnapshot({
-    enabled: params.ctx.config.telemetryEnabled === true,
-    generation: params.ctx.config.telemetryGeneration,
+    token: params.ctx.config.telemetryToken,
+    snapshotId: params.snapshotId,
     providerId: params.providerId,
     result: params.result,
-    timestamp: params.timestamp,
+    ...(params.cacheTimestamp !== undefined ? { cacheTimestamp: params.cacheTimestamp } : {}),
   });
 }
 
@@ -534,7 +536,14 @@ export async function fetchQuotaProviderResult(params: {
   const { provider, ctx, ttlMs, bypassCache = false } = params;
 
   if (bypassCache) {
-    return fetchValidatedProviderResult(provider, ctx);
+    const snapshot = await fetchValidatedProviderResult(provider, ctx);
+    publishQuotaTelemetry({
+      ctx,
+      providerId: provider.id,
+      snapshotId: `uncached:${provider.id}`,
+      result: snapshot,
+    });
+    return snapshot;
   }
 
   if (isLiveLocalUsageProviderId(provider.id)) {
@@ -542,8 +551,8 @@ export async function fetchQuotaProviderResult(params: {
     publishQuotaTelemetry({
       ctx,
       providerId: provider.id,
+      snapshotId: `uncached:${provider.id}`,
       result: snapshot,
-      timestamp: Date.now(),
     });
     return snapshot;
   }
@@ -557,8 +566,8 @@ export async function fetchQuotaProviderResult(params: {
     publishQuotaTelemetry({
       ctx,
       providerId: provider.id,
+      snapshotId: `uncached:${provider.id}`,
       result: snapshot,
-      timestamp: Date.now(),
     });
     return snapshot;
   }
@@ -583,8 +592,9 @@ export async function fetchQuotaProviderResult(params: {
     publishQuotaTelemetry({
       ctx,
       providerId: provider.id,
+      snapshotId: key,
       result: inMemory.result,
-      timestamp: inMemory.timestamp,
+      cacheTimestamp: inMemory.timestamp,
     });
     return cloneQuotaProviderResult(inMemory.result);
   }
@@ -595,8 +605,9 @@ export async function fetchQuotaProviderResult(params: {
     publishQuotaTelemetry({
       ctx,
       providerId: provider.id,
+      snapshotId: key,
       result: snapshot,
-      timestamp: inMemoryCache.get(key)?.timestamp ?? Date.now(),
+      cacheTimestamp: inMemoryCache.get(key)?.timestamp,
     });
     return cloneQuotaProviderResult(snapshot);
   }
@@ -618,8 +629,9 @@ export async function fetchQuotaProviderResult(params: {
     publishQuotaTelemetry({
       ctx,
       providerId: provider.id,
+      snapshotId: key,
       result: persisted.result,
-      timestamp: persisted.timestamp,
+      cacheTimestamp: persisted.timestamp,
     });
     return cloneQuotaProviderResult(persisted.result);
   }
@@ -657,8 +669,9 @@ export async function fetchQuotaProviderResult(params: {
   publishQuotaTelemetry({
     ctx,
     providerId: provider.id,
+    snapshotId: key,
     result: snapshot,
-    timestamp: inMemoryCache.get(key)?.timestamp ?? Date.now(),
+    cacheTimestamp: inMemoryCache.get(key)?.timestamp,
   });
   return cloneQuotaProviderResult(snapshot);
 }
@@ -690,8 +703,9 @@ export async function readCachedProviderResult(params: {
     publishQuotaTelemetry({
       ctx: params.ctx,
       providerId: params.provider.id,
+      snapshotId: key,
       result: inMemory.result,
-      timestamp: inMemory.timestamp,
+      cacheTimestamp: inMemory.timestamp,
     });
     return {
       hit: true,
@@ -720,8 +734,9 @@ export async function readCachedProviderResult(params: {
     publishQuotaTelemetry({
       ctx: params.ctx,
       providerId: params.provider.id,
+      snapshotId: key,
       result: persisted.result,
-      timestamp: persisted.timestamp,
+      cacheTimestamp: persisted.timestamp,
     });
     return {
       hit: true,

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -518,9 +518,13 @@ function publishQuotaTelemetry(params: {
   cacheTimestamp?: number;
 }): void {
   if (!params.ctx.config.telemetryToken) return;
+  const uncachedSnapshotId = `uncached:${params.providerId}`;
   updateQuotaTelemetrySnapshot({
     token: params.ctx.config.telemetryToken,
     snapshotId: params.snapshotId,
+    ...(params.snapshotId !== uncachedSnapshotId
+      ? { supersededSnapshotIds: [uncachedSnapshotId] }
+      : {}),
     providerId: params.providerId,
     result: params.result,
     ...(params.cacheTimestamp !== undefined ? { cacheTimestamp: params.cacheTimestamp } : {}),

--- a/src/lib/quota-telemetry.ts
+++ b/src/lib/quota-telemetry.ts
@@ -1,13 +1,37 @@
-import type { Attributes, MeterProvider, ObservableResult } from "@opentelemetry/api";
+import type { Attributes, ObservableResult } from "@opentelemetry/api";
 
 import type { QuotaProviderResult } from "./entries.js";
 import { isPercentEntry } from "./entries.js";
+import { getQuotaProviderShape } from "./provider-metadata.js";
 import { classifyQuotaWindowText } from "./quota-entry-display.js";
 import { QUOTA_PROVIDERS_AGGREGATE_ID } from "./quota-providers.js";
 
 const METER_NAME = "@slkiser/opencode-quota";
 const CONSUMED_METRIC_NAME = "opencode.quota.consumed";
 const CACHE_AGE_METRIC_NAME = "opencode.quota.cache.age";
+const TELEMETRY_STATE_KEY = Symbol.for("@slkiser/opencode-quota/quota-telemetry/v2");
+
+type ObservableCallback = (result: ObservableResult) => void;
+type ObservableGauge = {
+  addCallback(callback: ObservableCallback): void;
+  removeCallback?(callback: ObservableCallback): void;
+};
+type TelemetryApi = {
+  metrics: {
+    getMeter(name: string): {
+      createObservableGauge(
+        name: string,
+        options: { description: string; unit: string },
+      ): ObservableGauge;
+    };
+  };
+};
+type TelemetryApiLoader = () => Promise<TelemetryApi>;
+
+export interface QuotaTelemetryToken {
+  readonly ownerId: number;
+  readonly generation: number;
+}
 
 interface QuotaTelemetryObservation {
   value: number;
@@ -15,187 +39,338 @@ interface QuotaTelemetryObservation {
 }
 
 interface QuotaTelemetrySnapshot {
-  timestamp: number;
+  ownerId: number;
+  generation: number;
+  providerId: string;
+  cacheTimestamp?: number;
   consumed: QuotaTelemetryObservation[];
 }
 
-const snapshots = new Map<string, QuotaTelemetrySnapshot>();
-let initialization: Promise<void> | null = null;
-let telemetryApi: typeof import("@opentelemetry/api") | null = null;
-let registeredProvider: MeterProvider | null = null;
-let enabled = false;
-let generation = 0;
-
-function isInternalAggregateProviderId(providerId: string): boolean {
-  return providerId.startsWith(`${QUOTA_PROVIDERS_AGGREGATE_ID}:`);
+interface QuotaTelemetryOwner {
+  id: number;
+  generation: number;
+  enabled: boolean;
+  identity: string;
 }
 
-function buildAttributes(
-  providerId: string,
-  entry: Extract<QuotaProviderResult["entries"][number], { percentRemaining: number }>,
-): Attributes {
-  return {
-    "quota.provider": providerId,
-    "quota.result_type": entry.accounting.resultType,
-    "quota.window":
-      classifyQuotaWindowText(entry.label ?? "") ??
-      classifyQuotaWindowText(entry.name) ??
-      "unspecified",
-    "quota.acquisition_method": entry.accounting.acquisitionMethod,
-    "quota.ownership": entry.accounting.ownership,
-    "quota.authority": entry.accounting.authority,
+interface QuotaTelemetryState {
+  owners: WeakMap<object, QuotaTelemetryOwner>;
+  ownersById: Map<number, QuotaTelemetryOwner>;
+  nextOwnerId: number;
+  snapshots: Map<string, QuotaTelemetrySnapshot>;
+  initialization: Promise<void> | null;
+  unavailable: boolean;
+  registered: boolean;
+  apiLoader: TelemetryApiLoader;
+  consumedGauge?: ObservableGauge;
+  cacheAgeGauge?: ObservableGauge;
+  observeConsumed?: ObservableCallback;
+  observeCacheAge?: ObservableCallback;
+}
+
+function defaultApiLoader(): Promise<TelemetryApi> {
+  return import("@opentelemetry/api");
+}
+
+function getState(): QuotaTelemetryState {
+  const globalState = globalThis as unknown as Record<PropertyKey, unknown>;
+  const existing = globalState[TELEMETRY_STATE_KEY] as QuotaTelemetryState | undefined;
+  if (existing) return existing;
+
+  const state: QuotaTelemetryState = {
+    owners: new WeakMap(),
+    ownersById: new Map(),
+    nextOwnerId: 1,
+    snapshots: new Map(),
+    initialization: null,
+    unavailable: false,
+    registered: false,
+    apiLoader: defaultApiLoader,
   };
+  globalState[TELEMETRY_STATE_KEY] = state;
+  return state;
+}
+
+function safeProviderAttribute(providerId: string): string {
+  if (
+    providerId === QUOTA_PROVIDERS_AGGREGATE_ID ||
+    providerId.startsWith(`${QUOTA_PROVIDERS_AGGREGATE_ID}:`)
+  ) {
+    return "custom";
+  }
+  return getQuotaProviderShape(providerId)?.id ?? "other";
+}
+
+function activeProviderId(providerId: string): string {
+  return providerId.startsWith(`${QUOTA_PROVIDERS_AGGREGATE_ID}:`)
+    ? QUOTA_PROVIDERS_AGGREGATE_ID
+    : providerId;
 }
 
 function observationKey(attributes: Attributes): string {
   return [
     attributes["quota.provider"],
-    attributes["quota.result_type"],
     attributes["quota.window"],
-    attributes["quota.acquisition_method"],
-    attributes["quota.ownership"],
-    attributes["quota.authority"],
+    attributes["quota.result_type"],
   ].join("\u0000");
 }
 
-function observeConsumed(result: ObservableResult): void {
-  try {
-    for (const snapshot of snapshots.values()) {
-      for (const observation of snapshot.consumed) {
-        result.observe(observation.value, observation.attributes);
+function snapshotKey(ownerId: number, identity: string): string {
+  return `${ownerId}\u0000${identity}`;
+}
+
+function removeOwnerSnapshots(state: QuotaTelemetryState, ownerId: number): void {
+  const prefix = `${ownerId}\u0000`;
+  for (const key of state.snapshots.keys()) {
+    if (key.startsWith(prefix)) state.snapshots.delete(key);
+  }
+}
+
+function collectConsumedObservations(state: QuotaTelemetryState): QuotaTelemetryObservation[] {
+  const observations = new Map<string, QuotaTelemetryObservation>();
+  for (const snapshot of state.snapshots.values()) {
+    for (const observation of snapshot.consumed) {
+      const key = observationKey(observation.attributes);
+      const existing = observations.get(key);
+      if (!existing || observation.value > existing.value) {
+        observations.set(key, observation);
       }
     }
-  } catch {
-    // Telemetry callbacks must never affect the host or quota collection.
+  }
+  return [...observations.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, observation]) => observation);
+}
+
+function collectCacheAgeObservations(
+  state: QuotaTelemetryState,
+  now: number,
+): QuotaTelemetryObservation[] {
+  const observations = new Map<string, QuotaTelemetryObservation>();
+  for (const snapshot of state.snapshots.values()) {
+    if (snapshot.cacheTimestamp === undefined) continue;
+    const provider = safeProviderAttribute(snapshot.providerId);
+    const value = Math.max(0, now - snapshot.cacheTimestamp) / 1000;
+    const existing = observations.get(provider);
+    if (!existing || value > existing.value) {
+      observations.set(provider, {
+        value,
+        attributes: { "quota.provider": provider },
+      });
+    }
+  }
+  return [...observations.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, observation]) => observation);
+}
+
+function emitObservations(
+  result: ObservableResult,
+  observations: readonly QuotaTelemetryObservation[],
+): void {
+  for (const observation of observations) {
+    try {
+      result.observe(observation.value, observation.attributes);
+    } catch {
+      // One host observer failure must not suppress other safe series.
+    }
   }
 }
 
-function observeCacheAge(result: ObservableResult): void {
+function registerInstruments(state: QuotaTelemetryState, api: TelemetryApi): void {
+  const meter = api.metrics.getMeter(METER_NAME);
+  const consumedGauge = meter.createObservableGauge(CONSUMED_METRIC_NAME, {
+    description: "Normalized quota consumed, where 1 is 100% consumed",
+    unit: "1",
+  });
+  const cacheAgeGauge = meter.createObservableGauge(CACHE_AGE_METRIC_NAME, {
+    description: "Age of the normalized cached quota observation",
+    unit: "s",
+  });
+  const observeConsumed: ObservableCallback = (result) => {
+    try {
+      emitObservations(result, collectConsumedObservations(state));
+    } catch {
+      // Telemetry callbacks must never affect the host or quota collection.
+    }
+  };
+  const observeCacheAge: ObservableCallback = (result) => {
+    try {
+      emitObservations(result, collectCacheAgeObservations(state, Date.now()));
+    } catch {
+      // Telemetry callbacks must never affect the host or quota collection.
+    }
+  };
+
+  consumedGauge.addCallback(observeConsumed);
   try {
-    const now = Date.now();
-    for (const snapshot of snapshots.values()) {
-      const ageSeconds = Math.max(0, now - snapshot.timestamp) / 1000;
-      for (const observation of snapshot.consumed) {
-        result.observe(ageSeconds, observation.attributes);
-      }
-    }
-  } catch {
-    // Telemetry callbacks must never affect the host or quota collection.
+    cacheAgeGauge.addCallback(observeCacheAge);
+  } catch (error) {
+    consumedGauge.removeCallback?.(observeConsumed);
+    throw error;
   }
+
+  state.consumedGauge = consumedGauge;
+  state.cacheAgeGauge = cacheAgeGauge;
+  state.observeConsumed = observeConsumed;
+  state.observeCacheAge = observeCacheAge;
+  state.registered = true;
 }
 
-function registerCurrentMeterProvider(): void {
-  if (!telemetryApi) return;
+function initializeTelemetry(state: QuotaTelemetryState): void {
+  if (state.registered || state.unavailable || state.initialization) return;
 
-  const provider = telemetryApi.metrics.getMeterProvider();
-  if (provider === registeredProvider) return;
-
-  const meter = provider.getMeter(METER_NAME);
-  meter
-    .createObservableGauge(CONSUMED_METRIC_NAME, {
-      description: "Normalized quota consumed, where 1 is 100% consumed",
-      unit: "1",
-    })
-    .addCallback(observeConsumed);
-  meter
-    .createObservableGauge(CACHE_AGE_METRIC_NAME, {
-      description: "Age of the normalized cached quota observation",
-      unit: "s",
-    })
-    .addCallback(observeCacheAge);
-  registeredProvider = provider;
+  state.initialization = state
+    .apiLoader()
+    .then((api) => registerInstruments(state, api))
+    .catch(() => {
+      state.unavailable = true;
+    });
 }
 
-function initializeTelemetry(): void {
-  if (telemetryApi) {
-    registerCurrentMeterProvider();
-    return;
-  }
-  if (initialization) return;
-
-  initialization = import("@opentelemetry/api")
-    .then((api) => {
-      telemetryApi = api;
-      registerCurrentMeterProvider();
-    })
-    .catch(() => undefined);
-}
-
-export function configureQuotaTelemetry(nextEnabled: boolean): number {
+export function configureQuotaTelemetry(params: {
+  owner: object;
+  enabled: boolean;
+  identity: string;
+}): QuotaTelemetryToken | undefined {
   try {
-    if (enabled !== nextEnabled) {
-      enabled = nextEnabled;
-      generation += 1;
+    const state = getState();
+    let owner = state.owners.get(params.owner);
+    if (!owner) {
+      owner = {
+        id: state.nextOwnerId,
+        generation: 0,
+        enabled: false,
+        identity: "",
+      };
+      state.nextOwnerId += 1;
+      state.owners.set(params.owner, owner);
+      state.ownersById.set(owner.id, owner);
     }
 
-    if (!enabled) {
-      snapshots.clear();
-      return generation;
+    if (owner.enabled !== params.enabled || owner.identity !== params.identity) {
+      owner.enabled = params.enabled;
+      owner.identity = params.identity;
+      owner.generation += 1;
+      removeOwnerSnapshots(state, owner.id);
     }
 
-    initializeTelemetry();
+    if (!owner.enabled) return undefined;
+    initializeTelemetry(state);
+    return { ownerId: owner.id, generation: owner.generation };
   } catch {
     // OpenTelemetry is optional and must not affect normal plugin behavior.
+    return undefined;
   }
-  return generation;
+}
+
+export function disposeQuotaTelemetryOwner(ownerKey: object): void {
+  try {
+    const state = getState();
+    const owner = state.owners.get(ownerKey);
+    if (!owner) return;
+    removeOwnerSnapshots(state, owner.id);
+    state.owners.delete(ownerKey);
+    state.ownersById.delete(owner.id);
+  } catch {
+    // Plugin disposal must remain best-effort.
+  }
+}
+
+function isCurrentToken(
+  state: QuotaTelemetryState,
+  token: QuotaTelemetryToken | undefined,
+): token is QuotaTelemetryToken {
+  if (!token) return false;
+  const owner = state.ownersById.get(token.ownerId);
+  return Boolean(owner?.enabled && owner.generation === token.generation);
 }
 
 export function updateQuotaTelemetrySnapshot(params: {
-  enabled: boolean;
-  generation?: number;
+  token?: QuotaTelemetryToken;
+  snapshotId: string;
   providerId: string;
-  timestamp: number;
+  cacheTimestamp?: number;
   result: QuotaProviderResult | null;
 }): void {
   try {
-    if (params.generation !== undefined && params.generation !== generation) return;
+    const state = getState();
+    if (!isCurrentToken(state, params.token)) return;
 
-    if (!enabled || !params.enabled || isInternalAggregateProviderId(params.providerId)) {
-      snapshots.delete(params.providerId);
-      return;
-    }
-
-    initializeTelemetry();
-
+    const key = snapshotKey(params.token.ownerId, params.snapshotId);
     if (!params.result || !params.result.attempted || params.result.entries.length === 0) {
-      snapshots.delete(params.providerId);
+      state.snapshots.delete(key);
       return;
     }
 
-    const consumedByAttributes = new Map<string, QuotaTelemetryObservation>();
+    const provider = safeProviderAttribute(params.providerId);
+    const consumed = new Map<string, QuotaTelemetryObservation>();
     for (const entry of params.result.entries) {
-      if (!isPercentEntry(entry)) continue;
+      if (!isPercentEntry(entry) || !Number.isFinite(entry.percentRemaining)) continue;
 
-      const attributes = buildAttributes(params.providerId, entry);
-      const value = Math.max(0, (100 - entry.percentRemaining) / 100);
-      const key = observationKey(attributes);
-      const existing = consumedByAttributes.get(key);
-      if (!existing || value > existing.value) {
-        consumedByAttributes.set(key, { value, attributes });
+      const attributes: Attributes = {
+        "quota.provider": provider,
+        "quota.window":
+          classifyQuotaWindowText(entry.label ?? "") ??
+          classifyQuotaWindowText(entry.name) ??
+          "unknown",
+        "quota.result_type": entry.accounting.resultType,
+      };
+      const observation: QuotaTelemetryObservation = {
+        value: Math.min(1, Math.max(0, (100 - entry.percentRemaining) / 100)),
+        attributes,
+      };
+      const observationIdentity = observationKey(attributes);
+      const existing = consumed.get(observationIdentity);
+      if (!existing || observation.value > existing.value) {
+        consumed.set(observationIdentity, observation);
       }
     }
 
-    if (consumedByAttributes.size === 0) {
-      snapshots.delete(params.providerId);
+    if (consumed.size === 0) {
+      state.snapshots.delete(key);
       return;
     }
 
-    snapshots.set(params.providerId, {
-      timestamp: params.timestamp,
-      consumed: [...consumedByAttributes.values()],
+    const existing = state.snapshots.get(key);
+    if (
+      existing?.cacheTimestamp !== undefined &&
+      params.cacheTimestamp !== undefined &&
+      params.cacheTimestamp < existing.cacheTimestamp
+    ) {
+      return;
+    }
+
+    state.snapshots.set(key, {
+      ownerId: params.token.ownerId,
+      generation: params.token.generation,
+      providerId: params.providerId,
+      ...(params.cacheTimestamp !== undefined ? { cacheTimestamp: params.cacheTimestamp } : {}),
+      consumed: [...consumed.entries()]
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([, observation]) => observation),
     });
   } catch {
     // Snapshot publication is deliberately best-effort and synchronous.
   }
 }
 
-export function retainQuotaTelemetryProviders(providerIds: readonly string[]): void {
+export function retainQuotaTelemetryProviders(params: {
+  token?: QuotaTelemetryToken;
+  providerIds: readonly string[];
+}): void {
   try {
-    if (!enabled) return;
+    const state = getState();
+    if (!isCurrentToken(state, params.token)) return;
 
-    const retained = new Set(providerIds);
-    for (const providerId of snapshots.keys()) {
-      if (!retained.has(providerId)) snapshots.delete(providerId);
+    const retained = new Set(params.providerIds);
+    for (const [key, snapshot] of state.snapshots) {
+      if (
+        snapshot.ownerId === params.token.ownerId &&
+        !retained.has(activeProviderId(snapshot.providerId))
+      ) {
+        state.snapshots.delete(key);
+      }
     }
   } catch {
     // Reconciliation is best-effort and must not affect provider selection.
@@ -203,14 +378,24 @@ export function retainQuotaTelemetryProviders(providerIds: readonly string[]): v
 }
 
 export async function __flushQuotaTelemetryInitializationForTests(): Promise<void> {
-  await initialization;
+  await getState().initialization;
+}
+
+export function __setQuotaTelemetryApiLoaderForTests(loader: TelemetryApiLoader): void {
+  const state = getState();
+  state.apiLoader = loader;
+  state.initialization = null;
+  state.unavailable = false;
 }
 
 export function __resetQuotaTelemetryForTests(): void {
-  snapshots.clear();
-  initialization = null;
-  telemetryApi = null;
-  registeredProvider = null;
-  enabled = false;
-  generation = 0;
+  const globalState = globalThis as unknown as Record<PropertyKey, unknown>;
+  const state = globalState[TELEMETRY_STATE_KEY] as QuotaTelemetryState | undefined;
+  if (state?.consumedGauge && state.observeConsumed) {
+    state.consumedGauge.removeCallback?.(state.observeConsumed);
+  }
+  if (state?.cacheAgeGauge && state.observeCacheAge) {
+    state.cacheAgeGauge.removeCallback?.(state.observeCacheAge);
+  }
+  delete globalState[TELEMETRY_STATE_KEY];
 }

--- a/src/lib/quota-telemetry.ts
+++ b/src/lib/quota-telemetry.ts
@@ -1,0 +1,216 @@
+import type { Attributes, MeterProvider, ObservableResult } from "@opentelemetry/api";
+
+import type { QuotaProviderResult } from "./entries.js";
+import { isPercentEntry } from "./entries.js";
+import { classifyQuotaWindowText } from "./quota-entry-display.js";
+import { QUOTA_PROVIDERS_AGGREGATE_ID } from "./quota-providers.js";
+
+const METER_NAME = "@slkiser/opencode-quota";
+const CONSUMED_METRIC_NAME = "opencode.quota.consumed";
+const CACHE_AGE_METRIC_NAME = "opencode.quota.cache.age";
+
+interface QuotaTelemetryObservation {
+  value: number;
+  attributes: Attributes;
+}
+
+interface QuotaTelemetrySnapshot {
+  timestamp: number;
+  consumed: QuotaTelemetryObservation[];
+}
+
+const snapshots = new Map<string, QuotaTelemetrySnapshot>();
+let initialization: Promise<void> | null = null;
+let telemetryApi: typeof import("@opentelemetry/api") | null = null;
+let registeredProvider: MeterProvider | null = null;
+let enabled = false;
+let generation = 0;
+
+function isInternalAggregateProviderId(providerId: string): boolean {
+  return providerId.startsWith(`${QUOTA_PROVIDERS_AGGREGATE_ID}:`);
+}
+
+function buildAttributes(
+  providerId: string,
+  entry: Extract<QuotaProviderResult["entries"][number], { percentRemaining: number }>,
+): Attributes {
+  return {
+    "quota.provider": providerId,
+    "quota.result_type": entry.accounting.resultType,
+    "quota.window":
+      classifyQuotaWindowText(entry.label ?? "") ??
+      classifyQuotaWindowText(entry.name) ??
+      "unspecified",
+    "quota.acquisition_method": entry.accounting.acquisitionMethod,
+    "quota.ownership": entry.accounting.ownership,
+    "quota.authority": entry.accounting.authority,
+  };
+}
+
+function observationKey(attributes: Attributes): string {
+  return [
+    attributes["quota.provider"],
+    attributes["quota.result_type"],
+    attributes["quota.window"],
+    attributes["quota.acquisition_method"],
+    attributes["quota.ownership"],
+    attributes["quota.authority"],
+  ].join("\u0000");
+}
+
+function observeConsumed(result: ObservableResult): void {
+  try {
+    for (const snapshot of snapshots.values()) {
+      for (const observation of snapshot.consumed) {
+        result.observe(observation.value, observation.attributes);
+      }
+    }
+  } catch {
+    // Telemetry callbacks must never affect the host or quota collection.
+  }
+}
+
+function observeCacheAge(result: ObservableResult): void {
+  try {
+    const now = Date.now();
+    for (const snapshot of snapshots.values()) {
+      const ageSeconds = Math.max(0, now - snapshot.timestamp) / 1000;
+      for (const observation of snapshot.consumed) {
+        result.observe(ageSeconds, observation.attributes);
+      }
+    }
+  } catch {
+    // Telemetry callbacks must never affect the host or quota collection.
+  }
+}
+
+function registerCurrentMeterProvider(): void {
+  if (!telemetryApi) return;
+
+  const provider = telemetryApi.metrics.getMeterProvider();
+  if (provider === registeredProvider) return;
+
+  const meter = provider.getMeter(METER_NAME);
+  meter
+    .createObservableGauge(CONSUMED_METRIC_NAME, {
+      description: "Normalized quota consumed, where 1 is 100% consumed",
+      unit: "1",
+    })
+    .addCallback(observeConsumed);
+  meter
+    .createObservableGauge(CACHE_AGE_METRIC_NAME, {
+      description: "Age of the normalized cached quota observation",
+      unit: "s",
+    })
+    .addCallback(observeCacheAge);
+  registeredProvider = provider;
+}
+
+function initializeTelemetry(): void {
+  if (telemetryApi) {
+    registerCurrentMeterProvider();
+    return;
+  }
+  if (initialization) return;
+
+  initialization = import("@opentelemetry/api")
+    .then((api) => {
+      telemetryApi = api;
+      registerCurrentMeterProvider();
+    })
+    .catch(() => undefined);
+}
+
+export function configureQuotaTelemetry(nextEnabled: boolean): number {
+  try {
+    if (enabled !== nextEnabled) {
+      enabled = nextEnabled;
+      generation += 1;
+    }
+
+    if (!enabled) {
+      snapshots.clear();
+      return generation;
+    }
+
+    initializeTelemetry();
+  } catch {
+    // OpenTelemetry is optional and must not affect normal plugin behavior.
+  }
+  return generation;
+}
+
+export function updateQuotaTelemetrySnapshot(params: {
+  enabled: boolean;
+  generation?: number;
+  providerId: string;
+  timestamp: number;
+  result: QuotaProviderResult | null;
+}): void {
+  try {
+    if (params.generation !== undefined && params.generation !== generation) return;
+
+    if (!enabled || !params.enabled || isInternalAggregateProviderId(params.providerId)) {
+      snapshots.delete(params.providerId);
+      return;
+    }
+
+    initializeTelemetry();
+
+    if (!params.result || !params.result.attempted || params.result.entries.length === 0) {
+      snapshots.delete(params.providerId);
+      return;
+    }
+
+    const consumedByAttributes = new Map<string, QuotaTelemetryObservation>();
+    for (const entry of params.result.entries) {
+      if (!isPercentEntry(entry)) continue;
+
+      const attributes = buildAttributes(params.providerId, entry);
+      const value = Math.max(0, (100 - entry.percentRemaining) / 100);
+      const key = observationKey(attributes);
+      const existing = consumedByAttributes.get(key);
+      if (!existing || value > existing.value) {
+        consumedByAttributes.set(key, { value, attributes });
+      }
+    }
+
+    if (consumedByAttributes.size === 0) {
+      snapshots.delete(params.providerId);
+      return;
+    }
+
+    snapshots.set(params.providerId, {
+      timestamp: params.timestamp,
+      consumed: [...consumedByAttributes.values()],
+    });
+  } catch {
+    // Snapshot publication is deliberately best-effort and synchronous.
+  }
+}
+
+export function retainQuotaTelemetryProviders(providerIds: readonly string[]): void {
+  try {
+    if (!enabled) return;
+
+    const retained = new Set(providerIds);
+    for (const providerId of snapshots.keys()) {
+      if (!retained.has(providerId)) snapshots.delete(providerId);
+    }
+  } catch {
+    // Reconciliation is best-effort and must not affect provider selection.
+  }
+}
+
+export async function __flushQuotaTelemetryInitializationForTests(): Promise<void> {
+  await initialization;
+}
+
+export function __resetQuotaTelemetryForTests(): void {
+  snapshots.clear();
+  initialization = null;
+  telemetryApi = null;
+  registeredProvider = null;
+  enabled = false;
+  generation = 0;
+}

--- a/src/lib/quota-telemetry.ts
+++ b/src/lib/quota-telemetry.ts
@@ -289,6 +289,7 @@ function isCurrentToken(
 export function updateQuotaTelemetrySnapshot(params: {
   token?: QuotaTelemetryToken;
   snapshotId: string;
+  supersededSnapshotIds?: readonly string[];
   providerId: string;
   cacheTimestamp?: number;
   result: QuotaProviderResult | null;
@@ -296,6 +297,10 @@ export function updateQuotaTelemetrySnapshot(params: {
   try {
     const state = getState();
     if (!isCurrentToken(state, params.token)) return;
+
+    for (const snapshotId of params.supersededSnapshotIds ?? []) {
+      state.snapshots.delete(snapshotKey(params.token.ownerId, snapshotId));
+    }
 
     const key = snapshotKey(params.token.ownerId, params.snapshotId);
     if (!params.result || !params.result.attempted || params.result.entries.length === 0) {

--- a/src/lib/tui-runtime.ts
+++ b/src/lib/tui-runtime.ts
@@ -29,6 +29,7 @@ import {
 } from "./quota-export.js";
 
 const COMPACT_UNAVAILABLE_TEXT = "Quota unavailable";
+const tuiQuotaClients = new WeakMap<TuiPluginApi, ReturnType<typeof makeTuiQuotaClient>>();
 
 export function getTuiRuntimeRootHints(api: TuiPluginApi): RuntimeContextRootHints {
   return {
@@ -42,7 +43,7 @@ export function resolveWorkspaceDir(api: TuiPluginApi): string {
   return resolveRuntimeContextRoots(getTuiRuntimeRootHints(api)).workspaceRoot;
 }
 
-export function createTuiQuotaClient(api: TuiPluginApi) {
+function makeTuiQuotaClient(api: TuiPluginApi) {
   return {
     config: {
       providers: async () => {
@@ -81,6 +82,14 @@ export function createTuiQuotaClient(api: TuiPluginApi) {
       },
     },
   };
+}
+
+export function createTuiQuotaClient(api: TuiPluginApi) {
+  const existing = tuiQuotaClients.get(api);
+  if (existing) return existing;
+  const client = makeTuiQuotaClient(api);
+  tuiQuotaClients.set(api, client);
+  return client;
 }
 
 export function normalizeTuiSessionID(sessionID: unknown): string | undefined {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,11 @@ export interface QuotaExportConfig {
   path: string;
 }
 
+export interface QuotaTelemetryConfig {
+  /** Whether to publish quota gauges through the global OpenTelemetry MeterProvider. */
+  enabled: boolean;
+}
+
 export interface MaintainerAnnouncementsConfig {
   enabled: boolean;
   home: boolean;
@@ -173,6 +178,9 @@ export interface QuotaToastConfig {
   /** Opt-in periodic JSON export for external tool consumption. */
   export: QuotaExportConfig;
 
+  /** Opt-in quota metrics through the host's global OpenTelemetry MeterProvider. */
+  telemetry: QuotaTelemetryConfig;
+
   /** Responsive toast layout breakpoints (not used by the fixed-width TUI sidebar). */
   layout: {
     /** Default max width target for toast formatting */
@@ -238,6 +246,9 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
   export: {
     enabled: false,
     path: "",
+  },
+  telemetry: {
+    enabled: false,
   },
   layout: {
     maxWidth: 50,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -56,6 +56,7 @@ import {
   isQuotaDialogCommand,
   type QuotaDialogCommandId,
 } from "./lib/quota-dialog-commands.js";
+import { disposeQuotaTelemetryOwner } from "./lib/quota-telemetry.js";
 
 // =============================================================================
 // Types
@@ -1159,6 +1160,10 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
 
   // Return hook implementations
   return {
+    dispose: async () => {
+      disposeQuotaTelemetryOwner(typedClient);
+    },
+
     config: async (input: unknown) => {
       const cfg = input as PluginConfigInput;
       opencodeConfig = cfg;

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -37,6 +37,7 @@ import {
   resolveTuiSurfaceRegistration,
   writeTuiQuotaExportIfEnabled,
 } from "./lib/tui-runtime.js";
+import { disposeQuotaTelemetryOwner } from "./lib/quota-telemetry.js";
 import {
   QUOTA_DIALOG_COMMANDS,
   buildQuotaDialogCommandOutput,
@@ -598,6 +599,10 @@ function registerSidebarSlots(api: TuiPluginApi): void {
 }
 
 const tui: TuiPlugin = async (api) => {
+  api.lifecycle.onDispose(() => {
+    disposeQuotaTelemetryOwner(createTuiQuotaClient(api));
+  });
+
   let surfaceRegistration;
   try {
     surfaceRegistration = await resolveTuiSurfaceRegistration(api);

--- a/tests/helpers/plugin-test-harness.ts
+++ b/tests/helpers/plugin-test-harness.ts
@@ -236,6 +236,10 @@ export function makeQuotaToastTestConfig(
       ...DEFAULT_CONFIG.maintainerAnnouncements,
       ...overrides.maintainerAnnouncements,
     },
+    telemetry: {
+      ...DEFAULT_CONFIG.telemetry,
+      ...overrides.telemetry,
+    },
     layout: {
       ...DEFAULT_CONFIG.layout,
       ...overrides.layout,

--- a/tests/lib.config.security.test.ts
+++ b/tests/lib.config.security.test.ts
@@ -237,12 +237,42 @@ describe("loadConfig layered precedence", () => {
     expect(meta.settingSources["layout.maxWidth"]).toBe(
       quotaConfigSource(join(xdgConfigHome, "opencode")),
     );
-    expect(meta.settingSources["layout.narrowAt"]).toBe(
-      quotaConfigSource(workspaceDir),
+    expect(meta.settingSources["layout.narrowAt"]).toBe(quotaConfigSource(workspaceDir));
+    expect(meta.settingSources["layout.tinyAt"]).toBe(quotaConfigSource(workspaceDir));
+  });
+
+  it("preserves valid global telemetry when a workspace value is invalid", async () => {
+    writeFileSync(
+      join(xdgConfigHome, "opencode", "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            telemetry: { enabled: true },
+          },
+        },
+      }),
+      "utf-8",
     );
-    expect(meta.settingSources["layout.tinyAt"]).toBe(
-      quotaConfigSource(workspaceDir),
+    writeFileSync(
+      join(workspaceDir, "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            telemetry: { enabled: "yes" },
+          },
+        },
+      }),
+      "utf-8",
     );
+
+    const meta = createLoadConfigMeta();
+    const cfg = await loadConfig(undefined, meta, { cwd: workspaceDir });
+
+    expect(cfg.telemetry).toEqual({ enabled: true });
+    expect(meta.settingSources["telemetry.enabled"]).toBe(
+      quotaConfigSource(join(xdgConfigHome, "opencode")),
+    );
+    expect(meta.networkSettingSources).toEqual({});
   });
 
   it("merges maintainer announcements per field and ignores invalid workspace fields", async () => {
@@ -439,36 +469,16 @@ describe("loadConfig layered precedence", () => {
     expect(cfg.formatStyle).toBe("allWindows");
     expect(cfg.layout).toEqual({ maxWidth: 64, narrowAt: 35, tinyAt: 32 });
     const globalQuotaConfigSource = quotaConfigSource(join(xdgConfigHome, "opencode"));
-    expect(meta.settingSources.enabledProviders).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources.anthropicBinaryPath).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources.googleModels).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources.cursorIncludedApiUsd).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources.cursorBillingCycleStartDay).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources["pricingSnapshot.source"]).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources["pricingSnapshot.autoRefresh"]).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources.formatStyle).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources["layout.maxWidth"]).toBe(
-      globalQuotaConfigSource,
-    );
-    expect(meta.settingSources["layout.narrowAt"]).toBe(
-      quotaConfigSource(workspaceDir),
-    );
+    expect(meta.settingSources.enabledProviders).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources.anthropicBinaryPath).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources.googleModels).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources.cursorIncludedApiUsd).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources.cursorBillingCycleStartDay).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources["pricingSnapshot.source"]).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources["pricingSnapshot.autoRefresh"]).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources.formatStyle).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources["layout.maxWidth"]).toBe(globalQuotaConfigSource);
+    expect(meta.settingSources["layout.narrowAt"]).toBe(quotaConfigSource(workspaceDir));
   });
 
   it("accepts legacy toastStyle in file-backed config and still prefers formatStyle when present", async () => {

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -166,6 +166,23 @@ describe("loadConfig", () => {
     expect(invalidNested.meta.settingSources).toEqual({});
   });
 
+  it("defaults telemetry off and accepts an opt-in without changing network settings", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.telemetry).toEqual({ enabled: false });
+    expect(defaults.config.telemetry).not.toBe(DEFAULT_CONFIG.telemetry);
+
+    const explicit = await loadSdkConfig({ telemetry: { enabled: true } });
+    expect(explicit.config.telemetry).toEqual({ enabled: true });
+    expect(explicit.meta.settingSources).toEqual({
+      "telemetry.enabled": "client.config.get",
+    });
+    expect(explicit.meta.networkSettingSources).toEqual({});
+
+    const invalid = await loadSdkConfig({ telemetry: { enabled: "yes" } });
+    expect(invalid.config.telemetry).toEqual({ enabled: false });
+    expect(invalid.meta.settingSources).toEqual({});
+  });
+
   it("defaults TUI sidebar panel config and accepts validated nested overrides", async () => {
     const defaults = await loadSdkConfig({});
     expect(defaults.config.tuiSidebarPanel).toEqual(DEFAULT_CONFIG.tuiSidebarPanel);

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -178,6 +178,12 @@ describe("loadConfig", () => {
     });
     expect(explicit.meta.networkSettingSources).toEqual({});
 
+    const disabled = await loadSdkConfig({ telemetry: { enabled: false } });
+    expect(disabled.config.telemetry).toEqual({ enabled: false });
+    expect(disabled.meta.settingSources).toEqual({
+      "telemetry.enabled": "client.config.get",
+    });
+
     const invalid = await loadSdkConfig({ telemetry: { enabled: "yes" } });
     expect(invalid.config.telemetry).toEqual({ enabled: false });
     expect(invalid.meta.settingSources).toEqual({});

--- a/tests/lib.quota-runtime-context.test.ts
+++ b/tests/lib.quota-runtime-context.test.ts
@@ -24,6 +24,7 @@ import { resolveRuntimeContextRoots } from "../src/lib/config-file-utils.js";
 import { createLoadConfigMeta } from "../src/lib/config.js";
 import { DEFAULT_CONFIG } from "../src/lib/types.js";
 import { createRuntimeProviderIdResolver } from "../src/lib/runtime-provider-ids.js";
+import { __resetQuotaTelemetryForTests } from "../src/lib/quota-telemetry.js";
 
 function quotaConfigSource(dir: string): string {
   return join(dir, "opencode.json") + " (experimental.quotaToast)";
@@ -39,6 +40,7 @@ describe("quota runtime context", () => {
   let xdgConfigHome: string;
 
   beforeEach(() => {
+    __resetQuotaTelemetryForTests();
     delete process.env.OPENCODE_CONFIG_DIR;
     tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-runtime-context-"));
     mockedHomeDir.value = tempDir;
@@ -63,6 +65,7 @@ describe("quota runtime context", () => {
   });
 
   afterEach(() => {
+    __resetQuotaTelemetryForTests();
     process.chdir(originalCwd);
     process.env = originalEnv;
     mockedHomeDir.value = "";
@@ -211,22 +214,28 @@ describe("quota runtime context", () => {
     expect(providerContext.config?.requestTimeoutMsConfigured).toBe(true);
   });
 
-  it("enables provider telemetry only when both plugin and telemetry are enabled", () => {
+  it("scopes telemetry tokens to enabled normalized provider configuration without I/O", () => {
     const client = createClient();
-    const createContext = (enabled: boolean) =>
+    const createContext = (enabled: boolean, enabledProviders = DEFAULT_CONFIG.enabledProviders) =>
       createQuotaProviderRuntimeContext({
         client,
         resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
         config: {
           ...DEFAULT_CONFIG,
           enabled,
+          enabledProviders,
           telemetry: { enabled: true },
         },
         session: {},
       });
 
-    expect(createContext(false).config.telemetryEnabled).toBe(false);
-    expect(createContext(true).config.telemetryEnabled).toBe(true);
+    expect(createContext(false).config.telemetryToken).toBeUndefined();
+    const first = createContext(true).config.telemetryToken;
+    expect(first).toBeDefined();
+    expect(createContext(true).config.telemetryToken).toEqual(first);
+    expect(createContext(true, ["openai"]).config.telemetryToken).not.toEqual(first);
+    expect(client.config.get).not.toHaveBeenCalled();
+    expect(client.config.providers).not.toHaveBeenCalled();
   });
 
   it("copies default request timeout without marking it explicitly configured", () => {

--- a/tests/lib.quota-runtime-context.test.ts
+++ b/tests/lib.quota-runtime-context.test.ts
@@ -211,6 +211,24 @@ describe("quota runtime context", () => {
     expect(providerContext.config?.requestTimeoutMsConfigured).toBe(true);
   });
 
+  it("enables provider telemetry only when both plugin and telemetry are enabled", () => {
+    const client = createClient();
+    const createContext = (enabled: boolean) =>
+      createQuotaProviderRuntimeContext({
+        client,
+        resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
+        config: {
+          ...DEFAULT_CONFIG,
+          enabled,
+          telemetry: { enabled: true },
+        },
+        session: {},
+      });
+
+    expect(createContext(false).config.telemetryEnabled).toBe(false);
+    expect(createContext(true).config.telemetryEnabled).toBe(true);
+  });
+
   it("copies default request timeout without marking it explicitly configured", () => {
     const client = createClient();
     const providerContext = createQuotaProviderRuntimeContext({

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -32,6 +32,7 @@ const pkg = JSON.parse(await readFile(new URL("../package.json", import.meta.url
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   engines?: Record<string, string>;
   files?: string[];
   packageManager?: string;
@@ -78,6 +79,13 @@ describe("package manifest compatibility", () => {
     expect(readme).toContain("Node.js `>= 22` is required.");
     expect(readme).not.toContain("OpenCode `>= 1.4.3`");
     expect(pkg.engines).not.toHaveProperty("opencode");
+  });
+
+  it("keeps OpenTelemetry host-owned and optional at runtime", () => {
+    expect(pkg.peerDependencies?.["@opentelemetry/api"]).toBe("^1.9.0");
+    expect(pkg.peerDependenciesMeta?.["@opentelemetry/api"]).toEqual({ optional: true });
+    expect(pkg.devDependencies?.["@opentelemetry/api"]).toBe("^1.9.1");
+    expect(pkg.dependencies).not.toHaveProperty("@opentelemetry/api");
   });
 
   it("hardens pnpm dependency resolution against fresh-package supply-chain attacks", () => {
@@ -216,6 +224,10 @@ describe("package manifest compatibility", () => {
     expect(packedSmoke).toContain('readFile(tuiExportPath, "utf8")');
     expect(packedSmoke).toContain("dist\\\\/tui\\\\.js");
     expect(packedSmoke).not.toContain('await import("@slkiser/opencode-quota/tui")');
+    expect(packedSmoke).toContain('"@opentelemetry/api@1.9.0"');
+    expect(packedSmoke).toContain('"node_modules", "@opentelemetry", "api"');
+    expect(packedSmoke).toContain('identity: "packed-present"');
+    expect(packedSmoke).toContain('identity: "packed-absent"');
   });
 
   it("publishes only a release-tag artifact after both exact-artifact smoke jobs", () => {

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -433,7 +433,9 @@ describe("quota-state shared cache", () => {
   it("returns cache-owned clones for repeated non-live provider reads", async () => {
     const { __resetQuotaStateForTests, fetchQuotaProviderResult } =
       await import("../src/lib/quota-state.js");
+    const { configureQuotaTelemetry } = await import("../src/lib/quota-telemetry.js");
     __resetQuotaStateForTests();
+    configureQuotaTelemetry(true);
 
     const provider = {
       id: "synthetic",
@@ -458,9 +460,11 @@ describe("quota-state shared cache", () => {
       }),
     } as any;
 
+    const telemetryContext = createTestContext();
+    telemetryContext.config.telemetryEnabled = true;
     const first = await fetchQuotaProviderResult({
       provider,
-      ctx: createTestContext(),
+      ctx: telemetryContext,
       ttlMs: 60_000,
     });
     const firstEntry = first.entries[0] as any;
@@ -470,7 +474,7 @@ describe("quota-state shared cache", () => {
 
     const second = await fetchQuotaProviderResult({
       provider,
-      ctx: createTestContext(),
+      ctx: telemetryContext,
       ttlMs: 60_000,
     });
 

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -495,8 +495,13 @@ describe("quota-state shared cache", () => {
     expect(provider.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("publishes authoritative cache timestamps without changing persistence or bypass behavior", async () => {
+  it("publishes authoritative cache timestamps and retires superseded bypass snapshots", async () => {
     const callbacks = new Map<string, (result: { observe(value: number): void }) => void>();
+    const collectMetric = (name: string) => {
+      const values: number[] = [];
+      callbacks.get(name)?.({ observe: (value) => values.push(value) });
+      return values;
+    };
     const telemetry = await import("../src/lib/quota-telemetry.js");
     telemetry.__resetQuotaTelemetryForTests();
     telemetry.__setQuotaTelemetryApiLoaderForTests(async () => ({
@@ -570,11 +575,37 @@ describe("quota-state shared cache", () => {
       ttlMs: 60_000,
       bypassCache: true,
     });
-    const bypassAges: number[] = [];
-    callbacks.get("opencode.quota.cache.age")?.({
-      observe: (value) => bypassAges.push(value),
+    expect(collectMetric("opencode.quota.cache.age")).toEqual([]);
+    expect(collectMetric("opencode.quota.consumed")).toEqual([0.75]);
+
+    provider.fetch.mockResolvedValueOnce({
+      attempted: true,
+      entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 75 }],
+      errors: [],
     });
-    expect(bypassAges).toEqual([]);
+    await quotaState.fetchQuotaProviderResult({ provider, ctx, ttlMs: 0 });
+    expect(collectMetric("opencode.quota.consumed")).toEqual([0.25]);
+    vi.mocked(Date.now).mockReturnValue(2_200);
+    expect(collectMetric("opencode.quota.cache.age")).toEqual([0.6]);
+
+    provider.fetch.mockResolvedValueOnce({
+      attempted: true,
+      entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 10 }],
+      errors: [],
+    });
+    await quotaState.fetchQuotaProviderResult({
+      provider,
+      ctx,
+      ttlMs: 60_000,
+      bypassCache: true,
+    });
+    expect(collectMetric("opencode.quota.consumed")).toEqual([0.9]);
+    expect(collectMetric("opencode.quota.cache.age")).toEqual([0.6]);
+
+    provider.fetch.mockResolvedValueOnce({ attempted: true, entries: [], errors: [] });
+    await quotaState.fetchQuotaProviderResult({ provider, ctx, ttlMs: 0 });
+    expect(collectMetric("opencode.quota.consumed")).toEqual([]);
+    expect(collectMetric("opencode.quota.cache.age")).toEqual([]);
 
     telemetry.__resetQuotaTelemetryForTests();
   });

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -433,9 +433,7 @@ describe("quota-state shared cache", () => {
   it("returns cache-owned clones for repeated non-live provider reads", async () => {
     const { __resetQuotaStateForTests, fetchQuotaProviderResult } =
       await import("../src/lib/quota-state.js");
-    const { configureQuotaTelemetry } = await import("../src/lib/quota-telemetry.js");
     __resetQuotaStateForTests();
-    configureQuotaTelemetry(true);
 
     const provider = {
       id: "synthetic",
@@ -460,11 +458,9 @@ describe("quota-state shared cache", () => {
       }),
     } as any;
 
-    const telemetryContext = createTestContext();
-    telemetryContext.config.telemetryEnabled = true;
     const first = await fetchQuotaProviderResult({
       provider,
-      ctx: telemetryContext,
+      ctx: createTestContext(),
       ttlMs: 60_000,
     });
     const firstEntry = first.entries[0] as any;
@@ -474,7 +470,7 @@ describe("quota-state shared cache", () => {
 
     const second = await fetchQuotaProviderResult({
       provider,
-      ctx: telemetryContext,
+      ctx: createTestContext(),
       ttlMs: 60_000,
     });
 
@@ -497,6 +493,90 @@ describe("quota-state shared cache", () => {
       },
     });
     expect(provider.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes authoritative cache timestamps without changing persistence or bypass behavior", async () => {
+    const callbacks = new Map<string, (result: { observe(value: number): void }) => void>();
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+    telemetry.__resetQuotaTelemetryForTests();
+    telemetry.__setQuotaTelemetryApiLoaderForTests(async () => ({
+      metrics: {
+        getMeter: () => ({
+          createObservableGauge: (name: string) => ({
+            addCallback: (callback: (result: { observe(value: number): void }) => void) => {
+              callbacks.set(name, callback);
+            },
+            removeCallback: () => {},
+          }),
+        }),
+      },
+    }));
+
+    const quotaState = await import("../src/lib/quota-state.js");
+    quotaState.__resetQuotaStateForTests();
+    const ctx = createTestContext();
+    ctx.config.telemetryToken = telemetry.configureQuotaTelemetry({
+      owner: ctx.client,
+      enabled: true,
+      identity: "cache-integration",
+    });
+    const provider = {
+      id: "synthetic",
+      isAvailable: vi.fn(),
+      fetch: vi.fn().mockResolvedValue({
+        attempted: true,
+        entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
+        errors: [],
+      }),
+    } as any;
+
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    await quotaState.fetchQuotaProviderResult({ provider, ctx, ttlMs: 60_000 });
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    const key = quotaState.buildQuotaProviderStateCacheKey(provider.id, ctx);
+    const path = quotaState.getQuotaProviderStateCacheFilePath(provider.id, key);
+    const persisted = JSON.parse(await (await import("fs/promises")).readFile(path, "utf8"));
+    expect(persisted.version).toBe(2);
+    expect(persisted.timestamp).toBe(1_000);
+    expect(JSON.stringify(persisted)).not.toContain("telemetry");
+
+    vi.mocked(Date.now).mockReturnValue(1_600);
+    await quotaState.fetchQuotaProviderResult({ provider, ctx, ttlMs: 60_000 });
+    quotaState.__resetQuotaStateForTests();
+    await quotaState.readCachedProviderResult({ provider, ctx, ttlMs: 60_000 });
+    const ages: number[] = [];
+    callbacks.get("opencode.quota.cache.age")?.({
+      observe: (value) => ages.push(value),
+    });
+    expect(ages).toEqual([0.6]);
+    expect(provider.fetch).toHaveBeenCalledTimes(1);
+
+    provider.fetch.mockResolvedValueOnce({ attempted: true, entries: [], errors: [] });
+    await quotaState.fetchQuotaProviderResult({ provider, ctx, ttlMs: 0 });
+    const consumedAfterClear: number[] = [];
+    callbacks.get("opencode.quota.consumed")?.({
+      observe: (value) => consumedAfterClear.push(value),
+    });
+    expect(consumedAfterClear).toEqual([]);
+
+    provider.fetch.mockResolvedValueOnce({
+      attempted: true,
+      entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 25 }],
+      errors: [],
+    });
+    await quotaState.fetchQuotaProviderResult({
+      provider,
+      ctx,
+      ttlMs: 60_000,
+      bypassCache: true,
+    });
+    const bypassAges: number[] = [];
+    callbacks.get("opencode.quota.cache.age")?.({
+      observe: (value) => bypassAges.push(value),
+    });
+    expect(bypassAges).toEqual([]);
+
+    telemetry.__resetQuotaTelemetryForTests();
   });
 
   it("reuses cache v2 with accounting metadata across module resets", async () => {

--- a/tests/quota-telemetry.test.ts
+++ b/tests/quota-telemetry.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const otel = vi.hoisted(() => {
+  const callbacks = new Map<
+    string,
+    (result: { observe: (value: number, attributes?: Record<string, unknown>) => void }) => void
+  >();
+  const instruments: Array<{ name: string; options: Record<string, unknown> }> = [];
+  const meter = {
+    createObservableGauge: vi.fn((name: string, options: Record<string, unknown>) => {
+      instruments.push({ name, options });
+      return {
+        addCallback: (
+          callback: (result: {
+            observe: (value: number, attributes?: Record<string, unknown>) => void;
+          }) => void,
+        ) => callbacks.set(name, callback),
+      };
+    }),
+  };
+  const getMeter = vi.fn(() => meter);
+  const capturingProvider = { getMeter };
+  const currentProvider: { value: { getMeter: (...args: any[]) => any } } = {
+    value: capturingProvider,
+  };
+  const getMeterProvider = vi.fn(() => currentProvider.value);
+
+  return {
+    callbacks,
+    capturingProvider,
+    currentProvider,
+    getMeter,
+    getMeterProvider,
+    instruments,
+  };
+});
+
+vi.mock("@opentelemetry/api", () => ({
+  metrics: { getMeterProvider: otel.getMeterProvider },
+}));
+
+const ACCOUNTING = {
+  resultType: "quota",
+  acquisitionMethod: "remote_api",
+  ownership: "maintained",
+  authority: "provider_reported",
+} as const;
+
+function collect(name: string) {
+  const observations: Array<{ value: number; attributes?: Record<string, unknown> }> = [];
+  otel.callbacks.get(name)?.({
+    observe: (value, attributes) => observations.push({ value, attributes }),
+  });
+  return observations;
+}
+
+describe("quota telemetry", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    vi.resetModules();
+    otel.callbacks.clear();
+    otel.instruments.length = 0;
+    otel.currentProvider.value = otel.capturingProvider;
+  });
+
+  it("does not initialize OpenTelemetry while disabled", async () => {
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+
+    telemetry.configureQuotaTelemetry(false);
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: false,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result: {
+        attempted: true,
+        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
+        errors: [],
+      },
+    });
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+
+    expect(otel.getMeter).not.toHaveBeenCalled();
+    expect(otel.callbacks.size).toBe(0);
+  });
+
+  it("publishes normalized consumption and cache age with bounded attributes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T12:00:42.000Z"));
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+    telemetry.configureQuotaTelemetry(true);
+
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "openai",
+      timestamp: Date.parse("2026-07-25T12:00:00.000Z"),
+      result: {
+        attempted: true,
+        entries: [
+          {
+            accounting: {
+              ...ACCOUNTING,
+              sourceId: "account@example.com",
+              observedAtIso: "2026-07-25T11:59:00.000Z",
+            },
+            name: "OpenAI (account@example.com)",
+            label: "5h:",
+            percentRemaining: 25,
+          },
+          {
+            accounting: ACCOUNTING,
+            name: "OpenAI (another@example.com)",
+            label: "5 hour:",
+            percentRemaining: 10,
+          },
+          {
+            accounting: { ...ACCOUNTING, resultType: "rate_limit" },
+            name: "OpenAI Weekly https://sensitive.example",
+            percentRemaining: -20,
+          },
+          {
+            accounting: { ...ACCOUNTING, resultType: "balance" },
+            kind: "value",
+            name: "Balance",
+            value: "$42.00",
+          },
+        ],
+        errors: [{ label: "OpenAI", message: "token secret" }],
+      },
+    });
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+
+    expect(otel.getMeter).toHaveBeenCalledOnce();
+    expect(otel.instruments).toEqual([
+      {
+        name: "opencode.quota.consumed",
+        options: {
+          description: "Normalized quota consumed, where 1 is 100% consumed",
+          unit: "1",
+        },
+      },
+      {
+        name: "opencode.quota.cache.age",
+        options: {
+          description: "Age of the normalized cached quota observation",
+          unit: "s",
+        },
+      },
+    ]);
+
+    const consumed = collect("opencode.quota.consumed");
+    expect(consumed).toHaveLength(2);
+    expect(consumed.map(({ value }) => value).sort()).toEqual([0.9, 1.2]);
+    expect(consumed[0]?.attributes).toEqual({
+      "quota.provider": "openai",
+      "quota.result_type": "quota",
+      "quota.window": "five_hour",
+      "quota.acquisition_method": "remote_api",
+      "quota.ownership": "maintained",
+      "quota.authority": "provider_reported",
+    });
+    expect(JSON.stringify(consumed)).not.toMatch(
+      /account@example\.com|another@example\.com|sensitive\.example|token secret|\$42/,
+    );
+
+    const ages = collect("opencode.quota.cache.age");
+    expect(ages).toHaveLength(2);
+    expect(ages.every(({ value }) => value === 42)).toBe(true);
+  });
+
+  it("replaces stale windows, clears on disable, and ignores internal aggregate sources", async () => {
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+    telemetry.configureQuotaTelemetry(true);
+    const result = {
+      attempted: true,
+      entries: [
+        { accounting: ACCOUNTING, name: "Synthetic Daily", percentRemaining: 50 },
+        { accounting: ACCOUNTING, name: "Synthetic Weekly", percentRemaining: 25 },
+      ],
+      errors: [],
+    } as const;
+
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "quota-providers:private-source-id",
+      timestamp: Date.now(),
+      result,
+    });
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result,
+    });
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    expect(collect("opencode.quota.consumed")).toHaveLength(2);
+
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result: {
+        attempted: true,
+        entries: [result.entries[0]],
+        errors: [],
+      },
+    });
+    expect(collect("opencode.quota.consumed")).toHaveLength(1);
+
+    telemetry.configureQuotaTelemetry(false);
+    expect(collect("opencode.quota.consumed")).toEqual([]);
+  });
+
+  it("isolates observer failures from callers", async () => {
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+    telemetry.configureQuotaTelemetry(true);
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result: {
+        attempted: true,
+        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
+        errors: [],
+      },
+    });
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+
+    expect(() =>
+      otel.callbacks.get("opencode.quota.consumed")?.({
+        observe: () => {
+          throw new Error("collector failed");
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("registers instruments when the global MeterProvider changes", async () => {
+    const noopProvider = {
+      getMeter: vi.fn(() => ({
+        createObservableGauge: vi.fn(() => ({ addCallback: vi.fn() })),
+      })),
+    };
+    otel.currentProvider.value = noopProvider;
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+
+    telemetry.configureQuotaTelemetry(true);
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    expect(otel.callbacks.size).toBe(0);
+
+    otel.currentProvider.value = otel.capturingProvider;
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result: {
+        attempted: true,
+        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
+        errors: [],
+      },
+    });
+
+    expect(otel.callbacks.has("opencode.quota.consumed")).toBe(true);
+    expect(otel.callbacks.has("opencode.quota.cache.age")).toBe(true);
+  });
+
+  it("rejects snapshots from an obsolete telemetry configuration", async () => {
+    const telemetry = await import("../src/lib/quota-telemetry.js");
+    const oldGeneration = telemetry.configureQuotaTelemetry(true);
+    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    telemetry.configureQuotaTelemetry(false);
+    telemetry.configureQuotaTelemetry(true);
+
+    telemetry.updateQuotaTelemetrySnapshot({
+      enabled: true,
+      generation: oldGeneration,
+      providerId: "synthetic",
+      timestamp: Date.now(),
+      result: {
+        attempted: true,
+        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
+        errors: [],
+      },
+    });
+
+    expect(collect("opencode.quota.consumed")).toEqual([]);
+  });
+});

--- a/tests/quota-telemetry.test.ts
+++ b/tests/quota-telemetry.test.ts
@@ -1,43 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const otel = vi.hoisted(() => {
-  const callbacks = new Map<
-    string,
-    (result: { observe: (value: number, attributes?: Record<string, unknown>) => void }) => void
-  >();
-  const instruments: Array<{ name: string; options: Record<string, unknown> }> = [];
-  const meter = {
-    createObservableGauge: vi.fn((name: string, options: Record<string, unknown>) => {
-      instruments.push({ name, options });
-      return {
-        addCallback: (
-          callback: (result: {
-            observe: (value: number, attributes?: Record<string, unknown>) => void;
-          }) => void,
-        ) => callbacks.set(name, callback),
-      };
-    }),
-  };
-  const getMeter = vi.fn(() => meter);
-  const capturingProvider = { getMeter };
-  const currentProvider: { value: { getMeter: (...args: any[]) => any } } = {
-    value: capturingProvider,
-  };
-  const getMeterProvider = vi.fn(() => currentProvider.value);
-
-  return {
-    callbacks,
-    capturingProvider,
-    currentProvider,
-    getMeter,
-    getMeterProvider,
-    instruments,
-  };
-});
-
-vi.mock("@opentelemetry/api", () => ({
-  metrics: { getMeterProvider: otel.getMeterProvider },
-}));
+import type { QuotaProviderResult } from "../src/lib/entries.js";
+import {
+  __flushQuotaTelemetryInitializationForTests,
+  __resetQuotaTelemetryForTests,
+  __setQuotaTelemetryApiLoaderForTests,
+  configureQuotaTelemetry,
+  disposeQuotaTelemetryOwner,
+  retainQuotaTelemetryProviders,
+  updateQuotaTelemetrySnapshot,
+} from "../src/lib/quota-telemetry.js";
 
 const ACCOUNTING = {
   resultType: "quota",
@@ -46,90 +18,100 @@ const ACCOUNTING = {
   authority: "provider_reported",
 } as const;
 
-function collect(name: string) {
-  const observations: Array<{ value: number; attributes?: Record<string, unknown> }> = [];
-  otel.callbacks.get(name)?.({
-    observe: (value, attributes) => observations.push({ value, attributes }),
+type Observation = {
+  value: number;
+  attributes?: Record<string, unknown>;
+};
+type Callback = (result: {
+  observe(value: number, attributes?: Record<string, unknown>): void;
+}) => void;
+
+function createOtelHarness(options: { throwOnAdd?: string } = {}) {
+  const callbacks = new Map<string, Callback>();
+  const instruments: Array<{ name: string; options: Record<string, unknown> }> = [];
+  const createObservableGauge = vi.fn((name: string, gaugeOptions: Record<string, unknown>) => {
+    instruments.push({ name, options: gaugeOptions });
+    return {
+      addCallback(callback: Callback) {
+        if (options.throwOnAdd === name) throw new Error("callback registration failed");
+        callbacks.set(name, callback);
+      },
+      removeCallback(callback: Callback) {
+        if (callbacks.get(name) === callback) callbacks.delete(name);
+      },
+    };
   });
-  return observations;
+  const getMeter = vi.fn(() => ({ createObservableGauge }));
+  return {
+    api: { metrics: { getMeter } },
+    callbacks,
+    createObservableGauge,
+    getMeter,
+    instruments,
+    collect(name: string, observe?: (observation: Observation) => void): Observation[] {
+      const observations: Observation[] = [];
+      callbacks.get(name)?.({
+        observe(value, attributes) {
+          const observation = { value, attributes };
+          observations.push(observation);
+          observe?.(observation);
+        },
+      });
+      return observations;
+    },
+  };
+}
+
+function quotaResult(
+  entries: QuotaProviderResult["entries"],
+  extras: Partial<QuotaProviderResult> = {},
+): QuotaProviderResult {
+  return {
+    attempted: true,
+    entries,
+    errors: [],
+    ...extras,
+  };
+}
+
+function enable(owner: object, identity = "config-a") {
+  const token = configureQuotaTelemetry({ owner, enabled: true, identity });
+  expect(token).toBeDefined();
+  return token!;
 }
 
 describe("quota telemetry", () => {
   beforeEach(() => {
     vi.useRealTimers();
-    vi.clearAllMocks();
-    vi.resetModules();
-    otel.callbacks.clear();
-    otel.instruments.length = 0;
-    otel.currentProvider.value = otel.capturingProvider;
+    __resetQuotaTelemetryForTests();
   });
 
-  it("does not initialize OpenTelemetry while disabled", async () => {
-    const telemetry = await import("../src/lib/quota-telemetry.js");
-
-    telemetry.configureQuotaTelemetry(false);
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: false,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result: {
-        attempted: true,
-        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
-        errors: [],
-      },
-    });
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
-
-    expect(otel.getMeter).not.toHaveBeenCalled();
-    expect(otel.callbacks.size).toBe(0);
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    __resetQuotaTelemetryForTests();
   });
 
-  it("publishes normalized consumption and cache age with bounded attributes", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-07-25T12:00:42.000Z"));
-    const telemetry = await import("../src/lib/quota-telemetry.js");
-    telemetry.configureQuotaTelemetry(true);
+  it("does not load or register OpenTelemetry while disabled", async () => {
+    const loader = vi.fn(async () => createOtelHarness().api);
+    __setQuotaTelemetryApiLoaderForTests(loader);
+    const owner = {};
 
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "openai",
-      timestamp: Date.parse("2026-07-25T12:00:00.000Z"),
-      result: {
-        attempted: true,
-        entries: [
-          {
-            accounting: {
-              ...ACCOUNTING,
-              sourceId: "account@example.com",
-              observedAtIso: "2026-07-25T11:59:00.000Z",
-            },
-            name: "OpenAI (account@example.com)",
-            label: "5h:",
-            percentRemaining: 25,
-          },
-          {
-            accounting: ACCOUNTING,
-            name: "OpenAI (another@example.com)",
-            label: "5 hour:",
-            percentRemaining: 10,
-          },
-          {
-            accounting: { ...ACCOUNTING, resultType: "rate_limit" },
-            name: "OpenAI Weekly https://sensitive.example",
-            percentRemaining: -20,
-          },
-          {
-            accounting: { ...ACCOUNTING, resultType: "balance" },
-            kind: "value",
-            name: "Balance",
-            value: "$42.00",
-          },
-        ],
-        errors: [{ label: "OpenAI", message: "token secret" }],
-      },
-    });
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    expect(
+      configureQuotaTelemetry({ owner, enabled: false, identity: "disabled" }),
+    ).toBeUndefined();
+    await __flushQuotaTelemetryInitializationForTests();
 
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("registers exactly two callbacks once and reuses them across enable transitions", async () => {
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const owner = {};
+
+    const first = enable(owner);
+    await __flushQuotaTelemetryInitializationForTests();
     expect(otel.getMeter).toHaveBeenCalledOnce();
     expect(otel.instruments).toEqual([
       {
@@ -148,141 +130,334 @@ describe("quota telemetry", () => {
       },
     ]);
 
-    const consumed = collect("opencode.quota.consumed");
-    expect(consumed).toHaveLength(2);
-    expect(consumed.map(({ value }) => value).sort()).toEqual([0.9, 1.2]);
-    expect(consumed[0]?.attributes).toEqual({
-      "quota.provider": "openai",
-      "quota.result_type": "quota",
-      "quota.window": "five_hour",
-      "quota.acquisition_method": "remote_api",
-      "quota.ownership": "maintained",
-      "quota.authority": "provider_reported",
+    expect(enable(owner)).toEqual(first);
+    configureQuotaTelemetry({ owner, enabled: false, identity: "config-a" });
+    expect(otel.collect("opencode.quota.consumed")).toEqual([]);
+    enable(owner);
+    await __flushQuotaTelemetryInitializationForTests();
+
+    expect(otel.getMeter).toHaveBeenCalledOnce();
+    expect(otel.callbacks.size).toBe(2);
+  });
+
+  it("publishes clamped deterministic quota series with only bounded attributes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-25T12:00:42.000Z"));
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const token = enable({});
+
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "openai-cache",
+      providerId: "openai",
+      cacheTimestamp: Date.parse("2026-07-25T12:00:00.000Z"),
+      result: quotaResult(
+        [
+          {
+            accounting: {
+              ...ACCOUNTING,
+              sourceId: "account@example.com",
+              observedAtIso: "2026-07-25T11:59:00.000Z",
+            },
+            name: "OpenAI account@example.com",
+            label: "5h:",
+            percentRemaining: 25,
+          },
+          {
+            accounting: ACCOUNTING,
+            name: "OpenAI another@example.com",
+            label: "5 hour:",
+            percentRemaining: -20,
+          },
+          {
+            accounting: { ...ACCOUNTING, resultType: "rate_limit" },
+            name: "Private https://sensitive.example",
+            percentRemaining: 120,
+          },
+          {
+            accounting: { ...ACCOUNTING, resultType: "balance" },
+            kind: "value",
+            name: "Balance",
+            value: "$42.00",
+          },
+        ],
+        { errors: [{ label: "OpenAI", message: "token secret" }] },
+      ),
+    });
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "unknown-provider",
+      providerId: "private-customer-provider",
+      result: quotaResult([
+        {
+          accounting: ACCOUNTING,
+          name: "Private Customer",
+          percentRemaining: 50,
+        },
+      ]),
+    });
+    await __flushQuotaTelemetryInitializationForTests();
+
+    const consumed = otel.collect("opencode.quota.consumed");
+    expect(consumed.map(({ value }) => value).sort()).toEqual([0, 0.5, 1]);
+    expect(
+      consumed.every(
+        ({ attributes }) =>
+          JSON.stringify(Object.keys(attributes ?? {}).sort()) ===
+          JSON.stringify(["quota.provider", "quota.result_type", "quota.window"]),
+      ),
+    ).toBe(true);
+    expect(consumed).toContainEqual({
+      value: 1,
+      attributes: {
+        "quota.provider": "openai",
+        "quota.window": "five_hour",
+        "quota.result_type": "quota",
+      },
+    });
+    expect(consumed).toContainEqual({
+      value: 0.5,
+      attributes: {
+        "quota.provider": "other",
+        "quota.window": "unknown",
+        "quota.result_type": "quota",
+      },
     });
     expect(JSON.stringify(consumed)).not.toMatch(
       /account@example\.com|another@example\.com|sensitive\.example|token secret|\$42/,
     );
 
-    const ages = collect("opencode.quota.cache.age");
-    expect(ages).toHaveLength(2);
-    expect(ages.every(({ value }) => value === 42)).toBe(true);
+    expect(otel.collect("opencode.quota.cache.age")).toEqual([
+      {
+        value: 42,
+        attributes: { "quota.provider": "openai" },
+      },
+    ]);
   });
 
-  it("replaces stale windows, clears on disable, and ignores internal aggregate sources", async () => {
-    const telemetry = await import("../src/lib/quota-telemetry.js");
-    telemetry.configureQuotaTelemetry(true);
-    const result = {
-      attempted: true,
-      entries: [
-        { accounting: ACCOUNTING, name: "Synthetic Daily", percentRemaining: 50 },
-        { accounting: ACCOUNTING, name: "Synthetic Weekly", percentRemaining: 25 },
-      ],
-      errors: [],
-    } as const;
-
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "quota-providers:private-source-id",
-      timestamp: Date.now(),
-      result,
-    });
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result,
-    });
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
-    expect(collect("opencode.quota.consumed")).toHaveLength(2);
-
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result: {
-        attempted: true,
-        entries: [result.entries[0]],
-        errors: [],
+  it("maps aggregate sources to custom and reduces privacy-collapsed series by maximum", async () => {
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const token = enable({});
+    const entries = [
+      {
+        accounting: { ...ACCOUNTING, sourceId: "source-one" },
+        name: "First private source",
+        label: "Monthly:",
+        percentRemaining: 60,
       },
-    });
-    expect(collect("opencode.quota.consumed")).toHaveLength(1);
-
-    telemetry.configureQuotaTelemetry(false);
-    expect(collect("opencode.quota.consumed")).toEqual([]);
-  });
-
-  it("isolates observer failures from callers", async () => {
-    const telemetry = await import("../src/lib/quota-telemetry.js");
-    telemetry.configureQuotaTelemetry(true);
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result: {
-        attempted: true,
-        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
-        errors: [],
+      {
+        accounting: { ...ACCOUNTING, sourceId: "source-two" },
+        name: "Second private source",
+        label: "Month:",
+        percentRemaining: 20,
       },
-    });
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
+    ] satisfies QuotaProviderResult["entries"];
 
-    expect(() =>
-      otel.callbacks.get("opencode.quota.consumed")?.({
-        observe: () => {
-          throw new Error("collector failed");
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "aggregate",
+      providerId: "quota-providers",
+      cacheTimestamp: 1_000,
+      result: quotaResult([...entries].reverse()),
+    });
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "aggregate:private-source",
+      providerId: "quota-providers:private-source",
+      cacheTimestamp: 500,
+      result: quotaResult(entries),
+    });
+    await __flushQuotaTelemetryInitializationForTests();
+
+    expect(otel.collect("opencode.quota.consumed")).toEqual([
+      {
+        value: 0.8,
+        attributes: {
+          "quota.provider": "custom",
+          "quota.window": "month",
+          "quota.result_type": "quota",
         },
+      },
+    ]);
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    expect(otel.collect("opencode.quota.cache.age")).toEqual([
+      {
+        value: 1.5,
+        attributes: { "quota.provider": "custom" },
+      },
+    ]);
+  });
+
+  it("preserves newer cache timestamps, omits age for uncached data, and clamps future age", async () => {
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const token = enable({});
+    const result = (percentRemaining: number) =>
+      quotaResult([
+        {
+          accounting: ACCOUNTING,
+          name: "Synthetic",
+          percentRemaining,
+        },
+      ]);
+
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "cache",
+      providerId: "synthetic",
+      cacheTimestamp: 2_000,
+      result: result(50),
+    });
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "cache",
+      providerId: "synthetic",
+      cacheTimestamp: 1_000,
+      result: result(0),
+    });
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "uncached",
+      providerId: "other-private",
+      result: result(25),
+    });
+    await __flushQuotaTelemetryInitializationForTests();
+
+    expect(
+      otel
+        .collect("opencode.quota.consumed")
+        .map(({ value }) => value)
+        .sort(),
+    ).toEqual([0.5, 0.75]);
+    vi.spyOn(Date, "now").mockReturnValue(1_500);
+    expect(otel.collect("opencode.quota.cache.age")).toEqual([
+      {
+        value: 0,
+        attributes: { "quota.provider": "synthetic" },
+      },
+    ]);
+  });
+
+  it("keeps owners isolated, rejects stale generations, prunes providers, and disposes cleanly", async () => {
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const firstOwner = {};
+    const secondOwner = {};
+    const stale = enable(firstOwner, "first");
+    const second = enable(secondOwner, "second");
+    const result = quotaResult([
+      { accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 },
+    ]);
+
+    updateQuotaTelemetrySnapshot({
+      token: stale,
+      snapshotId: "first",
+      providerId: "synthetic",
+      result,
+    });
+    updateQuotaTelemetrySnapshot({
+      token: second,
+      snapshotId: "second",
+      providerId: "openai",
+      result,
+    });
+    const current = enable(firstOwner, "changed");
+    updateQuotaTelemetrySnapshot({
+      token: stale,
+      snapshotId: "late",
+      providerId: "anthropic",
+      result,
+    });
+    updateQuotaTelemetrySnapshot({
+      token: current,
+      snapshotId: "current",
+      providerId: "anthropic",
+      result,
+    });
+    retainQuotaTelemetryProviders({ token: current, providerIds: [] });
+    await __flushQuotaTelemetryInitializationForTests();
+
+    expect(otel.collect("opencode.quota.consumed")).toEqual([
+      {
+        value: 0.5,
+        attributes: {
+          "quota.provider": "openai",
+          "quota.window": "unknown",
+          "quota.result_type": "quota",
+        },
+      },
+    ]);
+    disposeQuotaTelemetryOwner(secondOwner);
+    expect(otel.collect("opencode.quota.consumed")).toEqual([]);
+  });
+
+  it("isolates API, registration, and individual observer failures", async () => {
+    const rejected = vi.fn(async () => {
+      throw new Error("optional API missing");
+    });
+    __setQuotaTelemetryApiLoaderForTests(rejected);
+    expect(() => enable({})).not.toThrow();
+    await expect(__flushQuotaTelemetryInitializationForTests()).resolves.toBeUndefined();
+
+    __resetQuotaTelemetryForTests();
+    const brokenApi = {
+      metrics: {
+        getMeter() {
+          throw new Error("meter failed");
+        },
+      },
+    };
+    __setQuotaTelemetryApiLoaderForTests(async () => brokenApi);
+    expect(() => enable({})).not.toThrow();
+    await expect(__flushQuotaTelemetryInitializationForTests()).resolves.toBeUndefined();
+
+    __resetQuotaTelemetryForTests();
+    const brokenRegistration = createOtelHarness({
+      throwOnAdd: "opencode.quota.cache.age",
+    });
+    __setQuotaTelemetryApiLoaderForTests(async () => brokenRegistration.api);
+    expect(() => enable({})).not.toThrow();
+    await expect(__flushQuotaTelemetryInitializationForTests()).resolves.toBeUndefined();
+    expect(brokenRegistration.callbacks.size).toBe(0);
+
+    __resetQuotaTelemetryForTests();
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const token = enable({});
+    updateQuotaTelemetrySnapshot({
+      token,
+      snapshotId: "one",
+      providerId: "openai",
+      result: quotaResult([
+        { accounting: ACCOUNTING, name: "Daily", percentRemaining: 50 },
+        { accounting: ACCOUNTING, name: "Weekly", percentRemaining: 25 },
+      ]),
+    });
+    await __flushQuotaTelemetryInitializationForTests();
+
+    let attempts = 0;
+    expect(() =>
+      otel.collect("opencode.quota.consumed", () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("collector failed");
       }),
     ).not.toThrow();
+    expect(attempts).toBe(2);
   });
 
-  it("registers instruments when the global MeterProvider changes", async () => {
-    const noopProvider = {
-      getMeter: vi.fn(() => ({
-        createObservableGauge: vi.fn(() => ({ addCallback: vi.fn() })),
-      })),
-    };
-    otel.currentProvider.value = noopProvider;
-    const telemetry = await import("../src/lib/quota-telemetry.js");
+  it("does not create timers while configuring or observing", async () => {
+    const otel = createOtelHarness();
+    __setQuotaTelemetryApiLoaderForTests(async () => otel.api);
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    const setTimeout = vi.spyOn(globalThis, "setTimeout");
 
-    telemetry.configureQuotaTelemetry(true);
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
-    expect(otel.callbacks.size).toBe(0);
+    enable({});
+    await __flushQuotaTelemetryInitializationForTests();
+    otel.collect("opencode.quota.consumed");
 
-    otel.currentProvider.value = otel.capturingProvider;
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result: {
-        attempted: true,
-        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
-        errors: [],
-      },
-    });
-
-    expect(otel.callbacks.has("opencode.quota.consumed")).toBe(true);
-    expect(otel.callbacks.has("opencode.quota.cache.age")).toBe(true);
-  });
-
-  it("rejects snapshots from an obsolete telemetry configuration", async () => {
-    const telemetry = await import("../src/lib/quota-telemetry.js");
-    const oldGeneration = telemetry.configureQuotaTelemetry(true);
-    await telemetry.__flushQuotaTelemetryInitializationForTests();
-    telemetry.configureQuotaTelemetry(false);
-    telemetry.configureQuotaTelemetry(true);
-
-    telemetry.updateQuotaTelemetrySnapshot({
-      enabled: true,
-      generation: oldGeneration,
-      providerId: "synthetic",
-      timestamp: Date.now(),
-      result: {
-        attempted: true,
-        entries: [{ accounting: ACCOUNTING, name: "Synthetic", percentRemaining: 50 }],
-        errors: [],
-      },
-    });
-
-    expect(collect("opencode.quota.consumed")).toEqual([]);
+    expect(setInterval).not.toHaveBeenCalled();
+    expect(setTimeout).not.toHaveBeenCalled();
   });
 });

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -4,6 +4,7 @@ const {
   buildQuotaDialogCommandOutput,
   cleanupFns,
   createTuiQuotaClient,
+  disposeQuotaTelemetryOwner,
   getTuiRuntimeRootHints,
   getTuiSessionModelMeta,
   loadTuiHomeBottomStatus,
@@ -15,6 +16,7 @@ const {
   buildQuotaDialogCommandOutput: vi.fn(),
   cleanupFns: [] as Array<() => void>,
   createTuiQuotaClient: vi.fn(() => ({ config: {} })),
+  disposeQuotaTelemetryOwner: vi.fn(),
   getTuiRuntimeRootHints: vi.fn(() => ({
     worktreeRoot: "/tmp/worktree",
     activeDirectory: "/tmp/worktree",
@@ -39,6 +41,10 @@ vi.mock("../src/lib/tui-runtime.js", () => ({
   normalizeTuiSessionID,
   resolveTuiSurfaceRegistration,
   writeTuiQuotaExportIfEnabled,
+}));
+
+vi.mock("../src/lib/quota-telemetry.js", () => ({
+  disposeQuotaTelemetryOwner,
 }));
 
 vi.mock("../src/lib/quota-dialog-commands.js", async (importOriginal) => {
@@ -252,6 +258,7 @@ describe("tui plugin smoke", () => {
       dialogSize: "xlarge",
     });
     createTuiQuotaClient.mockClear();
+    disposeQuotaTelemetryOwner.mockClear();
     getTuiRuntimeRootHints.mockClear();
     getTuiSessionModelMeta.mockReset();
     getTuiSessionModelMeta.mockResolvedValue({ modelID: "gpt-5", providerID: "openai" });
@@ -298,7 +305,14 @@ describe("tui plugin smoke", () => {
     await plugin.tui(api as any, undefined, {} as any);
 
     expect(api.keymap.registerLayer).toHaveBeenCalledOnce();
-    expect(api.lifecycle.onDispose).toHaveBeenCalledOnce();
+    expect(api.lifecycle.onDispose).toHaveBeenCalledTimes(2);
+    const telemetryCleanup = api.lifecycle.onDispose.mock.calls[0]?.[0];
+    expect(telemetryCleanup).toBeTypeOf("function");
+    telemetryCleanup?.();
+    expect(createTuiQuotaClient).toHaveBeenCalledOnce();
+    expect(disposeQuotaTelemetryOwner).toHaveBeenCalledWith(
+      createTuiQuotaClient.mock.results[0]?.value,
+    );
     expect(keymapLayers[0]?.commands.map((command) => command.slashName)).toEqual(TUI_COMMAND_IDS);
     for (const slashName of TUI_COMMAND_IDS) {
       expect(

--- a/tests/v4-phase5-cross-surface.test.ts
+++ b/tests/v4-phase5-cross-surface.test.ts
@@ -45,7 +45,30 @@ const mocks = vi.hoisted(() => ({
   fetchSessionTokensForDisplay: vi.fn(),
 }));
 
+const otel = vi.hoisted(() => {
+  const callbacks = new Map<
+    string,
+    (result: { observe(value: number, attributes?: Record<string, unknown>): void }) => void
+  >();
+  return {
+    callbacks,
+    getMeter: vi.fn(() => ({
+      createObservableGauge: vi.fn((name: string) => ({
+        addCallback: (
+          callback: (result: {
+            observe(value: number, attributes?: Record<string, unknown>): void;
+          }) => void,
+        ) => callbacks.set(name, callback),
+        removeCallback: () => callbacks.delete(name),
+      })),
+    })),
+  };
+});
+
 vi.mock("@opencode-ai/plugin", () => createPluginToolMockModule());
+vi.mock("@opentelemetry/api", () => ({
+  metrics: { getMeter: otel.getMeter },
+}));
 vi.mock("../src/lib/config.js", () => createConfigModuleMock(mocks.loadConfig));
 vi.mock("../src/providers/registry.js", () =>
   createProvidersRegistryModuleMock(mocks.getProviders),
@@ -88,6 +111,9 @@ function configFor(formatStyle: "allWindows" | "singleWindow") {
     maintainerAnnouncements: {
       enabled: false,
       home: false,
+    },
+    telemetry: {
+      enabled: true,
     },
     tuiCommandDisplay: "dialog",
     tuiSidebarPanel: {
@@ -148,6 +174,10 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
   let savedEnv: Record<string, string | undefined>;
 
   beforeEach(async () => {
+    const { __resetQuotaTelemetryForTests } = await import("../src/lib/quota-telemetry.js");
+    __resetQuotaTelemetryForTests();
+    otel.callbacks.clear();
+    otel.getMeter.mockClear();
     savedEnv = {
       PHASE5_TEAM_ACCOUNTING_KEY: process.env.PHASE5_TEAM_ACCOUNTING_KEY,
       PHASE5_OPENROUTER_KEY: process.env.PHASE5_OPENROUTER_KEY,
@@ -220,6 +250,8 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     vi.unstubAllGlobals();
     const { __resetQuotaStateForTests } = await import("../src/lib/quota-state.js");
     __resetQuotaStateForTests();
+    const { __resetQuotaTelemetryForTests } = await import("../src/lib/quota-telemetry.js");
+    __resetQuotaTelemetryForTests();
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });
   });
 
@@ -374,5 +406,51 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     for (const source of PHASE5_QUOTA_PROVIDERS) {
       expect(allOutput).not.toContain(source.url);
     }
+
+    const { __flushQuotaTelemetryInitializationForTests } =
+      await import("../src/lib/quota-telemetry.js");
+    await __flushQuotaTelemetryInitializationForTests();
+    const observations: Array<{
+      metric: string;
+      value: number;
+      attributes?: Record<string, unknown>;
+    }> = [];
+    for (const [metric, callback] of otel.callbacks) {
+      callback({
+        observe: (value, attributes) => {
+          observations.push({ metric, value, attributes });
+        },
+      });
+    }
+    expect(otel.getMeter).toHaveBeenCalledOnce();
+    expect(new Set(observations.map(({ metric }) => metric))).toEqual(
+      new Set(["opencode.quota.consumed", "opencode.quota.cache.age"]),
+    );
+    expect(
+      observations
+        .filter(({ metric }) => metric === "opencode.quota.consumed")
+        .every(
+          ({ attributes }) =>
+            attributes?.["quota.provider"] === "custom" &&
+            JSON.stringify(Object.keys(attributes).sort()) ===
+              JSON.stringify(["quota.provider", "quota.result_type", "quota.window"]),
+        ),
+    ).toBe(true);
+    expect(
+      observations
+        .filter(({ metric }) => metric === "opencode.quota.cache.age")
+        .every(
+          ({ attributes }) =>
+            JSON.stringify(attributes) === JSON.stringify({ "quota.provider": "custom" }),
+        ),
+    ).toBe(true);
+    const telemetryOutput = JSON.stringify(observations);
+    assertPhase5CanariesRedacted(telemetryOutput);
+    for (const source of PHASE5_QUOTA_PROVIDERS) {
+      expect(telemetryOutput).not.toContain(source.id);
+      expect(telemetryOutput).not.toContain(source.label);
+      expect(telemetryOutput).not.toContain(source.url);
+    }
+    expect(allOutput).not.toMatch(/telemetryToken|opencode\.quota\./);
   });
 });


### PR DESCRIPTION
## Summary

OpenCode Quota can now publish normalized quota consumption and cache freshness as opt-in OpenTelemetry observable gauges. Telemetry is disabled by default, reuses only the host global `MeterProvider`, performs no provider requests of its own, and does not configure an SDK, exporter, or timer.

Metrics use bounded accounting attributes and exclude display names, credentials, account/source identifiers, URLs, paths, model IDs, and errors. Missing or failing OpenTelemetry infrastructure remains a no-op, while existing UI behavior and JSON schemas are unchanged.

## Linked Issue

Refs #185

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.5
- Why this version is relevant to the fix: it is the current installed production runtime used to validate plugin compatibility; the Node 24 packed-package smoke also exercises the published server, TUI, and CLI entry points.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test` (158 files, 1,725 tests)
- [x] I ran `pnpm run release:check` on Node 24.18.0, including four-surface parity and packed-package smoke
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] Provider Changes does not apply; no provider implementation or authentication behavior changed

