### PR TITLE
feat(xai): auto-refresh expired OAuth before quota fetch

### DIFF
--- a/src/lib/atomic-json.ts
+++ b/src/lib/atomic-json.ts
@@ -6,6 +6,8 @@ export interface WriteJsonAtomicOptions {
   trailingNewline?: boolean;
   directoryMode?: number;
   fileMode?: number;
+  /** When false, do not replace an existing destination on retryable rename errors. */
+  replaceOnRenameError?: boolean;
 }
 
 async function safeRm(target: string): Promise<void> {
@@ -59,10 +61,10 @@ export async function writeTextAtomic(
       renameError && typeof renameError === "object" && "code" in renameError
         ? String((renameError as { code?: unknown }).code)
         : "";
-    const shouldRetryAsReplace =
+    const isRetryable =
       code === "EPERM" || code === "EEXIST" || code === "EACCES" || code === "ENOTEMPTY";
 
-    if (!shouldRetryAsReplace) {
+    if (!isRetryable || opts.replaceOnRenameError === false) {
       await safeRm(tmp);
       throw renameError;
     }

--- a/src/lib/opencode-auth.ts
+++ b/src/lib/opencode-auth.ts
@@ -9,6 +9,7 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 
+import { writeJsonAtomic } from "./atomic-json.js";
 import {
   getOpencodeRuntimeDirCandidates,
   getOpencodeRuntimeDirs,
@@ -25,6 +26,44 @@ type AuthCacheEntry = {
 };
 
 let authCache: AuthCacheEntry | null = null;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getAuthContentOverride(): Record<string, unknown> | null {
+  const content = process.env.OPENCODE_AUTH_CONTENT;
+  if (!content) return null;
+
+  try {
+    const data = JSON.parse(content);
+    return isRecord(data) ? data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function hasOpenCodeAuthContentOverride(): boolean {
+  return getAuthContentOverride() !== null;
+}
+
+type AuthFileSnapshot = {
+  path: string;
+  data: Record<string, unknown>;
+};
+
+async function readAuthFileSnapshot(): Promise<AuthFileSnapshot | null> {
+  for (const path of getAuthPaths()) {
+    try {
+      const data = JSON.parse(await readFile(path, "utf-8"));
+      if (isRecord(data)) return { path, data };
+    } catch {
+      // Try next path.
+    }
+  }
+
+  return null;
+}
 
 /**
  * Get candidate auth.json paths in priority order.
@@ -45,18 +84,78 @@ export function getAuthPath(): string {
 }
 
 export async function readAuthFile(): Promise<AuthData | null> {
-  const paths = getAuthPaths();
+  const overridden = getAuthContentOverride();
+  if (overridden) return overridden as AuthData;
 
-  for (const path of paths) {
-    try {
-      const content = await readFile(path, "utf-8");
-      return JSON.parse(content) as AuthData;
-    } catch {
-      // Try next path
-    }
+  const snapshot = await readAuthFileSnapshot();
+  return snapshot ? (snapshot.data as AuthData) : null;
+}
+
+/**
+ * Checks that the on-disk xAI OAuth entry still matches the token pair used
+ * for a refresh. Returns false when OPENCODE_AUTH_CONTENT owns credentials.
+ */
+export async function isCurrentXaiOAuth(params: {
+  access: string;
+  refresh: string;
+}): Promise<boolean> {
+  if (hasOpenCodeAuthContentOverride()) return false;
+
+  const snapshot = await readAuthFileSnapshot();
+  const xai = snapshot?.data.xai;
+  return (
+    isRecord(xai) &&
+    xai.type === "oauth" &&
+    xai.access === params.access &&
+    xai.refresh === params.refresh
+  );
+}
+
+/**
+ * Atomically replaces only the xAI OAuth entry while retaining every other
+ * auth.json record, including credentials unknown to OpenCode itself.
+ *
+ * Uses optimistic concurrency: if the on-disk entry no longer matches the
+ * expected access/refresh pair (e.g. OpenCode refreshed it concurrently),
+ * the write is skipped and false is returned.
+ */
+export async function updateCurrentXaiOAuth(params: {
+  expectedAccess: string;
+  expectedRefresh: string;
+  access: string;
+  refresh: string;
+  expires: number;
+}): Promise<boolean> {
+  if (hasOpenCodeAuthContentOverride()) return false;
+
+  const snapshot = await readAuthFileSnapshot();
+  const current = snapshot?.data.xai;
+  if (
+    !snapshot ||
+    !isRecord(current) ||
+    current.type !== "oauth" ||
+    current.access !== params.expectedAccess ||
+    current.refresh !== params.expectedRefresh
+  ) {
+    return false;
   }
 
-  return null;
+  await writeJsonAtomic(
+    snapshot.path,
+    {
+      ...snapshot.data,
+      xai: {
+        ...current,
+        type: "oauth",
+        access: params.access,
+        refresh: params.refresh,
+        expires: params.expires,
+      },
+    },
+    { trailingNewline: true, fileMode: 0o600, replaceOnRenameError: false },
+  );
+  authCache = null;
+  return true;
 }
 
 /**

--- a/src/lib/xai.ts
+++ b/src/lib/xai.ts
@@ -1,23 +1,35 @@
 /**
  * xAI SuperGrok subscription quota fetcher.
  *
- * Uses OpenCode's read-only `xai` OAuth entry and queries the same shared
- * period meter exposed by Grok Build:
+ * Uses OpenCode's `xai` OAuth entry and queries the shared period meter
+ * exposed by Grok Build:
  * GET https://cli-chat-proxy.grok.com/v1/billing?format=credits
  *
- * OpenCode remains the sole owner of OAuth refresh and auth.json persistence.
+ * Expired OAuth credentials are refreshed and then atomically saved back to
+ * the matching xAI entry without changing unrelated auth.json credentials.
  */
 
 import { sanitizeSingleLineDisplaySnippet } from "./display-sanitize.js";
 import { clampPercent } from "./format-utils.js";
 import { fetchWithTimeout } from "./http.js";
-import { readAuthFile, readAuthFileCached } from "./opencode-auth.js";
+import {
+  hasOpenCodeAuthContentOverride,
+  isCurrentXaiOAuth,
+  readAuthFile,
+  readAuthFileCached,
+  updateCurrentXaiOAuth,
+} from "./opencode-auth.js";
 import type { AuthData, QuotaError } from "./types.js";
 
 export const DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS = 5_000;
+export const XAI_ACCESS_TOKEN_REFRESH_SKEW_MS = 120_000;
 
 const CREDITS_URL = "https://cli-chat-proxy.grok.com/v1/billing?format=credits";
+const TOKEN_URL = "https://auth.x.ai/oauth2/token";
+const XAI_CLIENT_ID = "b1a00492-073a-47ea-816f-4c329264a828";
 const USER_AGENT = "OpenCode-Quota-Toast/1.0";
+const CONCURRENT_REFRESH_READ_ATTEMPTS = 3;
+const CONCURRENT_REFRESH_READ_DELAY_MS = 50;
 
 export type XaiPeriodKind = "weekly" | "monthly" | "daily" | "period";
 
@@ -41,8 +53,14 @@ export type ResolvedXaiOAuth =
   | {
       state: "configured";
       accessToken: string;
+      refreshToken?: string;
       expiresAt?: number;
     };
+
+type ConfiguredXaiOAuth = Extract<ResolvedXaiOAuth, { state: "configured" }>;
+type XaiOAuthRefreshResult = ConfiguredXaiOAuth | QuotaError;
+
+const xaiOAuthRefreshInFlight = new Map<string, Promise<XaiOAuthRefreshResult>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -91,6 +109,7 @@ export function resolveXaiOAuth(auth: AuthData | null | undefined): ResolvedXaiO
   return {
     state: "configured",
     accessToken,
+    refreshToken: getNonEmptyString(entry.refresh),
     expiresAt:
       typeof entry.expires === "number" && Number.isFinite(entry.expires)
         ? entry.expires
@@ -107,6 +126,184 @@ export async function hasXaiOAuthCached(params?: { maxAgeMs?: number }): Promise
     maxAgeMs: Math.max(0, params?.maxAgeMs ?? DEFAULT_XAI_AUTH_CACHE_MAX_AGE_MS),
   });
   return hasXaiOAuth(auth);
+}
+
+function accessTokenIsExpiring(accessToken: string): boolean {
+  const payload = accessToken.split(".")[1];
+  if (!payload) return false;
+
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: unknown;
+    };
+    return (
+      typeof claims.exp === "number" &&
+      Number.isFinite(claims.exp) &&
+      claims.exp * 1_000 <= Date.now() + XAI_ACCESS_TOKEN_REFRESH_SKEW_MS
+    );
+  } catch {
+    return false;
+  }
+}
+
+function needsXaiOAuthRefresh(auth: ConfiguredXaiOAuth): boolean {
+  if (!auth.expiresAt && !auth.refreshToken) return false;
+
+  return (
+    !auth.expiresAt ||
+    auth.expiresAt - Date.now() <= XAI_ACCESS_TOKEN_REFRESH_SKEW_MS ||
+    accessTokenIsExpiring(auth.accessToken)
+  );
+}
+
+async function readUpdatedXaiOAuth(
+  auth: ConfiguredXaiOAuth,
+): Promise<ConfiguredXaiOAuth | undefined> {
+  for (let attempt = 0; attempt < CONCURRENT_REFRESH_READ_ATTEMPTS; attempt++) {
+    const updated = resolveXaiOAuth(await readAuthFile());
+    if (updated.state === "configured" && !needsXaiOAuthRefresh(updated)) {
+      if (
+        updated.accessToken !== auth.accessToken ||
+        updated.refreshToken !== auth.refreshToken ||
+        updated.expiresAt !== auth.expiresAt
+      ) {
+        return updated;
+      }
+    }
+
+    if (attempt + 1 < CONCURRENT_REFRESH_READ_ATTEMPTS) {
+      await new Promise<void>((resolve) => setTimeout(resolve, CONCURRENT_REFRESH_READ_DELAY_MS));
+    }
+  }
+
+  return undefined;
+}
+
+function refreshError(error: string): QuotaError {
+  return { success: false, error };
+}
+
+function isQuotaError(result: XaiOAuthRefreshResult): result is QuotaError {
+  return "success" in result && result.success === false;
+}
+
+async function refreshXaiOAuth(params: {
+  auth: ConfiguredXaiOAuth;
+  requestTimeoutMs?: number;
+}): Promise<XaiOAuthRefreshResult> {
+  const { auth, requestTimeoutMs } = params;
+  const refreshToken = auth.refreshToken;
+  if (!refreshToken) {
+    return refreshError("xAI OAuth token expired; reconnect xAI");
+  }
+  if (hasOpenCodeAuthContentOverride()) {
+    return refreshError("xAI OAuth token expired; update OPENCODE_AUTH_CONTENT or reconnect xAI");
+  }
+
+  const refreshKey = `${auth.accessToken}\u0000${refreshToken}`;
+  const existing = xaiOAuthRefreshInFlight.get(refreshKey);
+  if (existing) return existing;
+
+  const refreshPromise = (async (): Promise<XaiOAuthRefreshResult> => {
+    try {
+      if (!(await isCurrentXaiOAuth({ access: auth.accessToken, refresh: refreshToken }))) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError("xAI OAuth changed; retry or reconnect xAI")
+        );
+      }
+
+      const payload = await fetchWithTimeout<{
+        access_token?: unknown;
+        refresh_token?: unknown;
+        expires_in?: unknown;
+      } | null>(TOKEN_URL, {
+        request: {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+            "User-Agent": USER_AGENT,
+          },
+          body: new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: refreshToken,
+            client_id: XAI_CLIENT_ID,
+          }).toString(),
+        },
+        timeoutMs: requestTimeoutMs,
+        consume: async (response) => {
+          if (!response.ok) return null;
+          return (await response.json()) as {
+            access_token?: unknown;
+            refresh_token?: unknown;
+            expires_in?: unknown;
+          };
+        },
+      });
+
+      if (!payload || !isRecord(payload)) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError("xAI OAuth refresh failed; reconnect xAI")
+        );
+      }
+
+      const access = getNonEmptyString(payload.access_token);
+      if (!access) {
+        return refreshError("xAI OAuth refresh returned invalid credentials; reconnect xAI");
+      }
+
+      const refresh = getNonEmptyString(payload.refresh_token) ?? refreshToken;
+      const expiresIn = payload.expires_in;
+      const expiresSeconds =
+        typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0
+          ? expiresIn
+          : 3_600;
+      const credentials = {
+        access,
+        refresh,
+        expires: Date.now() + expiresSeconds * 1_000,
+      };
+
+      const persisted = await updateCurrentXaiOAuth({
+        expectedAccess: auth.accessToken,
+        expectedRefresh: refreshToken,
+        ...credentials,
+      });
+      if (!persisted) {
+        return (
+          (await readUpdatedXaiOAuth(auth)) ??
+          refreshError("xAI OAuth changed during refresh; retry or reconnect xAI")
+        );
+      }
+
+      return {
+        state: "configured",
+        accessToken: credentials.access,
+        refreshToken: credentials.refresh,
+        expiresAt: credentials.expires,
+      };
+    } catch {
+      return (
+        (await readUpdatedXaiOAuth(auth)) ?? refreshError("xAI OAuth refresh failed; reconnect xAI")
+      );
+    }
+  })();
+
+  xaiOAuthRefreshInFlight.set(refreshKey, refreshPromise);
+  try {
+    return await refreshPromise;
+  } finally {
+    if (xaiOAuthRefreshInFlight.get(refreshKey) === refreshPromise) {
+      xaiOAuthRefreshInFlight.delete(refreshKey);
+    }
+  }
+}
+
+/** Test helper to clear an in-flight xAI OAuth refresh between test cases. */
+export function clearXaiOAuthRefreshForTests(): void {
+  xaiOAuthRefreshInFlight.clear();
 }
 
 function parseCreditsWindow(payload: unknown): XaiWindowValue | null {
@@ -153,14 +350,16 @@ export async function queryXaiQuota(
   // OpenCode can replace this OAuth entry while servicing a model request.
   // Read the file directly so a post-request quota fetch cannot reuse the
   // token snapshot from before that refresh.
-  const resolvedAuth = resolveXaiOAuth(await readAuthFile());
+  let resolvedAuth = resolveXaiOAuth(await readAuthFile());
   if (resolvedAuth.state !== "configured") return null;
 
-  if (resolvedAuth.expiresAt !== undefined && resolvedAuth.expiresAt <= Date.now()) {
-    return {
-      success: false,
-      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
-    };
+  if (needsXaiOAuthRefresh(resolvedAuth)) {
+    const refreshed = await refreshXaiOAuth({
+      auth: resolvedAuth,
+      requestTimeoutMs: options.requestTimeoutMs,
+    });
+    if (isQuotaError(refreshed)) return refreshed;
+    resolvedAuth = refreshed;
   }
 
   try {

--- a/tests/lib.opencode-auth.test.ts
+++ b/tests/lib.opencode-auth.test.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({ dataDir: "" }));
+
+vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
+  getOpencodeRuntimeDirCandidates: () => ({ dataDirs: [runtime.dataDir] }),
+  getOpencodeRuntimeDirs: () => ({ dataDir: runtime.dataDir }),
+}));
+
+import {
+  clearReadAuthFileCacheForTests,
+  isCurrentXaiOAuth,
+  readAuthFile,
+  updateCurrentXaiOAuth,
+} from "../src/lib/opencode-auth.js";
+
+describe("OpenCode auth updates", () => {
+  let tempDir: string;
+  let authFile: string;
+  let originalAuthContent: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "opencode-quota-auth-"));
+    runtime.dataDir = join(tempDir, "data");
+    authFile = join(runtime.dataDir, "auth.json");
+    mkdirSync(runtime.dataDir, { recursive: true });
+    originalAuthContent = process.env.OPENCODE_AUTH_CONTENT;
+    delete process.env.OPENCODE_AUTH_CONTENT;
+    clearReadAuthFileCacheForTests();
+  });
+
+  afterEach(() => {
+    if (originalAuthContent === undefined) {
+      delete process.env.OPENCODE_AUTH_CONTENT;
+    } else {
+      process.env.OPENCODE_AUTH_CONTENT = originalAuthContent;
+    }
+    clearReadAuthFileCacheForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("atomically replaces only the matching xAI record", async () => {
+    writeFileSync(
+      authFile,
+      JSON.stringify({
+        companion: { type: "oauth", access: "companion-access", custom: "preserve-me" },
+        xai: {
+          type: "oauth",
+          access: "old-access",
+          refresh: "old-refresh",
+          expires: 100,
+          accountId: "account-1",
+        },
+      }),
+      { encoding: "utf8", mode: 0o600 },
+    );
+
+    await expect(isCurrentXaiOAuth({ access: "old-access", refresh: "old-refresh" })).resolves.toBe(
+      true,
+    );
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "new-access",
+        refresh: "new-refresh",
+        expires: 200,
+      }),
+    ).resolves.toBe(true);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual({
+      companion: { type: "oauth", access: "companion-access", custom: "preserve-me" },
+      xai: {
+        type: "oauth",
+        access: "new-access",
+        refresh: "new-refresh",
+        expires: 200,
+        accountId: "account-1",
+      },
+    });
+    expect(statSync(authFile).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not overwrite an xAI record changed by OpenCode", async () => {
+    const original = {
+      xai: { type: "oauth", access: "newer-access", refresh: "newer-refresh", expires: 300 },
+    };
+    writeFileSync(authFile, JSON.stringify(original), { encoding: "utf8", mode: 0o600 });
+
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "refreshed-access",
+        refresh: "refreshed-refresh",
+        expires: 400,
+      }),
+    ).resolves.toBe(false);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual(original);
+  });
+
+  it("does not mutate file-backed auth when OPENCODE_AUTH_CONTENT is active", async () => {
+    const original = {
+      xai: { type: "oauth", access: "old-access", refresh: "old-refresh", expires: 100 },
+    };
+    writeFileSync(authFile, JSON.stringify(original), { encoding: "utf8", mode: 0o600 });
+    const environmentAuth = {
+      xai: { type: "oauth", access: "env-access", refresh: "env-refresh", expires: 200 },
+    };
+    process.env.OPENCODE_AUTH_CONTENT = JSON.stringify(environmentAuth);
+
+    await expect(readAuthFile()).resolves.toEqual(environmentAuth);
+
+    await expect(isCurrentXaiOAuth({ access: "old-access", refresh: "old-refresh" })).resolves.toBe(
+      false,
+    );
+    await expect(
+      updateCurrentXaiOAuth({
+        expectedAccess: "old-access",
+        expectedRefresh: "old-refresh",
+        access: "refreshed-access",
+        refresh: "refreshed-refresh",
+        expires: 200,
+      }),
+    ).resolves.toBe(false);
+
+    expect(JSON.parse(readFileSync(authFile, "utf8"))).toEqual(original);
+  });
+});

