### PR TITLE
fix: stop stripping trailing commas before comment-json parses

### DIFF
--- a/src/lib/jsonc.ts
+++ b/src/lib/jsonc.ts
@@ -3,67 +3,18 @@ import commentJson from "comment-json";
 const { parse, stringify } = commentJson;
 
 /**
- * Strip trailing commas from JSON content.
- * Removes commas that appear before closing brackets/braces,
- * while preserving commas inside strings.
- */
-export function stripTrailingCommas(content: string): string {
-  let result = "";
-  let i = 0;
-  let inString = false;
-  let stringChar = "";
-
-  while (i < content.length) {
-    const char = content[i];
-
-    // Handle string boundaries
-    if (char === '"' || char === "'") {
-      let backslashCount = 0;
-      let j = i - 1;
-      while (j >= 0 && content[j] === "\\") {
-        backslashCount++;
-        j--;
-      }
-
-      if (backslashCount % 2 === 0) {
-        if (!inString) {
-          inString = true;
-          stringChar = char;
-        } else if (char === stringChar) {
-          inString = false;
-        }
-        result += char;
-        i++;
-        continue;
-      }
-    }
-
-    // If not in a string, check for a trailing comma
-    if (!inString && char === ",") {
-      let j = i + 1;
-      while (j < content.length && /\s/.test(content[j])) {
-        j++;
-      }
-      // If the next non-whitespace character is a closing bracket/brace, skip this comma
-      if (j < content.length && (content[j] === "]" || content[j] === "}")) {
-        i++;
-        continue;
-      }
-    }
-
-    result += char;
-    i++;
-  }
-
-  return result;
-}
-
-/**
  * Parse JSON or JSONC content preserving comments via comment-json.
+ *
+ * `comment-json` accepts trailing commas natively, so the content is handed to
+ * it verbatim. An earlier hand-rolled pre-pass stripped trailing commas first;
+ * it tracked `"` and `'` as string delimiters without understanding comments, so
+ * a single unpaired quote inside a `//` or block comment inverted its
+ * in-string state for the rest of the file and it then edited real string
+ * values and comment text. Since `parse` never needed the help, the pre-pass
+ * could only ever do harm.
  */
 export function parseJsonOrJsonc(content: string, isJsonc: boolean): unknown {
-  const cleaned = stripTrailingCommas(content);
-  return parse(cleaned);
+  return parse(content);
 }
 
 /**

--- a/tests/lib.jsonc.test.ts
+++ b/tests/lib.jsonc.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { parseJsonOrJsonc, stringifyWithComments } from "../src/lib/jsonc.js";
+
+/**
+ * `parseJsonOrJsonc` is the read half of the installer's read-modify-write cycle
+ * over the user's own `opencode.jsonc` (`src/lib/init-installer.ts:546`, written
+ * back at `:1280` via `writeJsonAtomic`). Anything this parser gets wrong is
+ * persisted over the user's file, so the round trip has to be byte-faithful for
+ * every part of the document the installer does not intend to change.
+ *
+ * A hand-rolled trailing-comma pre-pass used to run before `parse`. It tracked
+ * `"`/`'` as string delimiters with no notion of comments, so one unpaired quote
+ * inside a comment inverted its in-string state for the remainder of the file.
+ */
+describe("parseJsonOrJsonc", () => {
+  it("accepts trailing commas without a pre-pass", () => {
+    // comment-json handles these natively; this is why the pre-pass was
+    // removable rather than merely fixable.
+    expect(parseJsonOrJsonc(`{"a":1,}`, true)).toEqual({ a: 1 });
+    expect(parseJsonOrJsonc(`[1,2,]`, true)).toEqual([1, 2]);
+    expect(parseJsonOrJsonc(`{"a":{"b":[1,],},}`, true)).toEqual({ a: { b: [1] } });
+  });
+
+  it("keeps a string value containing a comma before a closing brace", () => {
+    // A single `"` in the comment flipped the pre-pass into "in string" for the
+    // rest of the file, so the comma inside this value looked like a trailing
+    // comma and was deleted. `*.{ts,}` became `*.{ts}`.
+    const parsed = parseJsonOrJsonc(
+      `{
+  // 27" display
+  "glob": "*.{ts,}"
+}`,
+      true,
+    );
+
+    expect(parsed).toEqual({ glob: "*.{ts,}" });
+  });
+
+  it("keeps a string value containing a comma before a closing bracket", () => {
+    const parsed = parseJsonOrJsonc(
+      `{
+  // width 80" max
+  "pattern": "[a,]"
+}`,
+      true,
+    );
+
+    expect(parsed).toEqual({ pattern: "[a,]" });
+  });
+
+  it("preserves comment text ending in a comma across a round trip", () => {
+    // The installer rewrites one key and writes the whole document back, so a
+    // comment the pre-pass edited was persisted into the user's config. Here the
+    // trailing comma of "anthropic, openai," was deleted from their comment.
+    const source = `{
+  "plugin": ["@slkiser/opencode-quota"],
+  "model": "opus"
+  // providers we use: anthropic, openai,
+}`;
+
+    const parsed = parseJsonOrJsonc(source, true) as Record<string, unknown>;
+    parsed.model = "sonnet";
+
+    expect(stringifyWithComments(parsed)).toContain("// providers we use: anthropic, openai,");
+  });
+
+  it("preserves a comment mentioning a comma inside an array", () => {
+    const source = `{
+  "plugin": [
+    "@slkiser/opencode-quota"
+    // order matters: quota, auth,
+  ]
+}`;
+
+    const parsed = parseJsonOrJsonc(source, true) as Record<string, unknown>;
+    expect(stringifyWithComments(parsed)).toContain("// order matters: quota, auth,");
+  });
+
+  it("preserves comments and normalizes trailing commas on write", () => {
+    // comment-json drops trailing commas when stringifying; that is its
+    // documented behaviour and unrelated to the pre-pass.
+    const source = `{
+  // keep me
+  "plugin": [
+    "@slkiser/opencode-quota",
+  ],
+  /* and me */
+  "model": "opus",
+}`;
+
+    const parsed = parseJsonOrJsonc(source, true) as Record<string, unknown>;
+    parsed.model = "sonnet";
+    const written = stringifyWithComments(parsed);
+
+    expect(written).toContain("// keep me");
+    expect(written).toContain("/* and me */");
+    expect(written).toContain(`"model": "sonnet"`);
+    expect(parseJsonOrJsonc(written, true)).toEqual({
+      plugin: ["@slkiser/opencode-quota"],
+      model: "sonnet",
+    });
+  });
+
+  it("parses plain JSON unchanged", () => {
+    const source = `{"plugin":["@slkiser/opencode-quota"],"model":"opus"}`;
+    expect(parseJsonOrJsonc(source, false)).toEqual({
+      plugin: ["@slkiser/opencode-quota"],
+      model: "opus",
+    });
+  });
+
+  it("still rejects genuinely malformed content", () => {
+    // Removing the pre-pass must not make the parser lenient about real syntax
+    // errors: the installer refuses to write when the existing config will not
+    // parse (`src/lib/init-installer.ts:558`), and that guard has to keep firing.
+    expect(() => parseJsonOrJsonc(`{"a": 1`, true)).toThrow();
+    expect(() => parseJsonOrJsonc(`{"a" 1}`, true)).toThrow();
+    expect(() => parseJsonOrJsonc(`not json`, true)).toThrow();
+    expect(() => parseJsonOrJsonc(``, true)).toThrow();
+    // `{,}` used to survive because the pre-pass deleted the comma before
+    // handing the text over; rejecting it now is the stricter direction.
+    expect(() => parseJsonOrJsonc(`{,}`, true)).toThrow();
+  });
+
+  it("preserves an apostrophe in a comment", () => {
+    const source = `{
+  // don't reorder this
+  "model": "opus"
+}`;
+
+    const parsed = parseJsonOrJsonc(source, true) as Record<string, unknown>;
+    expect(stringifyWithComments(parsed)).toContain("// don't reorder this");
+  });
+});


