### PR TITLE
Add Kilo Gateway quota provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | GitHub Copilot     | Automatic OAuth / [billing PAT](docs/readme/providers.md#github-copilot) | Remote API         | Usage and budget   |
 | Google AGY         | [Needs setup](docs/readme/providers.md#google-agy-quick-setup)           | Remote API         | Quota              |
 | Google Antigravity | [Needs setup](docs/readme/providers.md#google-antigravity)               | Remote API         | Quota              |
+| Kilo Gateway       | [Needs setup](docs/readme/providers.md#kilo-gateway)                    | Remote API + page fallback | Usage, quota, and balance |
 | NanoGPT            | API key/config                                                           | Remote API         | Quota and balance  |
 | Ollama Cloud       | [Needs setup](docs/readme/providers.md#ollama-cloud)                     | Dashboard scraping | Quota              |
 | OpenAI             | Automatic                                                                | Remote API         | Quota              |

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -7,7 +7,7 @@
 | Find                                 | Go to                                                                                                                                                                                                     |
 | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Provider support                     | [Pre-configured providers](#pre-configured-providers) · [Custom providers](#custom-providers)                                                                                                             |
-| Billing, API key, or dashboard setup | [GitHub Copilot](#github-copilot) · [DeepSeek](#deepseek) · [Xiaomi MiMo](#xiaomi-mimo) · [Ollama Cloud](#ollama-cloud) · [OpenCode Go](#opencode-go) · [OpenCode Zen](#opencode-zen)                     |
+| Billing, API key, or dashboard setup | [GitHub Copilot](#github-copilot) · [DeepSeek](#deepseek) · [Kilo Gateway](#kilo-gateway) · [Xiaomi MiMo](#xiaomi-mimo) · [Ollama Cloud](#ollama-cloud) · [OpenCode Go](#opencode-go) · [OpenCode Zen](#opencode-zen) |
 | CLI or companion-plugin setup        | [Anthropic](#anthropic-claude) · [Cursor](#cursor) · [Qwen Code](#qwen-code) · [Google Antigravity](#google-antigravity) · [Google AGY](#google-agy-quick-setup) · [Gemini CLI (deprecated)](#gemini-cli) |
 
 ## Pre-configured providers
@@ -27,6 +27,7 @@ Most providers work automatically. If a provider has a “Needs setup” link, o
 | GitHub Copilot     | [Needs setup](#github-copilot)         | Remote API         | Usage and budget   |
 | Google AGY         | [Needs setup](#google-agy-quick-setup) | Remote API         | Quota              |
 | Google Antigravity | [Needs setup](#google-antigravity)     | Remote API         | Quota              |
+| Kilo Gateway       | [Needs setup](#kilo-gateway)           | Remote API + page fallback | Usage, quota, and balance |
 | NanoGPT            | API key/config                         | Remote API         | Quota and balance  |
 | Ollama Cloud       | [Needs setup](#ollama-cloud)           | Dashboard scraping | Quota              |
 | OpenAI             | Automatic                              | Remote API         | Quota              |
@@ -479,6 +480,40 @@ Or put the key in trusted user/global OpenCode config, not repo-local config:
 ```
 
 If you use manual provider selection, include `deepseek` in `enabledProviders`.
+
+<a id="xiaomi-mimo"></a>
+
+### Kilo Gateway
+
+Kilo Gateway reads the signed-in `app.kilo.ai` usage APIs and reports personal 30-day usage. If Kilo later embeds credit quota or balance data in the usage page, the provider also recognizes those page payloads as a fallback.
+
+Current authenticated web app calls observed during implementation include `usageAnalytics.getSummary` through `/api/trpc` for personal usage, plus `/api/gastown/token` before `https://gastown.kiloapps.io/trpc` for gateway features.
+
+Use exactly one trusted credential source. The environment variable has priority:
+
+```bash
+export KILO_USAGE_COOKIE='__Secure-next-auth.session-token=...'
+```
+
+Or create the trusted user/global OpenCode runtime file `opencode-quota/kilo.json` (commonly `~/.config/opencode/opencode-quota/kilo.json`):
+
+```json
+{
+  "cookie": "__Secure-next-auth.session-token=..."
+}
+```
+
+Do not put this credential in a repository or workspace config. A present invalid environment value or higher-priority `kilo.json` blocks lower-priority files instead of falling back.
+
+The value may start with `Cookie:`. OpenCode Quota rejects line breaks and keeps only `__Secure-next-auth.session-token` or `next-auth.session-token` before requests.
+
+To copy the value manually:
+
+1. Sign in at `app.kilo.ai`.
+2. Open the browser Developer Tools, then **Application/Storage → Cookies**.
+3. Copy the `__Secure-next-auth.session-token` value into the environment variable or trusted file above.
+
+The confirmed OpenCode provider IDs are `kilo`, `kilo-gateway`, and `kilo-code`. In manual provider mode, put canonical `kilo` in `enabledProviders`.
 
 <a id="xiaomi-mimo"></a>
 

--- a/src/lib/kilo-config.ts
+++ b/src/lib/kilo-config.ts
@@ -1,0 +1,187 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+import { getOpencodeRuntimeDirCandidates } from "./opencode-runtime-paths.js";
+
+export interface KiloConfig {
+  cookie: string;
+}
+
+export type ResolvedKiloConfig =
+  | { state: "none" }
+  | { state: "configured"; config: KiloConfig; source: string }
+  | { state: "invalid"; source: string; error: string };
+
+export interface KiloConfigDiagnostics {
+  state: ResolvedKiloConfig["state"];
+  source: string | null;
+  error: string | null;
+  checkedPaths: string[];
+}
+
+type ReadConfigFileResult =
+  | { state: "missing" }
+  | { state: "loaded"; cookie: unknown; keys: string[] }
+  | { state: "invalid"; error: string };
+
+const KILO_COOKIE_ENV = "KILO_USAGE_COOKIE";
+const SESSION_COOKIE_NAMES = [
+  "__Secure-next-auth.session-token",
+  "next-auth.session-token",
+] as const;
+
+function getConfigCandidatePaths(): string[] {
+  const { configDirs } = getOpencodeRuntimeDirCandidates();
+  return configDirs.map((dir) => join(dir, "opencode-quota", "kilo.json"));
+}
+
+function parseCookiePairs(raw: string): Map<string, string> | null {
+  if (raw.includes("\r") || raw.includes("\n")) return null;
+
+  const withoutPrefix = raw.trim().replace(/^cookie\s*:\s*/iu, "");
+  if (!withoutPrefix) return null;
+
+  const pairs = new Map<string, string>();
+  for (const rawPair of withoutPrefix.split(";")) {
+    const pair = rawPair.trim();
+    if (!pair) continue;
+
+    const separator = pair.indexOf("=");
+    if (separator <= 0) return null;
+
+    const name = pair.slice(0, separator).trim();
+    const value = pair.slice(separator + 1).trim();
+    if (!name || !value || pairs.has(name)) return null;
+    pairs.set(name, value);
+  }
+
+  return pairs;
+}
+
+export function normalizeKiloCookieHeader(raw: string): string | null {
+  const pairs = parseCookiePairs(raw);
+  if (!pairs) return null;
+
+  for (const name of SESSION_COOKIE_NAMES) {
+    const value = pairs.get(name);
+    if (value) return `${name}=${value}`;
+  }
+
+  if (pairs.size === 1) {
+    const [[name, value]] = [...pairs.entries()];
+    if (name === "session-token" || name === "session") {
+      return `__Secure-next-auth.session-token=${value}`;
+    }
+  }
+
+  return null;
+}
+
+async function readConfigFile(path: string): Promise<ReadConfigFileResult> {
+  try {
+    const data = await readFile(path, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data);
+    } catch {
+      return { state: "invalid", error: "Failed to parse JSON" };
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { state: "invalid", error: "Config file must contain a JSON object" };
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return { state: "loaded", cookie: record.cookie, keys: Object.keys(record) };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return { state: "missing" };
+    }
+    return { state: "invalid", error: "Failed to read config file" };
+  }
+}
+
+export function resolveKiloConfigFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): ResolvedKiloConfig | null {
+  if (env[KILO_COOKIE_ENV] === undefined) return null;
+
+  const cookie = normalizeKiloCookieHeader(env[KILO_COOKIE_ENV] ?? "");
+  if (!cookie) {
+    return {
+      state: "invalid",
+      source: `env:${KILO_COOKIE_ENV}`,
+      error: "Invalid cookie header",
+    };
+  }
+
+  return {
+    state: "configured",
+    config: { cookie },
+    source: `env:${KILO_COOKIE_ENV}`,
+  };
+}
+
+export async function resolveKiloConfig(): Promise<ResolvedKiloConfig> {
+  const envResult = resolveKiloConfigFromEnv();
+  if (envResult) return envResult;
+
+  for (const path of getConfigCandidatePaths()) {
+    const fileResult = await readConfigFile(path);
+    if (fileResult.state === "missing") continue;
+    if (fileResult.state === "invalid") {
+      return { state: "invalid", source: path, error: fileResult.error };
+    }
+
+    if (fileResult.keys.length !== 1 || fileResult.keys[0] !== "cookie") {
+      return {
+        state: "invalid",
+        source: path,
+        error: "Config file must contain only the cookie field",
+      };
+    }
+    if (typeof fileResult.cookie !== "string") {
+      return {
+        state: "invalid",
+        source: path,
+        error: "Config cookie field must be a string",
+      };
+    }
+
+    const cookie = normalizeKiloCookieHeader(fileResult.cookie);
+    if (!cookie) {
+      return { state: "invalid", source: path, error: "Invalid cookie header" };
+    }
+
+    return { state: "configured", config: { cookie }, source: path };
+  }
+
+  return { state: "none" };
+}
+
+let cachedConfig: ResolvedKiloConfig | null = null;
+let cachedAt = 0;
+
+export const DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS = 30_000;
+
+export async function resolveKiloConfigCached(params?: {
+  maxAgeMs?: number;
+}): Promise<ResolvedKiloConfig> {
+  const maxAgeMs = Math.max(0, params?.maxAgeMs ?? DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS);
+  const now = Date.now();
+  if (cachedConfig && now - cachedAt < maxAgeMs) return cachedConfig;
+
+  cachedConfig = await resolveKiloConfig();
+  cachedAt = now;
+  return cachedConfig;
+}
+
+export async function getKiloConfigDiagnostics(): Promise<KiloConfigDiagnostics> {
+  const resolved = await resolveKiloConfig();
+  return {
+    state: resolved.state,
+    source: "source" in resolved ? resolved.source : null,
+    error: "error" in resolved ? resolved.error : null,
+    checkedPaths: getConfigCandidatePaths(),
+  };
+}

--- a/src/lib/kilo.ts
+++ b/src/lib/kilo.ts
@@ -1,0 +1,702 @@
+import { sanitizeSingleLineDisplaySnippet } from "./display-sanitize.js";
+import { fetchWithTimeout } from "./http.js";
+
+const KILO_USAGE_URL = "https://app.kilo.ai/usage";
+const KILO_USAGE_SUMMARY_URL = "https://app.kilo.ai/api/trpc/usageAnalytics.getSummary";
+const KILO_REQUEST_TIMEOUT_MS = 10_000;
+const KILO_RESPONSE_MAX_BYTES = 512 * 1024;
+const KILO_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+
+export interface KiloUsageResult {
+  usedMicrodollars: number | null;
+  limitMicrodollars: number | null;
+  balanceMicrodollars: number | null;
+  resetTimeIso: string | null;
+  planName: string | null;
+  requestCount: number | null;
+  totalTokens: number | null;
+  freeRequestCount: number | null;
+  byokRequestCount: number | null;
+  /** Subscription tier from kiloPass.getState (e.g. "tier_19") */
+  subscriptionTier: string | null;
+  /** Subscription cadence (e.g. "monthly") */
+  subscriptionCadence: string | null;
+  /** Paid credits for this period in microdollars */
+  periodBaseCreditsUsd: number | null;
+  /** Bonus credits for this period in microdollars */
+  periodBonusCreditsUsd: number | null;
+  /** Hosting cost for this period in microdollars */
+  periodHostingCostUsd: number | null;
+  /** Total credit balance from credit blocks in microdollars */
+  creditBalanceMicrodollars: number | null;
+}
+
+export type KiloDashboardResult =
+  | { success: true; data: KiloUsageResult }
+  | { success: false; error: string };
+
+function emptyKiloUsageResult(): KiloUsageResult {
+  return {
+    usedMicrodollars: null,
+    limitMicrodollars: null,
+    balanceMicrodollars: null,
+    resetTimeIso: null,
+    planName: null,
+    requestCount: null,
+    totalTokens: null,
+    freeRequestCount: null,
+    byokRequestCount: null,
+    subscriptionTier: null,
+    subscriptionCadence: null,
+    periodBaseCreditsUsd: null,
+    periodBonusCreditsUsd: null,
+    periodHostingCostUsd: null,
+    creditBalanceMicrodollars: null,
+  };
+}
+
+function parseNonNegativeNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+
+  const normalized = value.trim().replace(/,/gu, "");
+  if (!/^\d+(?:\.\d+)?$/u.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function parseMoneyToMicrodollars(value: unknown): number | null {
+  const number = parseNonNegativeNumber(value);
+  if (number === null) return null;
+  return Number.isInteger(number) && number > 10_000 ? number : Math.round(number * 1_000_000);
+}
+
+function pickNumber(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (value === undefined || value === null) continue;
+    const parsed = parseMoneyToMicrodollars(value);
+    if (parsed !== null) return parsed;
+  }
+  return null;
+}
+
+function pickString(record: Record<string, unknown>, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value !== "string" || !value.trim()) continue;
+    return sanitizeSingleLineDisplaySnippet(value, 60) || null;
+  }
+  return null;
+}
+
+function mergeResult(target: KiloUsageResult, source: KiloUsageResult): void {
+  target.usedMicrodollars ??= source.usedMicrodollars;
+  target.limitMicrodollars ??= source.limitMicrodollars;
+  target.balanceMicrodollars ??= source.balanceMicrodollars;
+  target.resetTimeIso ??= source.resetTimeIso;
+  target.planName ??= source.planName;
+  target.requestCount ??= source.requestCount;
+  target.totalTokens ??= source.totalTokens;
+  target.freeRequestCount ??= source.freeRequestCount;
+  target.byokRequestCount ??= source.byokRequestCount;
+  target.subscriptionTier ??= source.subscriptionTier;
+  target.subscriptionCadence ??= source.subscriptionCadence;
+  target.periodBaseCreditsUsd ??= source.periodBaseCreditsUsd;
+  target.periodBonusCreditsUsd ??= source.periodBonusCreditsUsd;
+  target.periodHostingCostUsd ??= source.periodHostingCostUsd;
+  target.creditBalanceMicrodollars ??= source.creditBalanceMicrodollars;
+}
+
+function parseKiloRecord(record: Record<string, unknown>): KiloUsageResult {
+  const usedMicrodollars = pickNumber(record, [
+    "usedMicrodollars",
+    "used_microdollars",
+    "usageMicrodollars",
+    "usage_microdollars",
+    "spentMicrodollars",
+    "spent_microdollars",
+    "used",
+    "usage",
+    "spent",
+  ]);
+  const limitMicrodollars = pickNumber(record, [
+    "limitMicrodollars",
+    "limit_microdollars",
+    "monthlyLimitMicrodollars",
+    "monthly_limit_microdollars",
+    "creditLimitMicrodollars",
+    "credit_limit_microdollars",
+    "limit",
+  ]);
+  const balanceMicrodollars = pickNumber(record, [
+    "balanceMicrodollars",
+    "balance_microdollars",
+    "creditBalanceMicrodollars",
+    "credit_balance_microdollars",
+    "remainingMicrodollars",
+    "remaining_microdollars",
+    "balance",
+    "remaining",
+  ]);
+  const resetTimeIso = pickString(record, [
+    "resetTimeIso",
+    "reset_time_iso",
+    "resetAt",
+    "reset_at",
+    "renewsAt",
+    "renews_at",
+    "currentPeriodEnd",
+    "current_period_end",
+  ]);
+  const planName = pickString(record, [
+    "planName",
+    "plan_name",
+    "plan",
+    "tier",
+    "subscriptionPlan",
+    "subscription_plan",
+  ]);
+
+  return {
+    ...emptyKiloUsageResult(),
+    usedMicrodollars,
+    limitMicrodollars,
+    balanceMicrodollars,
+    resetTimeIso,
+    planName,
+  };
+}
+
+function parseJsonValue(value: unknown, depth = 0): KiloUsageResult {
+  const result = emptyKiloUsageResult();
+  if (depth > 10 || value === null || value === undefined) return result;
+
+  if (Array.isArray(value)) {
+    for (const item of value) mergeResult(result, parseJsonValue(item, depth + 1));
+    return result;
+  }
+
+  if (typeof value !== "object") return result;
+
+  const record = value as Record<string, unknown>;
+  mergeResult(result, parseKiloRecord(record));
+  for (const child of Object.values(record)) mergeResult(result, parseJsonValue(child, depth + 1));
+  return result;
+}
+
+function hasUsageData(result: KiloUsageResult): boolean {
+  return (
+    result.balanceMicrodollars !== null ||
+    result.creditBalanceMicrodollars !== null ||
+    result.usedMicrodollars !== null ||
+    result.requestCount !== null ||
+    result.totalTokens !== null ||
+    (result.usedMicrodollars !== null && result.limitMicrodollars !== null && result.limitMicrodollars > 0)
+  );
+}
+
+function extractJsonCandidates(text: string): unknown[] {
+  const candidates: unknown[] = [];
+  const scriptRe = /<script[^>]+id=["']__NEXT_DATA__["'][^>]*>([\s\S]*?)<\/script>/giu;
+  let match: RegExpExecArray | null;
+  while ((match = scriptRe.exec(text)) !== null) {
+    try {
+      candidates.push(JSON.parse(match[1] ?? ""));
+    } catch {
+      // Ignore unrelated script payloads.
+    }
+  }
+
+  const objectRe = /\{[^{}]*(?:credit|balance|usage|limit|subscription|plan)[^{}]*\}/giu;
+  while ((match = objectRe.exec(text)) !== null) {
+    try {
+      candidates.push(JSON.parse(match[0]));
+    } catch {
+      // Next.js RSC lines are not always valid JSON objects.
+    }
+  }
+
+  return candidates;
+}
+
+function parseTextFallback(text: string): KiloUsageResult {
+  const result = emptyKiloUsageResult();
+
+  const money = "\\$?\\s*([0-9][0-9,]*(?:\\.[0-9]+)?)";
+  const patterns = [
+    { key: "balanceMicrodollars", re: new RegExp(`(?:balance|remaining credits?)\\D{0,40}${money}`, "iu") },
+    { key: "usedMicrodollars", re: new RegExp(`(?:used|usage|spent)\\D{0,40}${money}`, "iu") },
+    { key: "limitMicrodollars", re: new RegExp(`(?:limit|monthly credits?)\\D{0,40}${money}`, "iu") },
+  ] as const;
+
+  for (const { key, re } of patterns) {
+    const match = text.match(re);
+    if (!match?.[1]) continue;
+    result[key] = parseMoneyToMicrodollars(match[1]);
+  }
+
+  const resetMatch = text.match(/(?:reset|renew|renews)[^0-9]{0,40}(\d{4}-\d{2}-\d{2}(?:T[0-9:.Z+-]+)?)/iu);
+  if (resetMatch?.[1]) result.resetTimeIso = resetMatch[1];
+
+  const planMatch = text.match(/(?:plan|tier)[^A-Za-z0-9]{0,20}([A-Za-z][A-Za-z0-9 _-]{1,40})/iu);
+  if (planMatch?.[1]) result.planName = sanitizeSingleLineDisplaySnippet(planMatch[1], 60) || null;
+
+  return result;
+}
+
+export function parseKiloUsagePage(text: string): KiloUsageResult | null {
+  const combined = emptyKiloUsageResult();
+
+  for (const candidate of extractJsonCandidates(text)) {
+    mergeResult(combined, parseJsonValue(candidate));
+  }
+  mergeResult(combined, parseTextFallback(text));
+
+  return hasUsageData(combined) ? combined : null;
+}
+
+function buildUsageSummaryUrl(now = new Date()): string {
+  const endDate = now.toISOString();
+  const start = new Date(now);
+  start.setUTCDate(start.getUTCDate() - 30);
+  const input = {
+    startDate: start.toISOString(),
+    endDate,
+    granularity: "day",
+    personalScope: "personal-only",
+    viewAs: "self",
+  };
+  const url = new URL(KILO_USAGE_SUMMARY_URL);
+  url.searchParams.set("input", JSON.stringify(input));
+  return url.toString();
+}
+
+function parseInteger(value: unknown): number | null {
+  const parsed = parseNonNegativeNumber(value);
+  return parsed === null ? null : Math.floor(parsed);
+}
+
+export function parseKiloUsageSummaryResponse(text: string): KiloUsageResult | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+
+  const data = (parsed as { result?: { data?: unknown } }).result?.data;
+  if (typeof data !== "object" || data === null) return null;
+  const record = data as Record<string, unknown>;
+  const result = {
+    ...emptyKiloUsageResult(),
+    usedMicrodollars: parseMoneyToMicrodollars(record.costMicrodollars),
+    planName: "Last 30 days",
+    requestCount: parseInteger(record.requestCount),
+    totalTokens: parseInteger(record.totalTokens),
+    freeRequestCount: parseInteger(record.freeRequestCount),
+    byokRequestCount: parseInteger(record.byokRequestCount),
+  };
+
+  return hasUsageData(result) ? result : null;
+}
+
+const KILO_PROFILE_BALANCE_URL = "https://app.kilo.ai/api/profile/balance";
+const KILO_TRPC_BASE = "https://app.kilo.ai/api/trpc";
+
+function buildTrpcUrl(procedure: string, input?: unknown): string {
+  const url = new URL(`${KILO_TRPC_BASE}/${procedure}`);
+  if (input !== undefined) url.searchParams.set("input", JSON.stringify(input));
+  return url.toString();
+}
+
+function parseProfileBalanceResponse(text: string): number | null {
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const record = parsed as Record<string, unknown>;
+    if (typeof record.balance === "number" && Number.isFinite(record.balance)) {
+      return Math.round(record.balance * 1_000_000);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface KiloPassStateData {
+  subscription?: {
+    subscriptionId?: string;
+    tier?: string;
+    cadence?: string;
+    status?: string;
+    currentPeriodBaseCreditsUsd?: number;
+    currentPeriodUsageUsd?: number;
+    currentPeriodBonusCreditsUsd?: number;
+    currentPeriodHostingCostUsd?: number;
+    nextBonusCreditsUsd?: number;
+    nextBillingAt?: string;
+    refillAt?: string;
+    currentStreakMonths?: number;
+    isFirstTimeSubscriberEver?: boolean;
+  };
+}
+
+function parseKiloPassStateResponse(text: string): {
+  tier: string | null;
+  cadence: string | null;
+  used: number | null;
+  limit: number | null;
+  bonus: number | null;
+  hosting: number | null;
+  refillAt: string | null;
+} | null {
+  try {
+    const parsed = JSON.parse(text) as {
+      result?: { data?: KiloPassStateData };
+    };
+    const sub = parsed?.result?.data?.subscription;
+    if (!sub) return null;
+    const used =
+      typeof sub.currentPeriodUsageUsd === "number" && Number.isFinite(sub.currentPeriodUsageUsd)
+        ? Math.round(sub.currentPeriodUsageUsd * 1_000_000)
+        : null;
+    const base =
+      typeof sub.currentPeriodBaseCreditsUsd === "number" && Number.isFinite(sub.currentPeriodBaseCreditsUsd)
+        ? Math.round(sub.currentPeriodBaseCreditsUsd * 1_000_000)
+        : null;
+    const bonus =
+      typeof sub.currentPeriodBonusCreditsUsd === "number" && Number.isFinite(sub.currentPeriodBonusCreditsUsd)
+        ? Math.round(sub.currentPeriodBonusCreditsUsd * 1_000_000)
+        : null;
+    const hosting =
+      typeof sub.currentPeriodHostingCostUsd === "number" && Number.isFinite(sub.currentPeriodHostingCostUsd)
+        ? Math.round(sub.currentPeriodHostingCostUsd * 1_000_000)
+        : null;
+    const limit = base !== null && bonus !== null ? base + bonus : base;
+    return {
+      tier: sub.tier ?? null,
+      cadence: sub.cadence ?? null,
+      used,
+      limit,
+      bonus,
+      hosting,
+      refillAt: sub.refillAt ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+interface CreditBlocksData {
+  creditBlocks?: Array<{
+    balance_mUsd?: number;
+    expiry_date?: string | null;
+    is_free?: boolean;
+  }>;
+  totalBalance_mUsd?: number;
+}
+
+function parseCreditBlocksResponse(text: string): {
+  totalBalance_mUsd: number | null;
+} | null {
+  try {
+    const parsed = JSON.parse(text) as {
+      result?: { data?: CreditBlocksData };
+    };
+    const data = parsed?.result?.data;
+    if (!data) return null;
+    const totalBalance =
+      typeof data.totalBalance_mUsd === "number" && Number.isFinite(data.totalBalance_mUsd)
+        ? data.totalBalance_mUsd
+        : null;
+    return { totalBalance_mUsd: totalBalance };
+  } catch {
+    return null;
+  }
+}
+
+async function queryKiloProfile(
+  cookie: string,
+  timeoutMs: number,
+): Promise<KiloUsageResult | null> {
+  const result = emptyKiloUsageResult();
+
+  const balancePromise = fetchWithTimeout(KILO_PROFILE_BALANCE_URL, {
+    request: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Cookie: cookie,
+        Referer: "https://app.kilo.ai/profile",
+        "User-Agent": KILO_USER_AGENT,
+      },
+    },
+    timeoutMs,
+    consume: async (response) => {
+      if (!response.ok) return null;
+      const text = await readBoundedText(response);
+      return parseProfileBalanceResponse(text);
+    },
+  });
+
+  const statePromise = fetchWithTimeout(buildTrpcUrl("kiloPass.getState"), {
+    request: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Cookie: cookie,
+        Referer: "https://app.kilo.ai/profile",
+        "User-Agent": KILO_USER_AGENT,
+      },
+    },
+    timeoutMs,
+    consume: async (response) => {
+      if (!response.ok) return null;
+      const text = await readBoundedText(response);
+      return parseKiloPassStateResponse(text);
+    },
+  });
+
+  const creditBlocksPromise = fetchWithTimeout(buildTrpcUrl("user.getCreditBlocks", {}), {
+    request: {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Cookie: cookie,
+        Referer: "https://app.kilo.ai/profile",
+        "User-Agent": KILO_USER_AGENT,
+      },
+    },
+    timeoutMs,
+    consume: async (response) => {
+      if (!response.ok) return null;
+      const text = await readBoundedText(response);
+      return parseCreditBlocksResponse(text);
+    },
+  });
+
+  const [balance, state, creditBlocks] = await Promise.allSettled([
+    balancePromise,
+    statePromise,
+    creditBlocksPromise,
+  ]);
+
+  if (balance.status === "fulfilled" && balance.value !== null) {
+    result.balanceMicrodollars = balance.value;
+  }
+  if (state.status === "fulfilled" && state.value !== null) {
+    result.usedMicrodollars ??= state.value.used;
+    result.limitMicrodollars ??= state.value.limit;
+    result.subscriptionTier = state.value.tier;
+    result.subscriptionCadence = state.value.cadence;
+    result.periodBaseCreditsUsd =
+      state.value.limit !== null && state.value.bonus !== null ? state.value.limit - state.value.bonus : null;
+    result.periodBonusCreditsUsd = state.value.bonus;
+    result.periodHostingCostUsd = state.value.hosting;
+    result.resetTimeIso ??= state.value.refillAt;
+    result.planName ??= derivePlanName(state.value.tier, state.value.cadence);
+  }
+  if (creditBlocks.status === "fulfilled" && creditBlocks.value !== null) {
+    result.creditBalanceMicrodollars = creditBlocks.value.totalBalance_mUsd;
+  }
+
+  return hasUsageData(result) ? result : null;
+}
+
+function mergedRequestCounts(target: KiloUsageResult, source: KiloUsageResult): void {
+  target.requestCount ??= source.requestCount;
+  target.totalTokens ??= source.totalTokens;
+  target.freeRequestCount ??= source.freeRequestCount;
+  target.byokRequestCount ??= source.byokRequestCount;
+  target.usedMicrodollars ??= source.usedMicrodollars;
+}
+
+function derivePlanName(tier: string | null, cadence: string | null): string | null {
+  if (!tier && !cadence) return null;
+  const parts: string[] = [];
+  if (tier) {
+    if (tier === "tier_19") parts.push("Starter");
+    else if (tier === "tier_49") parts.push("Pro");
+    else if (tier === "tier_99") parts.push("Expert");
+    else parts.push(tier.replace(/^tier_/iu, "Tier "));
+  }
+  return parts.join(" • ") || null;
+}
+
+async function readBoundedText(response: Response): Promise<string> {
+  if (!response.body) throw new Error("empty response");
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+
+  try {
+    const contentLength = Number(response.headers.get("content-length"));
+    if (Number.isFinite(contentLength) && contentLength > KILO_RESPONSE_MAX_BYTES) {
+      throw new Error("response too large");
+    }
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      byteLength += value.byteLength;
+      if (byteLength > KILO_RESPONSE_MAX_BYTES) throw new Error("response too large");
+      chunks.push(value);
+    }
+  } catch (error) {
+    try {
+      await reader.cancel();
+    } catch {
+      // Preserve original read error.
+    }
+    throw error;
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
+}
+
+function getCookieValues(cookie: string): string[] {
+  return cookie
+    .split(";")
+    .map((part) => part.slice(part.indexOf("=") + 1).trim())
+    .filter(Boolean);
+}
+
+function sanitizeRequestError(error: unknown, cookie: string): string {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const secret of [cookie, ...getCookieValues(cookie)]) {
+    message = message.split(secret).join("[redacted]");
+  }
+  return sanitizeSingleLineDisplaySnippet(message, 120) || "request failed";
+}
+
+export async function queryKiloDashboard(
+  cookie: string,
+  options: { requestTimeoutMs?: number } = {},
+): Promise<KiloDashboardResult> {
+  try {
+    const timeoutMs = options.requestTimeoutMs ?? KILO_REQUEST_TIMEOUT_MS;
+    const summary = await fetchWithTimeout(buildUsageSummaryUrl(), {
+      request: {
+        method: "GET",
+        redirect: "manual",
+        headers: {
+          Accept: "application/json",
+          Cookie: cookie,
+          Referer: "https://app.kilo.ai/usage",
+          "User-Agent": KILO_USER_AGENT,
+        },
+      },
+      timeoutMs,
+      consume: async (response, timeoutSignal): Promise<KiloDashboardResult> => {
+        if (response.status === 401 || response.status === 403) {
+          return { success: false, error: "Kilo Gateway usage request requires login" };
+        }
+        if (!response.ok) {
+          return { success: false, error: `Kilo Gateway usage summary request failed (HTTP ${response.status})` };
+        }
+
+        let text: string;
+        try {
+          text = await readBoundedText(response);
+        } catch (error) {
+          if (timeoutSignal.aborted) throw error;
+          return { success: false, error: "Kilo Gateway usage summary response could not be read" };
+        }
+
+        const parsed = parseKiloUsageSummaryResponse(text);
+        if (!parsed) {
+          return {
+            success: false,
+            error: "Kilo Gateway usage summary did not contain recognized usage data",
+          };
+        }
+
+        return { success: true, data: parsed };
+      },
+    });
+    if (!summary.success && summary.error === "Kilo Gateway usage request requires login") return summary;
+
+    const combined = emptyKiloUsageResult();
+
+    const profileResult = await queryKiloProfile(cookie, timeoutMs);
+    if (profileResult) mergeResult(combined, profileResult);
+
+    if (summary.success && summary.data) {
+      mergedRequestCounts(combined, summary.data);
+      combined.planName ??= "Last 30 days";
+    } else {
+      const pageResult = await fetchWithTimeout(KILO_USAGE_URL, {
+        request: {
+          method: "GET",
+          redirect: "manual",
+          headers: {
+            Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            Cookie: cookie,
+            Referer: "https://app.kilo.ai/usage",
+            "User-Agent": KILO_USER_AGENT,
+          },
+        },
+        timeoutMs,
+        consume: async (response, timeoutSignal): Promise<KiloDashboardResult> => {
+          if (response.status >= 300 && response.status < 400) {
+            return { success: false, error: "Kilo Gateway usage request requires login" };
+          }
+          if (!response.ok) {
+            return { success: false, error: `Kilo Gateway usage request failed (HTTP ${response.status})` };
+          }
+
+          let text: string;
+          try {
+            text = await readBoundedText(response);
+          } catch (error) {
+            if (timeoutSignal.aborted) throw error;
+            return { success: false, error: "Kilo Gateway usage response could not be read" };
+          }
+
+          const parsed = parseKiloUsagePage(text);
+          if (!parsed) {
+            return {
+              success: false,
+              error: "Kilo Gateway usage response did not contain recognized quota or balance data",
+            };
+          }
+
+          return { success: true, data: parsed };
+        },
+      });
+      if (pageResult.success && pageResult.data) {
+        mergeResult(combined, pageResult.data);
+      }
+    }
+
+    if (!hasUsageData(combined)) {
+      return {
+        success: false,
+        error: "No usage data found in Kilo Gateway usage API or page",
+      };
+    }
+
+    return { success: true, data: combined };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Kilo Gateway usage request failed: ${sanitizeRequestError(error, cookie)}`,
+    };
+  }
+}

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -270,6 +270,18 @@ const PROVIDER_CATALOG_SOURCE = {
       notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
     },
   },
+  kilo: {
+    label: "Kilo Gateway",
+    runtimeIds: ["kilo", "kilo-gateway", "kilo-code"],
+    synonyms: ["kilo-gateway", "kilo-code"],
+    shape: {
+      autoSetup: "needs_quick_setup",
+      authentication: "state_only",
+      quota: "remote_api",
+      quickSetupAnchor: "kilo-gateway",
+      notes: "Reads Kilo usage APIs with a filtered trusted session cookie",
+    },
+  },
   xiaomi: {
     label: "Xiaomi MiMo",
     runtimeIds: [

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -81,18 +81,6 @@ const PROVIDER_CATALOG_SOURCE = {
       quota: "remote_api",
     },
   },
-  kilo: {
-    label: "Kilo Gateway",
-    runtimeIds: ["kilo"],
-    synonyms: [],
-    shape: {
-      autoSetup: "usually",
-      authentication: "opencode_auth_api_key",
-      authFallbacks: ["env_api_key", "global_opencode_config"],
-      quota: "remote_api",
-      notes: "Queries the documented Kilo profile balance API; reports personal USD balance only",
-    },
-  },
   cursor: {
     label: "Cursor",
     runtimeIds: ["cursor", "cursor-acp"],

--- a/src/lib/quota-entry-display.ts
+++ b/src/lib/quota-entry-display.ts
@@ -63,8 +63,12 @@ export function buildSingleWindowPercentEntryDisplayName(entry: QuotaToastEntry)
   }
 
   if (group) {
-    const provider = formatGroupedHeader(group);
-    return windowLabel ? `${provider} ${windowLabel}` : provider;
+    const groupedPlan = group.match(/^\[([^\]]+)\]\s+(.+)$/u);
+    const provider = groupedPlan ? `[${groupedPlan[1]}] (${groupedPlan[2]!.trim()})` : formatGroupedHeader(group);
+    const customLabel = classifyQuotaWindowText(entry.label ?? "")
+      ? ""
+      : normalizeSingleWindowLabelText(entry.label);
+    return windowLabel ? `${provider} ${windowLabel}` : customLabel ? `${provider} ${customLabel}` : provider;
   }
 
   return name;

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -386,12 +386,19 @@ function buildSingleWindowName(params: {
     params.singleWindowDisplayName?.trim() ||
     params.entry.name.trim() ||
     "";
-  const provider = formatGroupedHeader(providerText);
+  const groupedPlan = providerText.match(/^\[([^\]]+)\]\s+(.+)$/u);
+  const provider = groupedPlan
+    ? `[${groupedPlan[1]}] (${groupedPlan[2]!.trim()})`
+    : formatGroupedHeader(providerText);
   const windowLabel =
     normalizeSingleWindowWindowLabel(params.entry.label) ??
     normalizeSingleWindowWindowLabel(params.entry.name);
+  const customLabel =
+    groupedPlan && !classifyQuotaWindowText(params.entry.label ?? "")
+      ? (params.entry.label?.trim().replace(/:+$/u, "").trim() ?? "")
+      : "";
 
-  return windowLabel ? `${provider} ${windowLabel}` : provider;
+  return windowLabel ? `${provider} ${windowLabel}` : customLabel ? `${provider} ${customLabel}` : provider;
 }
 
 function renameSingleWindowEntry(entry: QuotaToastEntry, name: string): QuotaToastEntry {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -388,7 +388,13 @@ function buildSingleWindowName(params: {
     "";
   const groupedPlan = providerText.match(/^\[([^\]]+)\]\s+(.+)$/u);
   const provider = groupedPlan
-    ? `[${groupedPlan[1]}] (${groupedPlan[2]!.trim()})`
+    ? (() => {
+        const plan = groupedPlan[2]!.trim();
+        const hasParens = plan.startsWith("(") && plan.endsWith(")");
+        return hasParens
+          ? `[${groupedPlan[1]}] ${plan}`
+          : `[${groupedPlan[1]}] (${plan})`;
+      })()
     : formatGroupedHeader(providerText);
   const windowLabel =
     normalizeSingleWindowWindowLabel(params.entry.label) ??

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -584,6 +584,14 @@ function supportedProviderPricingRow(params: {
     };
   }
 
+  if (id === "kilo") {
+    return {
+      id,
+      pricing: "no",
+      notes: "usage API plus credit quota/balance page fallback (not token-priced)",
+    };
+  }
+
   if (id === "kimi-for-coding" || id === "kimi-code") {
     return {
       id,
@@ -741,7 +749,10 @@ export async function buildQuotaStatusReport(params: {
     );
   }
   toastLines.push("- providers:");
-  for (const p of params.providerAvailability) {
+  const sortedAvailability = [...params.providerAvailability].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+  for (const p of sortedAvailability) {
     const bits: string[] = [];
     bits.push(p.enabled ? "enabled" : "disabled");
     bits.push(p.available ? "available" : "unavailable");
@@ -892,6 +903,7 @@ export async function buildQuotaStatusReport(params: {
     { id: "kimi", title: "kimi:", providerId: "kimi-for-coding" },
     { id: "opencode_go", title: "opencode_go:", providerId: "opencode-go" },
     { id: "opencode_zen", title: "opencode_zen:", providerId: "opencode" },
+    { id: "kilo", title: "kilo:", providerId: "kilo" },
     { id: "xiaomi", title: "xiaomi:", providerId: "xiaomi" },
     { id: "zai", title: "zai:", providerId: "zai" },
     { id: "zhipu", title: "zhipu:", providerId: "zhipu" },

--- a/src/lib/toast-format-grouped.ts
+++ b/src/lib/toast-format-grouped.ts
@@ -117,6 +117,7 @@ export function formatQuotaRowsGrouped(params: {
           decimals: params.resetTimeDecimals,
         });
         const value = entry.value.trim();
+        const leftText = right ? `${label} ${right}` : label;
 
         if (isTiny) {
           // Tiny: "label  time  value"
@@ -128,7 +129,6 @@ export function formatQuotaRowsGrouped(params: {
             1,
             maxWidth - separator.length - timeWidth - separator.length - valueCol,
           );
-          const leftText = right ? `${label} ${right}` : label;
           const line = [
             padRight(leftText, tinyNameCol),
             padLeft(timeStr, timeWidth),
@@ -138,23 +138,34 @@ export function formatQuotaRowsGrouped(params: {
           continue;
         }
 
-        // Non-tiny: single line (no bar)
-        const timeWidth = Math.max(timeStr.length, timeCol);
-        const valueWidth = Math.max(value.length, 6);
-        const leftMax = Math.max(
-          1,
-          barWidth - separator.length - valueWidth - separator.length - timeWidth,
-        );
-        const leftText = right ? `${label} ${right}` : label;
-        lines.push(
-          (
-            padRight(leftText, leftMax) +
-            separator +
-            padLeft(value, valueWidth) +
-            separator +
-            padLeft(timeStr, timeWidth)
-          ).slice(0, maxWidth),
-        );
+        if (timeStr) {
+          // Non-tiny with reset time: label + value + time
+          const timeWidth = Math.max(timeStr.length, timeCol);
+          const valueWidth = Math.max(value.length, 6);
+          const leftMax = Math.max(
+            1,
+            maxWidth - separator.length - valueWidth - separator.length - timeWidth,
+          );
+          lines.push(
+            (
+              padRight(leftText, leftMax) +
+              separator +
+              padLeft(value, valueWidth) +
+              separator +
+              padLeft(timeStr, timeWidth)
+            ).slice(0, maxWidth),
+          );
+        } else {
+          // Non-tiny without reset time: no time column wasted
+          const valueWidth = Math.max(value.length, 6);
+          const leftMax = Math.max(1, maxWidth - separator.length - valueWidth);
+          lines.push(
+            (padRight(leftText, leftMax) + separator + padLeft(value, valueWidth)).slice(
+              0,
+              maxWidth,
+            ),
+          );
+        }
         continue;
       }
 

--- a/src/lib/tui-compact-format.ts
+++ b/src/lib/tui-compact-format.ts
@@ -76,7 +76,13 @@ function getProviderName(entry: QuotaToastEntry): string {
 
   if (entry.group?.trim()) {
     const groupedPlan = entry.group.trim().match(/^\[([^\]]+)\]\s+(.+)$/u);
-    if (groupedPlan) return `[${groupedPlan[1]!.trim()}] (${groupedPlan[2]!.trim()})`;
+    if (groupedPlan) {
+        const plan = groupedPlan[2]!.trim();
+        const hasParens = plan.startsWith("(") && plan.endsWith(")");
+        return hasParens
+          ? `[${groupedPlan[1]!.trim()}] ${plan}`
+          : `[${groupedPlan[1]!.trim()}] (${plan})`;
+      }
     return formatCompactProviderLabel(formatGroupedHeader(entry.group));
   }
 

--- a/src/lib/tui-compact-format.ts
+++ b/src/lib/tui-compact-format.ts
@@ -75,6 +75,8 @@ function getProviderName(entry: QuotaToastEntry): string {
   if (bracketedProvider) return formatCompactProviderLabel(bracketedProvider);
 
   if (entry.group?.trim()) {
+    const groupedPlan = entry.group.trim().match(/^\[([^\]]+)\]\s+(.+)$/u);
+    if (groupedPlan) return `[${groupedPlan[1]!.trim()}] (${groupedPlan[2]!.trim()})`;
     return formatCompactProviderLabel(formatGroupedHeader(entry.group));
   }
 
@@ -119,7 +121,8 @@ function formatCompactPercentGroupSegment(group: CompactPercentGroup): string | 
           .map((window) => (window.label ? `${window.label} ${window.percent}` : window.percent))
           .join(COMPACT_WINDOW_SEPARATOR);
 
-  const separator = windows.every((window) => window.label && !window.isWindow) ? ": " : " ";
+  const hasOnlyCustomLabels = windows.every((window) => window.label && !window.isWindow);
+  const separator = hasOnlyCustomLabels && !group.provider.startsWith("[") ? ": " : " ";
   return compactText(`${group.provider}${separator}${summary}`);
 }
 

--- a/src/providers/kilo.ts
+++ b/src/providers/kilo.ts
@@ -1,0 +1,159 @@
+import type {
+  AccountingMetadata,
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import {
+  DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS,
+  getKiloConfigDiagnostics,
+  resolveKiloConfigCached,
+} from "../lib/kilo-config.js";
+import type { KiloUsageResult } from "../lib/kilo.js";
+import { queryKiloDashboard } from "../lib/kilo.js";
+import { sanitizeSingleLineDisplaySnippet } from "../lib/display-sanitize.js";
+import { getQuotaProviderRuntimeIds } from "../lib/provider-metadata.js";
+import {
+  attemptedErrorResult,
+  configStatusDetails,
+  attemptedResult,
+  notAttemptedResult,
+  withStatusDetails,
+} from "./result-helpers.js";
+
+const KILO_LABEL = "Kilo Gateway";
+const KILO_DISPLAY_LABEL = "Kilo";
+const KILO_RUNTIME_IDS = new Set(getQuotaProviderRuntimeIds("kilo"));
+
+const QUOTA_ACCOUNTING: AccountingMetadata = {
+  resultType: "quota",
+  acquisitionMethod: "dashboard_scrape",
+  ownership: "maintained",
+  authority: "provider_reported",
+};
+const BALANCE_ACCOUNTING: AccountingMetadata = {
+  resultType: "balance",
+  acquisitionMethod: "dashboard_scrape",
+  ownership: "maintained",
+  authority: "provider_reported",
+};
+const USAGE_ACCOUNTING: AccountingMetadata = {
+  resultType: "usage",
+  acquisitionMethod: "remote_api",
+  ownership: "maintained",
+  authority: "provider_reported",
+};
+
+function formatMicrodollars(value: number): string {
+  const d = value / 1_000_000;
+  return d % 1 === 0 ? `$${d.toFixed(0)}` : `$${d.toFixed(2)}`;
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function getGroup(result: KiloUsageResult): string {
+  const plan = result.planName ? sanitizeSingleLineDisplaySnippet(result.planName, 40) : "";
+  return plan ? `[${KILO_DISPLAY_LABEL}] ${plan}` : KILO_DISPLAY_LABEL;
+}
+
+function buildEntries(result: KiloUsageResult): QuotaToastEntry[] {
+  const group = getGroup(result);
+  const entries: QuotaToastEntry[] = [];
+
+  if (result.usedMicrodollars !== null && result.limitMicrodollars !== null && result.limitMicrodollars > 0) {
+    const right =
+      result.periodBonusCreditsUsd != null && result.periodBonusCreditsUsd > 0
+        ? `${formatMicrodollars(result.usedMicrodollars)}/${formatMicrodollars(result.limitMicrodollars)} +${formatMicrodollars(result.periodBonusCreditsUsd)} bonus`
+        : `${formatMicrodollars(result.usedMicrodollars)}/${formatMicrodollars(result.limitMicrodollars)}`;
+    entries.push({
+      accounting: QUOTA_ACCOUNTING,
+      name: `${KILO_DISPLAY_LABEL} Credits`,
+      group,
+      label: "Credits:",
+      right,
+      percentRemaining:
+        result.limitMicrodollars > 0
+          ? 100 - (result.usedMicrodollars / result.limitMicrodollars) * 100
+          : 100,
+    });
+  }
+
+  if (result.balanceMicrodollars !== null) {
+    let val = formatMicrodollars(result.balanceMicrodollars);
+    if (result.periodBonusCreditsUsd != null && result.periodBonusCreditsUsd > 0) {
+      val += ` +${formatMicrodollars(result.periodBonusCreditsUsd)} bonus`;
+    }
+    if (result.usedMicrodollars !== null) {
+      val += ` | Usage ${formatMicrodollars(result.usedMicrodollars)}`;
+    }
+    entries.push({
+      accounting: BALANCE_ACCOUNTING,
+      kind: "value",
+      name: `${KILO_DISPLAY_LABEL} Credit Balance`,
+      group,
+      label: "Balance",
+      value: val,
+    });
+  } else if (result.usedMicrodollars !== null) {
+    entries.push({
+      accounting: USAGE_ACCOUNTING,
+      kind: "value",
+      name: `${KILO_DISPLAY_LABEL} Usage`,
+      group,
+      label: "Usage",
+      value: formatMicrodollars(result.usedMicrodollars),
+    });
+  }
+
+  return entries;
+}
+
+export const kiloProvider: QuotaProvider = {
+  id: "kilo",
+
+  async isAvailable(_ctx: QuotaProviderContext): Promise<boolean> {
+    const config = await resolveKiloConfigCached({ maxAgeMs: DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS });
+    return config.state === "configured";
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    const [provider] = model.trim().toLowerCase().split("/", 2);
+    return KILO_RUNTIME_IDS.has(provider);
+  },
+
+  async fetch(ctx: QuotaProviderContext) {
+    const diagnostics = await getKiloConfigDiagnostics();
+    const statusDetails = configStatusDetails({
+      ...diagnostics,
+      error: diagnostics.error ? sanitizeSingleLineDisplaySnippet(diagnostics.error, 120) : undefined,
+    });
+    const config = await resolveKiloConfigCached({ maxAgeMs: DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS });
+
+    if (config.state === "none") return withStatusDetails(notAttemptedResult(), statusDetails);
+    if (config.state === "invalid") {
+      return withStatusDetails(
+        attemptedErrorResult(KILO_LABEL, `Invalid config (${config.source}): ${config.error}`),
+        statusDetails,
+      );
+    }
+
+    const result = await queryKiloDashboard(config.config.cookie, {
+      requestTimeoutMs: ctx.config?.requestTimeoutMsConfigured ? ctx.config.requestTimeoutMs : undefined,
+    });
+    if (!result.success) {
+      return withStatusDetails(attemptedErrorResult(KILO_LABEL, result.error), statusDetails);
+    }
+
+    const entries = buildEntries(result.data);
+    if (entries.length === 0) {
+      return withStatusDetails(
+        attemptedErrorResult(KILO_LABEL, "No usage data found in Kilo Gateway usage API or page"),
+        statusDetails,
+      );
+    }
+
+    return withStatusDetails(attemptedResult(entries), statusDetails);
+  },
+};

--- a/src/providers/kilo.ts
+++ b/src/providers/kilo.ts
@@ -55,7 +55,7 @@ function formatNumber(value: number): string {
 
 function getGroup(result: KiloUsageResult): string {
   const plan = result.planName ? sanitizeSingleLineDisplaySnippet(result.planName, 40) : "";
-  return plan ? `[${KILO_DISPLAY_LABEL}] ${plan}` : KILO_DISPLAY_LABEL;
+  return plan ? `[${KILO_DISPLAY_LABEL}] (${plan})` : KILO_DISPLAY_LABEL;
 }
 
 function buildEntries(result: KiloUsageResult): QuotaToastEntry[] {
@@ -63,16 +63,11 @@ function buildEntries(result: KiloUsageResult): QuotaToastEntry[] {
   const entries: QuotaToastEntry[] = [];
 
   if (result.usedMicrodollars !== null && result.limitMicrodollars !== null && result.limitMicrodollars > 0) {
-    const right =
-      result.periodBonusCreditsUsd != null && result.periodBonusCreditsUsd > 0
-        ? `${formatMicrodollars(result.usedMicrodollars)}/${formatMicrodollars(result.limitMicrodollars)} +${formatMicrodollars(result.periodBonusCreditsUsd)} bonus`
-        : `${formatMicrodollars(result.usedMicrodollars)}/${formatMicrodollars(result.limitMicrodollars)}`;
     entries.push({
       accounting: QUOTA_ACCOUNTING,
       name: `${KILO_DISPLAY_LABEL} Credits`,
       group,
       label: "Credits:",
-      right,
       percentRemaining:
         result.limitMicrodollars > 0
           ? 100 - (result.usedMicrodollars / result.limitMicrodollars) * 100

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -30,7 +30,6 @@ import { opencodeZenProvider } from "./opencode-zen.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
 import { xaiProvider } from "./xai.js";
-import { kiloProvider } from "./kilo.js";
 import { xiaomiProvider } from "./mimo.js";
 import { ollamaCloudProvider } from "./ollama-cloud.js";
 import { quotaProvidersProvider } from "./quota-providers.js";
@@ -59,7 +58,6 @@ export function getProviders(): QuotaProvider[] {
     kimiCodeProvider,
     deepseekProvider,
     xaiProvider,
-    kiloProvider,
     xiaomiProvider,
     opencodeGoProvider,
     opencodeZenProvider,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -29,6 +29,7 @@ import { opencodeZenProvider } from "./opencode-zen.js";
 import { kimiCodeProvider } from "./kimi-code.js";
 import { deepseekProvider } from "./deepseek.js";
 import { xaiProvider } from "./xai.js";
+import { kiloProvider } from "./kilo.js";
 import { xiaomiProvider } from "./mimo.js";
 import { ollamaCloudProvider } from "./ollama-cloud.js";
 import { quotaProvidersProvider } from "./quota-providers.js";
@@ -56,6 +57,7 @@ export function getProviders(): QuotaProvider[] {
     kimiCodeProvider,
     deepseekProvider,
     xaiProvider,
+    kiloProvider,
     xiaomiProvider,
     opencodeGoProvider,
     opencodeZenProvider,

--- a/tests/helpers/provider-assertions.ts
+++ b/tests/helpers/provider-assertions.ts
@@ -229,6 +229,26 @@ export const PROVIDER_ACCOUNTING_LEDGER: Record<string, Array<QuotaToastEntry["a
       authority: "provider_reported",
     },
   ],
+  kilo: [
+    {
+      resultType: "quota",
+      acquisitionMethod: "dashboard_scrape",
+      ownership: "maintained",
+      authority: "provider_reported",
+    },
+    {
+      resultType: "balance",
+      acquisitionMethod: "dashboard_scrape",
+      ownership: "maintained",
+      authority: "provider_reported",
+    },
+    {
+      resultType: "usage",
+      acquisitionMethod: "remote_api",
+      ownership: "maintained",
+      authority: "provider_reported",
+    },
+  ],
   xiaomi: [
     {
       resultType: "quota",

--- a/tests/kilo.test.ts
+++ b/tests/kilo.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeKiloCookieHeader } from "../src/lib/kilo-config.js";
+import { parseKiloUsagePage, parseKiloUsageSummaryResponse } from "../src/lib/kilo.js";
+
+describe("Kilo config", () => {
+  it("keeps only the NextAuth session cookie", () => {
+    expect(
+      normalizeKiloCookieHeader(
+        "Cookie: foo=bar; __Secure-next-auth.session-token=secret; analytics=value",
+      ),
+    ).toBe("__Secure-next-auth.session-token=secret");
+  });
+
+  it("rejects CRLF and missing session cookies", () => {
+    expect(normalizeKiloCookieHeader("__Secure-next-auth.session-token=secret\nX: y")).toBeNull();
+    expect(normalizeKiloCookieHeader("foo=bar")).toBeNull();
+  });
+});
+
+describe("Kilo usage parser", () => {
+  it("extracts usage data from Next.js JSON", () => {
+    const html = `<script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+      props: {
+        pageProps: {
+          creditBalanceMicrodollars: 37_500_000,
+          usedMicrodollars: 12_500_000,
+          limitMicrodollars: 50_000_000,
+          currentPeriodEnd: "2026-08-01T00:00:00.000Z",
+          planName: "Kilo Pass",
+        },
+      },
+    })}</script>`;
+
+    expect(parseKiloUsagePage(html)).toMatchObject({
+      usedMicrodollars: 12_500_000,
+      limitMicrodollars: 50_000_000,
+      balanceMicrodollars: 37_500_000,
+      resetTimeIso: "2026-08-01T00:00:00.000Z",
+      planName: "Kilo Pass",
+    });
+  });
+
+  it("extracts simple text fallback data", () => {
+    expect(
+      parseKiloUsagePage("Plan Kilo Pass Balance $37.50 Used $12.50 Limit $50.00 reset 2026-08-01"),
+    ).toMatchObject({
+      usedMicrodollars: 12_500_000,
+      limitMicrodollars: 50_000_000,
+      balanceMicrodollars: 37_500_000,
+      resetTimeIso: "2026-08-01",
+    });
+  });
+
+  it("returns null when usage page has no recognized data", () => {
+    expect(parseKiloUsagePage("<html>sign in</html>")).toBeNull();
+  });
+
+  it("extracts personal usage summary from tRPC JSON", () => {
+    expect(
+      parseKiloUsageSummaryResponse(
+        JSON.stringify({
+          result: {
+            data: {
+              costMicrodollars: 125_000,
+              requestCount: 3,
+              totalTokens: 52_876,
+              freeRequestCount: 1,
+              byokRequestCount: 2,
+            },
+          },
+        }),
+      ),
+    ).toMatchObject({
+      usedMicrodollars: 125_000,
+      requestCount: 3,
+      totalTokens: 52_876,
+      freeRequestCount: 1,
+      byokRequestCount: 2,
+      planName: "Last 30 days",
+    });
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -158,6 +158,14 @@ describe("provider-metadata", () => {
         notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
       },
       {
+        id: "kilo",
+        autoSetup: "needs_quick_setup",
+        authentication: "state_only",
+        quota: "remote_api",
+        quickSetupAnchor: "kilo-gateway",
+        notes: "Reads Kilo usage APIs with a filtered trusted session cookie",
+      },
+      {
         id: "xiaomi",
         autoSetup: "needs_quick_setup",
         authentication: "state_only",
@@ -294,6 +302,7 @@ describe("provider-metadata", () => {
     expect(QUOTA_PROVIDER_RUNTIME_IDS.deepseek).toEqual(["deepseek"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.opencode).toEqual(["opencode", "opencode-zen"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.xai).toEqual(["xai"]);
+    expect(QUOTA_PROVIDER_RUNTIME_IDS.kilo).toEqual(["kilo", "kilo-gateway", "kilo-code"]);
     expect(QUOTA_PROVIDER_RUNTIME_IDS.xiaomi).toEqual([
       "xiaomi",
       "xiaomi-token-plan-cn",
@@ -354,6 +363,11 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderRuntimeIds("deep-seek")).toEqual(["deepseek"]);
     expect(getQuotaProviderRuntimeIds("opencode-zen")).toEqual(["opencode", "opencode-zen"]);
     expect(getQuotaProviderRuntimeIds("xai")).toEqual(["xai"]);
+    expect(getQuotaProviderRuntimeIds("kilo-gateway")).toEqual([
+      "kilo",
+      "kilo-gateway",
+      "kilo-code",
+    ]);
     expect(getQuotaProviderRuntimeIds("xiaomi-token-plan-cn")).toEqual([
       "xiaomi",
       "xiaomi-token-plan-cn",
@@ -425,6 +439,14 @@ describe("provider-metadata", () => {
       quota: "remote_api",
       notes: "SuperGrok OAuth via OpenCode /connect; shared weekly credit meter",
     });
+    expect(getQuotaProviderShape("kilo-gateway")).toEqual({
+      id: "kilo",
+      autoSetup: "needs_quick_setup",
+      authentication: "state_only",
+      quota: "remote_api",
+      quickSetupAnchor: "kilo-gateway",
+      notes: "Reads Kilo usage APIs with a filtered trusted session cookie",
+    });
     expect(getQuotaProviderShape("xiaomi-token-plan-ams")).toEqual({
       id: "xiaomi",
       autoSetup: "needs_quick_setup",
@@ -456,6 +478,7 @@ describe("provider-metadata", () => {
     expect(getQuotaProviderDisplayLabel("deep-seek")).toBe("DeepSeek");
     expect(getQuotaProviderDisplayLabel("opencode-zen")).toBe("OpenCode Zen");
     expect(getQuotaProviderDisplayLabel("xai")).toBe("xAI");
+    expect(getQuotaProviderDisplayLabel("kilo-gateway")).toBe("Kilo Gateway");
     expect(getQuotaProviderDisplayLabel("xiaomi")).toBe("Xiaomi MiMo");
     expect(getQuotaProviderDisplayLabel("xiaomi-token-plan-sgp")).toBe("Xiaomi MiMo");
     expect(getQuotaProviderDisplayLabel("mimo")).toBe("mimo");

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -1338,6 +1338,7 @@ minimax_china:
 kimi:
 opencode_go:
 opencode_zen:
+kilo:
 xiaomi:
 zai:
 zhipu:

--- a/tests/lib.quota-window-classification.test.ts
+++ b/tests/lib.quota-window-classification.test.ts
@@ -44,4 +44,21 @@ describe("quota window classification", () => {
   it("leaves non-window labels unclassified", () => {
     expect(classifyQuotaWindowText("API requests")).toBeNull();
   });
+
+  it("projects custom grouped labels in single-window display", () => {
+    expect(
+      buildSingleWindowPercentEntryDisplayName({
+        name: "Kilo Credits",
+        group: "[Kilo] Starter",
+        label: "Credits:",
+        percentRemaining: 100,
+        accounting: {
+          resultType: "quota",
+          acquisitionMethod: "dashboard_scrape",
+          ownership: "maintained",
+          authority: "provider_reported",
+        },
+      }),
+    ).toBe("[Kilo] (Starter) Credits");
+  });
 });

--- a/tests/providers.kilo.test.ts
+++ b/tests/providers.kilo.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  expectAttemptedWithErrorLabel,
+  expectAttemptedWithNoErrors,
+  expectNotAttempted,
+  visibleEntries,
+} from "./helpers/provider-assertions.js";
+import { buildCompactQuotaStatusLine } from "../src/lib/tui-compact-format.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveKiloConfigCached: vi.fn(),
+  queryKiloDashboard: vi.fn(),
+}));
+
+vi.mock("../src/lib/kilo-config.js", () => ({
+  DEFAULT_KILO_CONFIG_CACHE_MAX_AGE_MS: 30_000,
+  resolveKiloConfigCached: mocks.resolveKiloConfigCached,
+  getKiloConfigDiagnostics: vi.fn(async () => ({
+    state: "none",
+    source: null,
+    error: null,
+    checkedPaths: [],
+  })),
+}));
+
+vi.mock("../src/lib/kilo.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/lib/kilo.js")>();
+  return {
+    ...original,
+    queryKiloDashboard: mocks.queryKiloDashboard,
+  };
+});
+
+import { kiloProvider } from "../src/providers/kilo.js";
+
+const quotaAccounting = {
+  resultType: "quota",
+  acquisitionMethod: "dashboard_scrape",
+  ownership: "maintained",
+  authority: "provider_reported",
+} as const;
+const balanceAccounting = {
+  resultType: "balance",
+  acquisitionMethod: "dashboard_scrape",
+  ownership: "maintained",
+  authority: "provider_reported",
+} as const;
+const usageAccounting = {
+  resultType: "usage",
+  acquisitionMethod: "remote_api",
+  ownership: "maintained",
+  authority: "provider_reported",
+} as const;
+
+function context(config: Record<string, unknown> = {}): any {
+  return { config };
+}
+
+function configured(): void {
+  mocks.resolveKiloConfigCached.mockResolvedValueOnce({
+    state: "configured",
+    source: "env:KILO_USAGE_COOKIE",
+    config: { cookie: "__Secure-next-auth.session-token=session-secret" },
+  });
+}
+
+function dashboard(overrides: Record<string, unknown> = {}): void {
+  mocks.queryKiloDashboard.mockResolvedValueOnce({
+    success: true,
+    data: {
+      usedMicrodollars: 12_500_000,
+      limitMicrodollars: 50_000_000,
+      balanceMicrodollars: 37_500_000,
+      resetTimeIso: "2026-08-01T00:00:00.000Z",
+      planName: "Kilo Pass",
+      ...overrides,
+    },
+  });
+}
+
+describe("Kilo Gateway provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses canonical kilo provider identity", () => {
+    expect(kiloProvider.id).toBe("kilo");
+  });
+
+  it.each([
+    [{ state: "configured", config: { cookie: "filtered" }, source: "env" }, true],
+    [{ state: "invalid", source: "env", error: "Invalid cookie header" }, false],
+    [{ state: "none" }, false],
+  ])("reports availability for config state %j", async (configState, expected) => {
+    mocks.resolveKiloConfigCached.mockResolvedValueOnce(configState);
+    await expect(kiloProvider.isAvailable(context())).resolves.toBe(expected);
+  });
+
+  it.each([
+    ["kilo/claude-sonnet-4", true],
+    ["kilo-gateway/gpt-5", true],
+    ["kilo-code/model", true],
+    ["KILO/GPT-5", true],
+    ["openai/gpt-5", false],
+  ])("matchesCurrentModel(%s) -> %s", (model, expected) => {
+    expect(kiloProvider.matchesCurrentModel?.(model)).toBe(expected);
+  });
+
+  it("does not attempt a request without trusted configuration", async () => {
+    mocks.resolveKiloConfigCached.mockResolvedValueOnce({ state: "none" });
+
+    expectNotAttempted(await kiloProvider.fetch(context()));
+    expect(mocks.queryKiloDashboard).not.toHaveBeenCalled();
+  });
+
+  it("projects invalid configuration as a safe attempted error", async () => {
+    mocks.resolveKiloConfigCached.mockResolvedValueOnce({
+      state: "invalid",
+      source: "/tmp/config/opencode-quota/kilo.json",
+      error: "Invalid cookie header",
+    });
+
+    const result = await kiloProvider.fetch(context());
+
+    expectAttemptedWithErrorLabel(result, "Kilo Gateway");
+    expect(result.errors[0]?.message).toBe(
+      "Invalid config (/tmp/config/opencode-quota/kilo.json): Invalid cookie header",
+    );
+    expect(JSON.stringify(result)).not.toContain("session-secret");
+  });
+
+  it("maps credit balance with bonus breakdown", async () => {
+    configured();
+    dashboard({
+      usedMicrodollars: 0,
+      limitMicrodollars: 28_500_000,
+      balanceMicrodollars: 19_000_000,
+      periodBonusCreditsUsd: 9_500_000,
+    });
+
+    const result = await kiloProvider.fetch(context());
+
+    expectAttemptedWithNoErrors(result);
+    expect(result.entries).toEqual([
+      {
+        accounting: quotaAccounting,
+        name: "Kilo Credits",
+        group: "[Kilo] Kilo Pass",
+        label: "Credits:",
+        right: "$0/$28.50 +$9.50 bonus",
+        percentRemaining: 100,
+      },
+      {
+        accounting: balanceAccounting,
+        kind: "value",
+        name: "Kilo Credit Balance",
+        group: "[Kilo] Kilo Pass",
+        label: "Balance",
+        value: "$19 +$9.50 bonus | Usage $0",
+      },
+    ]);
+    visibleEntries(result.entries, "kilo");
+  });
+
+  it("formats compact credits with dynamic plan in parentheses", async () => {
+    configured();
+    dashboard({
+      planName: "Starter",
+      usedMicrodollars: 0,
+      limitMicrodollars: 28_500_000,
+      balanceMicrodollars: null,
+    });
+
+    const result = await kiloProvider.fetch(context());
+
+    expectAttemptedWithNoErrors(result);
+    expect(
+      buildCompactQuotaStatusLine({
+        data: { entries: result.entries, errors: [] },
+        percentDisplayMode: "used",
+        maxWidth: 120,
+      }),
+    ).toContain("[Kilo] (Starter) Credits");
+  });
+
+  it("keeps balance-only results", async () => {
+    configured();
+    dashboard({ usedMicrodollars: null, limitMicrodollars: null, balanceMicrodollars: 0 });
+
+    const result = await kiloProvider.fetch(context());
+
+    expectAttemptedWithNoErrors(result);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({ kind: "value", value: "$0" });
+  });
+
+  it("maps personal usage summary without quota data", async () => {
+    configured();
+    dashboard({
+      usedMicrodollars: 0,
+      limitMicrodollars: null,
+      balanceMicrodollars: null,
+      planName: "Last 30 days",
+      requestCount: 1,
+      totalTokens: 52_876,
+    });
+
+    const result = await kiloProvider.fetch(context());
+
+    expectAttemptedWithNoErrors(result);
+    expect(result.entries).toEqual([
+      {
+        accounting: usageAccounting,
+        kind: "value",
+        name: "Kilo Usage",
+        group: "[Kilo] Last 30 days",
+        label: "Usage",
+        value: "$0",
+      },
+    ]);
+    visibleEntries(result.entries, "kilo");
+  });
+
+  it("passes a configured timeout and otherwise keeps the client default", async () => {
+    configured();
+    dashboard();
+    await kiloProvider.fetch(context({ requestTimeoutMs: 7_654, requestTimeoutMsConfigured: true }));
+    expect(mocks.queryKiloDashboard).toHaveBeenLastCalledWith(
+      "__Secure-next-auth.session-token=session-secret",
+      { requestTimeoutMs: 7_654 },
+    );
+
+    configured();
+    dashboard();
+    await kiloProvider.fetch(context({ requestTimeoutMs: 5_000, requestTimeoutMsConfigured: false }));
+    expect(mocks.queryKiloDashboard).toHaveBeenLastCalledWith(
+      "__Secure-next-auth.session-token=session-secret",
+      { requestTimeoutMs: undefined },
+    );
+  });
+});

--- a/tests/providers.registry.test.ts
+++ b/tests/providers.registry.test.ts
@@ -24,6 +24,7 @@ const EXPECTED_PROVIDER_ORDER = [
   "kimi-for-coding",
   "deepseek",
   "xai",
+  "kilo",
   "xiaomi",
   "opencode-go",
   "opencode",

--- a/tests/quota-render-data.test.ts
+++ b/tests/quota-render-data.test.ts
@@ -918,6 +918,36 @@ describe("collectQuotaRenderData shared quota state", () => {
     ]);
   });
 
+  it("keeps custom percent labels when projecting grouped plan names", async () => {
+    const provider = testProvider("kilo", {
+      entries: [
+        {
+          accounting: TEST_ACCOUNTING,
+          name: "Kilo Credits",
+          group: "[Kilo] Starter",
+          label: "Credits:",
+          percentRemaining: 100,
+        },
+      ],
+    });
+
+    const result = await collectQuotaRenderData({
+      client: TEST_CLIENT,
+      config: renderConfig({ enabledProviders: [provider.id] }),
+      surfaceExplicitProviderIssues: true,
+      formatStyle: "singleWindow",
+      providers: [provider],
+    });
+
+    expect(result.data?.entries).toEqual([
+      {
+        accounting: TEST_ACCOUNTING,
+        name: "[Kilo] (Starter) Credits",
+        percentRemaining: 100,
+      },
+    ]);
+  });
+
   it("keeps one labeled Google AGY result per account in single-window mode", async () => {
     const provider = testProvider("google-agy", {
       entries: [


### PR DESCRIPTION
## Summary
- add Kilo Gateway provider with trusted cookie config and usage/credit APIs
- register provider metadata, status output, and docs
- add focused parser/provider/display tests

## Verification
- pnpm exec vitest run tests/kilo.test.ts tests/providers.kilo.test.ts tests/lib.quota-window-classification.test.ts tests/format.test.ts
- pnpm run typecheck
- pnpm run build