--- a/tests/lib.xai.test.ts
+++ b/tests/lib.xai.test.ts
@@ -1,33 +1,75 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hasXaiOAuth, periodKindLabel, queryXaiQuota, resolveXaiOAuth } from "../src/lib/xai.js";
+
 import superGrokWeeklyFixture from "./fixtures/xai/supergrok-weekly.json";
 
-vi.mock("../src/lib/opencode-auth.js", () => ({
+const mocks = vi.hoisted(() => ({
+  hasOpenCodeAuthContentOverride: vi.fn(),
+  isCurrentXaiOAuth: vi.fn(),
   readAuthFile: vi.fn(),
   readAuthFileCached: vi.fn(),
+  updateCurrentXaiOAuth: vi.fn(),
 }));
 
-async function mockConfiguredAuth(overrides: Record<string, unknown> = {}): Promise<void> {
-  const { readAuthFile } = await import("../src/lib/opencode-auth.js");
-  (readAuthFile as any).mockResolvedValueOnce({
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  hasOpenCodeAuthContentOverride: mocks.hasOpenCodeAuthContentOverride,
+  isCurrentXaiOAuth: mocks.isCurrentXaiOAuth,
+  readAuthFile: mocks.readAuthFile,
+  readAuthFileCached: mocks.readAuthFileCached,
+  updateCurrentXaiOAuth: mocks.updateCurrentXaiOAuth,
+}));
+
+import {
+  clearXaiOAuthRefreshForTests,
+  hasXaiOAuth,
+  periodKindLabel,
+  queryXaiQuota,
+  resolveXaiOAuth,
+} from "../src/lib/xai.js";
+
+function configureAuth(overrides: Record<string, unknown> = {}): void {
+  mocks.readAuthFile.mockResolvedValueOnce({
     xai: {
       type: "oauth",
       access: "token-1",
-      expires: Date.now() + 60_000,
+      refresh: "refresh-1",
+      expires: Date.now() + 10 * 60_000,
       ...overrides,
     },
   });
 }
 
+function quotaResponse(): Response {
+  return new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.hasOpenCodeAuthContentOverride.mockReturnValue(false);
+  mocks.isCurrentXaiOAuth.mockReset();
+  mocks.readAuthFile.mockReset();
+  mocks.readAuthFileCached.mockReset();
+  mocks.updateCurrentXaiOAuth.mockReset();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  clearXaiOAuthRefreshForTests();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  clearXaiOAuthRefreshForTests();
+});
+
 describe("xAI auth resolution", () => {
-  it("resolves only the read-only xai OAuth access token", () => {
+  it("resolves the xAI OAuth access and refresh tokens", () => {
     expect(
       resolveXaiOAuth({
-        xai: { type: "oauth", access: " token-1 ", refresh: "ignored", expires: 123 },
+        xai: { type: "oauth", access: " token-1 ", refresh: " refresh-1 ", expires: 123 },
       }),
     ).toEqual({
       state: "configured",
       accessToken: "token-1",
+      refreshToken: "refresh-1",
       expiresAt: 123,
     });
 
@@ -46,25 +88,15 @@ describe("xAI auth resolution", () => {
     ).toEqual({
       state: "configured",
       accessToken: "token-1",
+      refreshToken: undefined,
       expiresAt: undefined,
     });
   });
 });
 
 describe("queryXaiQuota", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.unstubAllGlobals();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.unstubAllGlobals();
-  });
-
   it("returns null for missing, wrong-type, and incomplete auth", async () => {
-    const { readAuthFile } = await import("../src/lib/opencode-auth.js");
-    (readAuthFile as any)
+    mocks.readAuthFile
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({ xai: { type: "api", key: "xai-key" } })
       .mockResolvedValueOnce({ xai: { type: "oauth", refresh: "refresh-only" } });
@@ -74,9 +106,10 @@ describe("queryXaiQuota", () => {
     await expect(queryXaiQuota()).resolves.toBeNull();
   });
 
-  it("does not refresh, fetch, or write an expired token", async () => {
-    const { readAuthFile, readAuthFileCached } = await import("../src/lib/opencode-auth.js");
-    (readAuthFile as any).mockResolvedValueOnce({
+  it("refreshes expired OAuth, persists it, then queries quota", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-23T00:00:00.000Z"));
+    mocks.readAuthFile.mockResolvedValueOnce({
       xai: {
         type: "oauth",
         access: "expired-token",
@@ -84,28 +117,19 @@ describe("queryXaiQuota", () => {
         expires: Date.now() - 1_000,
       },
     });
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(queryXaiQuota()).resolves.toEqual({
-      success: false,
-      error: "xAI OAuth token expired; use xAI in OpenCode to refresh it or reconnect xAI",
-    });
-    expect(readAuthFile).toHaveBeenCalledOnce();
-    expect(readAuthFileCached).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("reads the refreshed OAuth entry instead of a stale cached token", async () => {
-    const { readAuthFile, readAuthFileCached } = await import("../src/lib/opencode-auth.js");
-    (readAuthFileCached as any).mockResolvedValueOnce({
-      xai: { type: "oauth", access: "stale-token", expires: Date.now() - 1_000 },
-    });
-    (readAuthFile as any).mockResolvedValueOnce({
-      xai: { type: "oauth", access: "fresh-token", expires: Date.now() + 60_000 },
-    });
-    const fetchMock = vi.fn(
-      async () => new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 }),
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(true);
+    mocks.updateCurrentXaiOAuth.mockResolvedValueOnce(true);
+    const fetchMock = vi.fn(async (url: string) =>
+      url === "https://auth.x.ai/oauth2/token"
+        ? new Response(
+            JSON.stringify({
+              access_token: "refreshed-access",
+              refresh_token: "refreshed-refresh",
+              expires_in: 3600,
+            }),
+            { status: 200 },
+          )
+        : quotaResponse(),
     ) as any;
     vi.stubGlobal("fetch", fetchMock);
 
@@ -113,8 +137,131 @@ describe("queryXaiQuota", () => {
       success: true,
       window: { percentRemaining: 95, kind: "weekly" },
     });
-    expect(readAuthFile).toHaveBeenCalledOnce();
-    expect(readAuthFileCached).not.toHaveBeenCalled();
+    expect(mocks.updateCurrentXaiOAuth).toHaveBeenCalledWith({
+      expectedAccess: "expired-token",
+      expectedRefresh: "refresh-1",
+      access: "refreshed-access",
+      refresh: "refreshed-refresh",
+      expires: Date.parse("2026-07-23T01:00:00.000Z"),
+    });
+  });
+
+  it("does not use a rotated refresh token when persistence detects changed auth", async () => {
+    const expiredAuth = {
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    };
+    mocks.readAuthFile.mockResolvedValue(expiredAuth);
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(true);
+    mocks.updateCurrentXaiOAuth.mockResolvedValueOnce(false);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "refreshed-access",
+              refresh_token: "refreshed-refresh",
+            }),
+            { status: 200 },
+          ),
+      ) as any,
+    );
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI OAuth changed during refresh; retry or reconnect xAI",
+    });
+  });
+
+  it("uses an xAI credential refreshed by another plugin context", async () => {
+    const expiredAuth = {
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    };
+    mocks.readAuthFile
+      .mockResolvedValueOnce(expiredAuth)
+      .mockResolvedValueOnce(expiredAuth)
+      .mockResolvedValueOnce({
+        xai: {
+          type: "oauth",
+          access: "other-context-access",
+          refresh: "other-context-refresh",
+          expires: Date.now() + 10 * 60_000,
+        },
+      });
+    mocks.isCurrentXaiOAuth.mockResolvedValueOnce(false);
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer other-context-access" }),
+      }),
+    );
+    expect(mocks.updateCurrentXaiOAuth).not.toHaveBeenCalled();
+  });
+
+  it("does not consume a refresh token when OPENCODE_AUTH_CONTENT owns credentials", async () => {
+    mocks.readAuthFile.mockResolvedValueOnce({
+      xai: {
+        type: "oauth",
+        access: "expired-token",
+        refresh: "refresh-1",
+        expires: Date.now() - 1_000,
+      },
+    });
+    mocks.hasOpenCodeAuthContentOverride.mockReturnValue(true);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toEqual({
+      success: false,
+      error: "xAI OAuth token expired; update OPENCODE_AUTH_CONTENT or reconnect xAI",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh access-only credential without forcing a refresh", async () => {
+    mocks.readAuthFile.mockResolvedValueOnce({
+      xai: { type: "oauth", access: "access-only-token" },
+    });
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer access-only-token" }),
+      }),
+    );
+    expect(mocks.isCurrentXaiOAuth).not.toHaveBeenCalled();
+  });
+
+  it("reads the current auth file instead of a stale cached token", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      xai: { type: "oauth", access: "stale-token", expires: Date.now() - 1_000 },
+    });
+    configureAuth({ access: "fresh-token" });
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({
+      success: true,
+      window: { percentRemaining: 95, kind: "weekly" },
+    });
+    expect(mocks.readAuthFileCached).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledWith(
       "https://cli-chat-proxy.grok.com/v1/billing?format=credits",
       expect.objectContaining({
@@ -124,11 +271,8 @@ describe("queryXaiQuota", () => {
   });
 
   it("maps the exact PR fixture through one fixed authenticated GET", async () => {
-    await mockConfiguredAuth();
-
-    const fetchMock = vi.fn(
-      async () => new Response(JSON.stringify(superGrokWeeklyFixture), { status: 200 }),
-    ) as any;
+    configureAuth();
+    const fetchMock = vi.fn(async () => quotaResponse()) as any;
     vi.stubGlobal("fetch", fetchMock);
 
     await expect(queryXaiQuota({ requestTimeoutMs: 3_210 })).resolves.toEqual({
@@ -141,7 +285,6 @@ describe("queryXaiQuota", () => {
       },
     });
 
-    expect(fetchMock).toHaveBeenCalledOnce();
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://cli-chat-proxy.grok.com/v1/billing?format=credits");
     expect(init).toEqual({
@@ -159,7 +302,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("treats an omitted protobuf percentage as 0% used when a period exists", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -190,7 +333,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("uses the exact billingPeriodEnd reset fallback from the PR", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -220,8 +363,8 @@ describe("queryXaiQuota", () => {
   });
 
   it("rejects malformed percentages and response shapes", async () => {
-    await mockConfiguredAuth();
-    await mockConfiguredAuth();
+    configureAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi
@@ -251,7 +394,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("reports missing period data instead of inventing quota", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -267,7 +410,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("bounds and sanitizes HTTP errors without exposing the bearer token", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(
@@ -287,7 +430,7 @@ describe("queryXaiQuota", () => {
   });
 
   it("sanitizes network errors without exposing the bearer token", async () => {
-    await mockConfiguredAuth();
+    configureAuth();
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => {
@@ -303,7 +446,7 @@ describe("queryXaiQuota", () => {
 
   it("returns the normalized timeout error", async () => {
     vi.useFakeTimers();
-    await mockConfiguredAuth();
+    configureAuth();
 
     const fetchMock = vi.fn((_url: string, init: RequestInit) => {
       return new Promise<Response>((_resolve, reject) => {


### PR DESCRIPTION
## Problem

xAI access tokens expire after ~6 hours. When the token expires, the quota panel shows "xAI OAuth token expired" and the user must send an xAI model message in OpenCode to trigger a refresh — even if they only want to monitor the quota.

## Solution

The plugin now refreshes the token itself using the stored `refresh_token` before querying the quota, then atomically persists the new credentials back to `auth.json` — replacing only the `xai` entry while preserving every other provider credential.

## Key design decisions

- **Optimistic concurrency**: before writing, the plugin checks that the on-disk `xai` entry still matches the access/refresh pair used for the refresh request. If OpenCode already refreshed it concurrently, the write is skipped.
- **In-flight deduplication**: concurrent quota requests share one refresh promise.
- **`replaceOnRenameError: false`**: the atomic write refuses to clobber an existing `auth.json` that another process may have just updated.
- **`OPENCODE_AUTH_CONTENT` env override**: when set, the plugin never touches the file and reports the override path instead.
- **120s skew**: tokens within 2 minutes of expiry are refreshed proactively.
- **Access-only fallback**: credentials without a `refresh_token` (older auth formats) are queried directly without forcing a refresh.

## Files changed

| File | Change |
|---|---|
| `src/lib/xai.ts` | Refresh logic, JWT exp parsing, concurrent-refresh dedup |
| `src/lib/opencode-auth.ts` | `isCurrentXaiOAuth`, `updateCurrentXaiOAuth`, env override |
| `src/lib/atomic-json.ts` | `replaceOnRenameError` option |
| `tests/lib.xai.test.ts` | 18 tests including refresh, persistence, concurrency |
| `tests/lib.opencode-auth.test.ts` | 3 tests for atomic xAI record updates |

## Test results

All 29 targeted tests pass. 1806/1807 full suite (1 pre-existing `release-gates` failure also present on `main`).