### PR DESCRIPTION
## Summary

`stripTrailingCommas` ran as a pre-pass before every `parseJsonOrJsonc` call. It tracked `"` and `'` as string delimiters but had no notion of comments, so **a single unpaired quote inside a `//` or `/* */` comment inverted its `inString` state for the rest of the file** — from there its idea of "inside a string" was exactly backwards, and it deleted commas out of real string values and out of comment text.

`src/lib/init-installer.ts:546` reads the user's own `opencode.jsonc` through this function and writes the result back at `:1280` via `writeJsonAtomic`, so those edits were persisted over their file.

The pre-pass was also unnecessary. `comment-json@5.0.0` accepts trailing commas natively:

```js
parse(`{"a":1,}`)           // parses
parse(`[1,2,]`)             // parses
parse(`{"a":{"b":[1,],},}`) // parses
```

So there was no upside to weigh against the corruption. Measured on `main@69a2154`:

| input | correct (`parse` alone) | on `main` | corrupted |
| --- | --- | --- | --- |
| `{` / `// 27" display` / `"glob": "*.{ts,}"` / `}` | `{"glob":"*.{ts,}"}` | `{"glob":"*.{ts}"}` | **yes** |
| `{` / `// width 80" max` / `"pattern": "[a,]"` / `}` | `{"pattern":"[a,]"}` | `{"pattern":"[a]"}` | **yes** |
| `"model": "opus"` + `// providers: anthropic, openai,` | comment kept verbatim | trailing comma deleted from the **comment** | **yes** |
| `"plugin": [ … ` + `// order matters: quota, auth,` `]` | comment kept verbatim | trailing comma deleted from the **comment** | **yes** |

The two failure shapes have different triggers, worth separating:

- **String values** need an unpaired `"` earlier in the file to flip the state. `27" display` or `80" wide` in a comment is ordinary prose.
- **Comment text** needs nothing at all. Comment bodies sit outside any string as far as the scanner is concerned, so a `, }` or `, ]` spanning the end of a comment is stripped directly.

Neither reports an error. The user sees no warning and no diff, and for the installer path the result is already written to disk.

## What changed

Deleted `stripTrailingCommas` and hand the content to `parse` verbatim. `parseJsonOrJsonc` keeps its signature — `isJsonc` was already unused before this change, and the four other call sites pass it positionally, so narrowing it is a separate concern.

Two consequences worth flagging:

- `{,}` is a parse error again. It only survived because the pre-pass deleted the comma before `parse` saw it. Rejecting it is the stricter direction and matches what `readExistingConfig` wants: refuse to write when the existing config will not parse (`init-installer.ts:558`).
- Trailing commas are still normalised away **on write**, because `comment-json`'s `stringify` drops them. That is its documented behaviour and predates this change.

## Linked Issue

Fixes #193

## OpenCode Validation

- Current production released OpenCode version tested: `1.18.1` (the `@opencode-ai/plugin` version pinned in `package.json`).
- Why this version is relevant to the fix: the defect is in this repo's own JSONC reader on the `opencode init` write path, so it reproduces independently of the OpenCode runtime; the pinned plugin version is what the local gates build and test against.

## Verification

- `pnpm exec vitest run tests/lib.jsonc.test.ts` — **9 pass**.
- Control: with `src/lib/jsonc.ts` reverted to `main` and the new tests kept — **5 fail / 4 pass**.
- `pnpm exec vitest run tests/lib.init-installer.test.ts` — **38 pass**, unchanged on both `main` and this branch. That includes `"preserves unrelated JSONC comments and trailing commas during an in-place rerun edit"`; none of the existing cases put a quote inside a comment, which is why this went unnoticed.
- `pnpm run typecheck` — clean.
- `pnpm run build` — clean.
- Full `pnpm test`: the set of failing files is **identical** before and after (14 files, all pre-existing on this Windows checkout — POSIX path assumptions in `lib.config-file-utils` / `lib.opencode-runtime-paths` / `lib.cursor-detection` and friends, e.g. `expected 'D:\home\user\project\.opencode' to be '\home\user\project\.opencode'`). Test counts move only by the 9 added here. Note the full parallel run is somewhat flaky on this machine — baseline measured 64 and then 68 failures across two runs of unmodified `main` — so the failing-**file** set is the stable comparison, and `upstream-plugin-sync.test.ts` passes in isolation 3/3 on both revisions.
- `prettier --write` applied to both touched files.

## Tests added

`tests/lib.jsonc.test.ts` — 9 cases:

- trailing commas parse without a pre-pass (the reason it was removable rather than merely fixable)
- a string value containing `,}` survives an unpaired `"` in an earlier comment
- same for `,]`
- comment text ending in a comma survives a full round trip through a key edit — the installer's actual usage
- same for a comment inside an array
- comments preserved and trailing commas normalised on write
- plain JSON parses unchanged
- genuinely malformed content still throws, including `{,}`
- an apostrophe in a comment is preserved

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed — no user-facing workflow, command, or config surface changes; the only behaviour differences are the corruption being fixed and `{,}` being rejected
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply — not a provider change
