### PR TITLE
feat: notify when quota windows reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ More ways to use it:
 - Send quota data to monitoring tools with optional OpenTelemetry metrics
 - Run the same slash commands in the TUI, Web, and Desktop
 - Tune reset countdown precision without changing the default compact display
+- Opt in to popup notifications when selected quota windows reset with [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again); they reuse existing quota checks
 - Choose current-session or descendant-tree token totals across `/quota`, toasts, the sidebar, and the compact input line
 - Diagnose authentication, quota sources, pricing, and maintainer notices
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -76,9 +76,14 @@ Quota, so enabling them does not add provider requests.
 The first observation establishes a baseline. A success toast appears only after OpenCode Quota
 observes the advertised reset boundary, a newer reset timestamp, and an increase in remaining
 quota. A local acknowledgment prevents the same reset from being announced again after restart.
-The acknowledgment stores only a hashed account/window identity and reset metadata; account source
-identifiers and display labels are not written to the state file.
-Supported window names are `fiveHour`, `hourly`, `daily`, `weekly`, `monthly`, and `yearly`.
+The state file stores pseudonymous SHA-256 identity keys plus remaining percentages and reset,
+observation, and acknowledgment timestamps. Literal account source identifiers, display labels, and
+credentials are not written to it.
+
+Reset notifications use the server popup-toast surface. They do not appear in slash-command or CLI
+output, Sidebar, Compact status, status collection, telemetry, or JSON exports, and require a host
+that supports `tui.showToast`. Supported window names are `fiveHour`, `hourly`, `daily`, `weekly`,
+`monthly`, and `yearly`.
 
 ### Include subagent session tokens
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -76,6 +76,8 @@ Quota, so enabling them does not add provider requests.
 The first observation establishes a baseline. A success toast appears only after OpenCode Quota
 observes the advertised reset boundary, a newer reset timestamp, and an increase in remaining
 quota. A local acknowledgment prevents the same reset from being announced again after restart.
+The acknowledgment stores only a hashed account/window identity and reset metadata; account source
+identifiers and display labels are not written to the state file.
 Supported window names are `fiveHour`, `hourly`, `daily`, `weekly`, `monthly`, and `yearly`.
 
 ### Include subagent session tokens

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -28,6 +28,7 @@ Strict `.json` files also work. Run `/quota_status` if you are unsure which file
 | Show slash results in a TUI popup          | `tuiCommandDisplay: "dialog"` |
 | Turn the TUI sidebar on or off             | `tuiSidebarPanel.enabled`     |
 | Turn popup quota notifications on or off   | `enableToast`                 |
+| Notify when weekly quota resets            | `resetNotifications.enabled`  |
 | Turn the compact quota line on or off      | `tuiCompactStatus.enabled`    |
 | Show or hide session input/output tokens   | `showSessionTokens`           |
 | Include descendant/subagent session tokens | `sessionTokenScope: "tree"`   |
@@ -51,11 +52,31 @@ The installer chooses `allWindows` by default. If the setting is absent, the bui
   // Show the sidebar, but not toast or compact status.
   "tuiSidebarPanel": { "enabled": true },
   "enableToast": false,
+  "resetNotifications": { "enabled": false, "windows": ["weekly"] },
   "tuiCompactStatus": { "enabled": false },
 }
 ```
 
 Restart OpenCode after changing the file.
+
+### Notify when quota becomes available again
+
+Reset notifications are opt-in. They reuse provider snapshots already collected by OpenCode
+Quota, so enabling them does not add provider requests.
+
+```jsonc
+{
+  "resetNotifications": {
+    "enabled": true,
+    "windows": ["weekly"],
+  },
+}
+```
+
+The first observation establishes a baseline. A success toast appears only after OpenCode Quota
+observes the advertised reset boundary, a newer reset timestamp, and an increase in remaining
+quota. A local acknowledgment prevents the same reset from being announced again after restart.
+Supported window names are `fiveHour`, `hourly`, `daily`, `weekly`, `monthly`, and `yearly`.
 
 ### Include subagent session tokens
 
@@ -293,6 +314,8 @@ Existing `experimental.quotaToast` settings remain supported. Quota settings do 
 | Option                        | Default        | Meaning                                                                                                                                                                                                                                                                                                             |
 | ----------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `enabled`                     | `true`         | Master switch for quota collection and handled slash commands. When `false`, `/quota`, `/quota_status`, `/pricing_refresh`, and `/tokens_*` are handled as no-ops.                                                                                                                                                  |
+| `resetNotifications.enabled`  | `false`        | Emit a one-shot success toast when an observed configured quota window resets. Requires popup toasts to be enabled and adds no provider requests.                                                                                                                                                                   |
+| `resetNotifications.windows`  | `["weekly"]`   | Window classes eligible for reset notifications: `fiveHour`, `hourly`, `daily`, `weekly`, `monthly`, or `yearly`.                                                                                                                                                                                                   |
 | `enabledProviders`            | `"auto"`       | Auto-detect providers, or set an explicit provider list. Use the aggregate ID `quota-providers` for configured definitions.                                                                                                                                                                                         |
 | `quotaProviders`              | `[]`           | Ordered global-only `remote-api` or `local-estimate` definitions maintained in global OpenCode JSONC/JSON. Each item has a stable `id`; `providerId` is only needed when different.                                                                                                                                 |
 | `minIntervalMs`               | `300000`       | Minimum fetch interval between provider updates.                                                                                                                                                                                                                                                                    |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -24,6 +24,7 @@ import type {
   GoogleModelId,
   PercentDisplayMode,
   PricingSnapshotSource,
+  QuotaResetWindow,
   QuotaToastConfig,
   SessionTokenScope,
   TuiCommandDisplay,
@@ -39,6 +40,8 @@ export const QUOTA_TOAST_CONFIG_RELATIVE_PATH = QUOTA_TOAST_CONFIG_RELATIVE_PATH
 export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "enabled",
   "enableToast",
+  "resetNotifications.enabled",
+  "resetNotifications.windows",
   "tuiCommandDisplay",
   "formatStyle",
   "percentDisplayMode",
@@ -135,6 +138,7 @@ const NETWORK_SETTING_SOURCE_KEYS = [
 ] as const satisfies readonly QuotaToastSettingSourceKey[];
 
 type PricingSnapshotPatch = Partial<QuotaToastConfig["pricingSnapshot"]>;
+type QuotaResetNotificationsPatch = Partial<QuotaToastConfig["resetNotifications"]>;
 type TuiSidebarPanelPatch = Partial<QuotaToastConfig["tuiSidebarPanel"]>;
 type TuiCompactStatusPatch = Partial<QuotaToastConfig["tuiCompactStatus"]>;
 type MaintainerAnnouncementsPatch = Partial<QuotaToastConfig["maintainerAnnouncements"]>;
@@ -145,6 +149,7 @@ type TelemetryConfigPatch = Partial<QuotaToastConfig["telemetry"]>;
 type ValidatedQuotaToastPatch = {
   enabled?: boolean;
   enableToast?: boolean;
+  resetNotifications?: QuotaResetNotificationsPatch;
   tuiCommandDisplay?: TuiCommandDisplay;
   formatStyle?: QuotaToastConfig["formatStyle"];
   percentDisplayMode?: PercentDisplayMode;
@@ -318,6 +323,10 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
       ? [...config.enabledProviders]
       : config.enabledProviders,
     quotaProviders: cloneQuotaProviders(config.quotaProviders),
+    resetNotifications: {
+      ...config.resetNotifications,
+      windows: [...config.resetNotifications.windows],
+    },
     googleModels: [...config.googleModels],
     opencodeGoWindows: [...config.opencodeGoWindows],
     opencodeMonthlyLimit: config.opencodeMonthlyLimit,
@@ -329,6 +338,47 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
     export: { ...config.export },
     telemetry: { ...config.telemetry },
   };
+}
+
+const QUOTA_RESET_WINDOWS: readonly QuotaResetWindow[] = [
+  "fiveHour",
+  "hourly",
+  "daily",
+  "weekly",
+  "monthly",
+  "yearly",
+];
+
+function extractQuotaResetNotificationsPatch(
+  value: unknown,
+  reportIssue?: (key: string, message: string) => void,
+): QuotaResetNotificationsPatch | undefined {
+  if (!isPlainObject(value)) return undefined;
+
+  const patch: QuotaResetNotificationsPatch = {};
+  if (hasOwnKey(value, "enabled")) {
+    if (typeof value.enabled === "boolean") patch.enabled = value.enabled;
+    else reportIssue?.("resetNotifications.enabled", "expected boolean");
+  }
+
+  if (hasOwnKey(value, "windows")) {
+    if (
+      Array.isArray(value.windows) &&
+      value.windows.length > 0 &&
+      value.windows.every((window): window is QuotaResetWindow =>
+        QUOTA_RESET_WINDOWS.includes(window as QuotaResetWindow),
+      )
+    ) {
+      patch.windows = dedupe(value.windows);
+    } else {
+      reportIssue?.(
+        "resetNotifications.windows",
+        `expected a non-empty array of: ${QUOTA_RESET_WINDOWS.join(", ")}`,
+      );
+    }
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
 }
 
 type NormalizedEnabledProviders = {
@@ -560,6 +610,14 @@ function extractValidatedQuotaToastPatch(
     typeof quotaToastConfig.enableToast === "boolean"
   ) {
     patch.enableToast = quotaToastConfig.enableToast;
+  }
+
+  if (hasOwnKey(quotaToastConfig, "resetNotifications")) {
+    const resetNotifications = extractQuotaResetNotificationsPatch(
+      quotaToastConfig.resetNotifications,
+      reportIssue,
+    );
+    if (resetNotifications) patch.resetNotifications = resetNotifications;
   }
 
   if (hasOwnKey(quotaToastConfig, "tuiCommandDisplay")) {
@@ -802,6 +860,17 @@ function applyValidatedQuotaToastPatch(
   if (hasOwnKey(patch, "enableToast")) {
     config.enableToast = patch.enableToast!;
     applySettingSource(settingSources, "enableToast", sourcePath);
+  }
+
+  if (patch.resetNotifications) {
+    if (hasOwnKey(patch.resetNotifications, "enabled")) {
+      config.resetNotifications.enabled = patch.resetNotifications.enabled!;
+      applySettingSource(settingSources, "resetNotifications.enabled", sourcePath);
+    }
+    if (hasOwnKey(patch.resetNotifications, "windows")) {
+      config.resetNotifications.windows = [...patch.resetNotifications.windows!];
+      applySettingSource(settingSources, "resetNotifications.windows", sourcePath);
+    }
   }
 
   if (hasOwnKey(patch, "tuiCommandDisplay")) {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -101,6 +101,8 @@ export type CollectQuotaRenderDataResult = {
   selection: QuotaRenderSelection | null;
   availability: QuotaAvailability[];
   active: QuotaProvider[];
+  /** Unprojected provider results for stateful observers such as reset detection. */
+  providerResults: QuotaStatusLiveProbe[];
   attemptedAny: boolean;
   hasExplicitProviderIssues: boolean;
   data: QuotaRenderData | null;
@@ -640,6 +642,7 @@ export async function collectQuotaRenderData(params: {
       selection: null,
       availability: [],
       active: [],
+      providerResults: [],
       attemptedAny: false,
       hasExplicitProviderIssues: false,
       data: null,
@@ -655,6 +658,7 @@ export async function collectQuotaRenderData(params: {
       selection,
       availability: [],
       active: [],
+      providerResults: [],
       attemptedAny: false,
       hasExplicitProviderIssues: false,
       data: null,
@@ -687,6 +691,7 @@ export async function collectQuotaRenderData(params: {
       selection,
       availability,
       active,
+      providerResults: [],
       attemptedAny: false,
       hasExplicitProviderIssues: explicitProviderIssues.length > 0,
       data: packageQuotaRenderData({ entries: [], errors: explicitProviderIssues }),
@@ -771,6 +776,10 @@ export async function collectQuotaRenderData(params: {
     selection,
     availability,
     active,
+    providerResults: active.map((provider, index) => ({
+      providerId: provider.id,
+      result: results[index]!,
+    })),
     attemptedAny,
     hasExplicitProviderIssues,
     data,

--- a/src/lib/quota-reset-notifications.ts
+++ b/src/lib/quota-reset-notifications.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { writeJsonAtomic } from "./atomic-json.js";
+import { isPercentEntry, type QuotaProviderResult, type QuotaToastEntry } from "./entries.js";
+import { getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
+import { getQuotaProviderDisplayLabel } from "./provider-metadata.js";
+import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
+import type { QuotaResetWindow } from "./types.js";
+
+const STATE_VERSION = 1;
+const MAX_TRANSITION_AGE_MS = 24 * 60 * 60 * 1000;
+const MAX_OBSERVATION_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+const WINDOW_KINDS: Readonly<Record<QuotaResetWindow, QuotaWindowKind>> = {
+  fiveHour: "five_hour",
+  hourly: "hour",
+  daily: "day",
+  weekly: "week",
+  monthly: "month",
+  yearly: "year",
+};
+
+type ResetObservation = {
+  resetAtMs: number;
+  percentRemaining: number;
+  observedAtMs: number;
+  notifiedResetAtMs?: number;
+};
+
+type ResetNotificationState = {
+  version: typeof STATE_VERSION;
+  observations: Record<string, ResetObservation>;
+};
+
+export type QuotaResetProviderResult = {
+  providerId: string;
+  result: QuotaProviderResult;
+};
+
+export type QuotaResetNotice = {
+  providerId: string;
+  label: string;
+  window: QuotaResetWindow;
+  percentRemaining: number;
+};
+
+function getStatePath(): string {
+  return join(
+    getOpencodeRuntimeDirs().stateDir,
+    "opencode-quota",
+    "quota-reset-notifications.json",
+  );
+}
+
+function getWindow(entry: QuotaToastEntry): QuotaWindowKind | null {
+  return classifyQuotaWindowText(entry.label ?? "") ?? classifyQuotaWindowText(entry.name);
+}
+
+function getConfiguredWindow(
+  kind: QuotaWindowKind | null,
+  configured: readonly QuotaResetWindow[],
+): QuotaResetWindow | null {
+  if (!kind) return null;
+  return configured.find((window) => WINDOW_KINDS[window] === kind) ?? null;
+}
+
+function getIdentity(providerId: string, entry: QuotaToastEntry, window: QuotaResetWindow): string {
+  const raw = [
+    providerId,
+    entry.accounting.sourceId ?? "",
+    window,
+    entry.group ?? "",
+    entry.label ?? "",
+    entry.name,
+  ].join("\u001f");
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+function isObservation(value: unknown): value is ResetObservation {
+  if (!value || typeof value !== "object") return false;
+  const item = value as Partial<ResetObservation>;
+  return (
+    Number.isFinite(item.resetAtMs) &&
+    Number.isFinite(item.percentRemaining) &&
+    Number.isFinite(item.observedAtMs)
+  );
+}
+
+async function readState(path: string): Promise<ResetNotificationState> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<ResetNotificationState>;
+    if (parsed.version !== STATE_VERSION || !parsed.observations) throw new Error("invalid state");
+    return {
+      version: STATE_VERSION,
+      observations: Object.fromEntries(
+        Object.entries(parsed.observations).filter((entry) => isObservation(entry[1])),
+      ),
+    };
+  } catch {
+    return { version: STATE_VERSION, observations: {} };
+  }
+}
+
+function didReset(previous: ResetObservation, current: ResetObservation, nowMs: number): boolean {
+  const transitionAge = nowMs - previous.resetAtMs;
+  return (
+    previous.observedAtMs <= previous.resetAtMs &&
+    transitionAge >= 0 &&
+    transitionAge <= MAX_TRANSITION_AGE_MS &&
+    current.resetAtMs > previous.resetAtMs &&
+    current.resetAtMs > nowMs &&
+    current.percentRemaining > previous.percentRemaining &&
+    previous.percentRemaining < 100 &&
+    previous.notifiedResetAtMs !== previous.resetAtMs
+  );
+}
+
+export async function observeQuotaResetNotifications(params: {
+  providers: QuotaResetProviderResult[];
+  windows: readonly QuotaResetWindow[];
+  nowMs?: number;
+  statePath?: string;
+}): Promise<QuotaResetNotice[]> {
+  const nowMs = params.nowMs ?? Date.now();
+  const statePath = params.statePath ?? getStatePath();
+  const state = await readState(statePath);
+  const observations = Object.fromEntries(
+    Object.entries(state.observations).filter(
+      ([, observation]) => nowMs - observation.observedAtMs <= MAX_OBSERVATION_AGE_MS,
+    ),
+  );
+  const notices: QuotaResetNotice[] = [];
+
+  for (const provider of params.providers) {
+    for (const entry of provider.result.entries) {
+      if (!isPercentEntry(entry)) continue;
+      if (entry.accounting.resultType !== "quota" && entry.accounting.resultType !== "rate_limit") {
+        continue;
+      }
+      if (!entry.resetTimeIso) continue;
+
+      const window = getConfiguredWindow(getWindow(entry), params.windows);
+      if (!window) continue;
+      const resetAtMs = Date.parse(entry.resetTimeIso);
+      if (!Number.isFinite(resetAtMs)) continue;
+
+      const key = getIdentity(provider.providerId, entry, window);
+      const previous = observations[key];
+      const current: ResetObservation = {
+        resetAtMs,
+        percentRemaining: entry.percentRemaining,
+        observedAtMs: nowMs,
+      };
+
+      if (previous && didReset(previous, current, nowMs)) {
+        current.notifiedResetAtMs = previous.resetAtMs;
+        notices.push({
+          providerId: provider.providerId,
+          label: entry.group?.trim() || getQuotaProviderDisplayLabel(provider.providerId),
+          window,
+          percentRemaining: entry.percentRemaining,
+        });
+      }
+
+      observations[key] = current;
+    }
+  }
+
+  await writeJsonAtomic(
+    statePath,
+    { version: STATE_VERSION, observations } satisfies ResetNotificationState,
+    { trailingNewline: true, directoryMode: 0o700, fileMode: 0o600 },
+  );
+  return notices;
+}
+
+export function formatQuotaResetNotification(notices: readonly QuotaResetNotice[]): string | null {
+  if (notices.length === 0) return null;
+  const labels = [...new Set(notices.map((notice) => notice.label))];
+  const shown = labels.slice(0, 3);
+  const overflow = labels.length - shown.length;
+  const providers = `${shown.join(", ")}${overflow > 0 ? ` and ${overflow} more` : ""}`;
+
+  const [notice] = notices;
+  if (notice && notices.length === 1) {
+    const window = notice.window === "weekly" ? "Weekly" : "Quota";
+    return `${window} quota reset: ${providers} is available again (${Math.round(notice.percentRemaining)}% remaining).`;
+  }
+  return `Quota reset: ${providers} are available again.`;
+}

--- a/src/lib/quota-reset-notifications.ts
+++ b/src/lib/quota-reset-notifications.ts
@@ -1,6 +1,7 @@
-import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { writeFileSync } from "node:fs";
+import { mkdir, open, readFile, rm, rmdir, stat, unlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 import { writeJsonAtomic } from "./atomic-json.js";
 import { isPercentEntry, type QuotaProviderResult, type QuotaToastEntry } from "./entries.js";
@@ -9,9 +10,14 @@ import { getQuotaProviderDisplayLabel } from "./provider-metadata.js";
 import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
 import type { QuotaResetWindow } from "./types.js";
 
-const STATE_VERSION = 1;
+const STATE_VERSION = 2;
 const MAX_TRANSITION_AGE_MS = 24 * 60 * 60 * 1000;
 const MAX_OBSERVATION_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const LOCK_RETRY_DELAY_MS = 20;
+const LOCK_TIMEOUT_MS = 2_000;
+const STALE_LOCK_AGE_MS = 30_000;
+const LOCK_OWNER_FILE = "owner.json";
+const LOCK_RECLAIM_FILE = "reclaim";
 
 const WINDOW_KINDS: Readonly<Record<QuotaResetWindow, QuotaWindowKind>> = {
   fiveHour: "five_hour",
@@ -32,6 +38,17 @@ type ResetObservation = {
 type ResetNotificationState = {
   version: typeof STATE_VERSION;
   observations: Record<string, ResetObservation>;
+};
+
+type ResetCandidate = {
+  current: ResetObservation;
+  notice: QuotaResetNotice;
+};
+
+type StateLockOwner = {
+  token: string;
+  pid: number;
+  createdAtMs: number;
 };
 
 export type QuotaResetProviderResult = {
@@ -69,11 +86,9 @@ function getConfiguredWindow(
 function getIdentity(providerId: string, entry: QuotaToastEntry, window: QuotaResetWindow): string {
   const raw = [
     providerId,
-    entry.accounting.sourceId ?? "",
+    entry.accounting.sourceId ?? "single-source",
     window,
-    entry.group ?? "",
-    entry.label ?? "",
-    entry.name,
+    entry.accounting.resultType,
   ].join("\u001f");
   return createHash("sha256").update(raw).digest("hex");
 }
@@ -103,6 +118,148 @@ async function readState(path: string): Promise<ResetNotificationState> {
   }
 }
 
+function isFileSystemError(error: unknown, code: string): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === code;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseLockOwner(value: string): StateLockOwner | null {
+  try {
+    const owner = JSON.parse(value) as Partial<StateLockOwner>;
+    if (
+      typeof owner.token !== "string" ||
+      !Number.isSafeInteger(owner.pid) ||
+      (owner.pid ?? 0) <= 0 ||
+      !Number.isFinite(owner.createdAtMs)
+    ) {
+      return null;
+    }
+    return owner as StateLockOwner;
+  } catch {
+    return null;
+  }
+}
+
+async function readLockOwner(lockPath: string): Promise<StateLockOwner | null> {
+  try {
+    return parseLockOwner(await readFile(join(lockPath, LOCK_OWNER_FILE), "utf8"));
+  } catch (error) {
+    if (isFileSystemError(error, "ENOENT")) return null;
+    throw error;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return !isFileSystemError(error, "ESRCH");
+  }
+}
+
+async function getReclaimStatus(
+  lockPath: string,
+): Promise<{ reclaimable: boolean; allowMissingOwner: boolean }> {
+  const owner = await readLockOwner(lockPath);
+  if (owner) return { reclaimable: !isProcessAlive(owner.pid), allowMissingOwner: false };
+
+  try {
+    const lock = await stat(lockPath);
+    const stale = Date.now() - lock.mtimeMs > STALE_LOCK_AGE_MS;
+    return { reclaimable: stale, allowMissingOwner: stale };
+  } catch (error) {
+    if (isFileSystemError(error, "ENOENT")) {
+      return { reclaimable: true, allowMissingOwner: true };
+    }
+    throw error;
+  }
+}
+
+async function tryReclaimStateLock(lockPath: string, allowMissingOwner: boolean): Promise<boolean> {
+  const reclaimPath = join(lockPath, LOCK_RECLAIM_FILE);
+  try {
+    const handle = await open(reclaimPath, "wx", 0o600);
+    await handle.close();
+  } catch (error) {
+    if (isFileSystemError(error, "ENOENT")) return true;
+    if (!isFileSystemError(error, "EEXIST")) throw error;
+
+    try {
+      const reclaim = await stat(reclaimPath);
+      if (Date.now() - reclaim.mtimeMs <= STALE_LOCK_AGE_MS) return false;
+    } catch (statError) {
+      if (isFileSystemError(statError, "ENOENT")) return false;
+      throw statError;
+    }
+
+    const owner = await readLockOwner(lockPath);
+    if (owner && isProcessAlive(owner.pid)) {
+      await unlink(reclaimPath).catch(() => undefined);
+      return false;
+    }
+    if (!owner && !allowMissingOwner) return false;
+    await rm(lockPath, { recursive: true, force: true });
+    return true;
+  }
+
+  const owner = await readLockOwner(lockPath);
+  const reclaimable = owner ? !isProcessAlive(owner.pid) : allowMissingOwner;
+  if (reclaimable) {
+    await rm(lockPath, { recursive: true, force: true });
+    return true;
+  }
+
+  await unlink(reclaimPath).catch((error: unknown) => {
+    if (!isFileSystemError(error, "ENOENT")) throw error;
+  });
+  return false;
+}
+
+async function acquireStateLock(statePath: string): Promise<() => Promise<void>> {
+  await mkdir(dirname(statePath), { recursive: true, mode: 0o700 });
+  const lockPath = `${statePath}.lock`;
+  const token = randomUUID();
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      await mkdir(lockPath, { mode: 0o700 });
+      const owner = { token, pid: process.pid, createdAtMs: Date.now() } satisfies StateLockOwner;
+      try {
+        writeFileSync(join(lockPath, LOCK_OWNER_FILE), JSON.stringify(owner), {
+          flag: "wx",
+          mode: 0o600,
+        });
+      } catch (error) {
+        await rmdir(lockPath).catch(() => undefined);
+        throw error;
+      }
+
+      return async () => {
+        const currentOwner = await readLockOwner(lockPath);
+        if (currentOwner?.token !== token) return;
+        await rm(lockPath, { recursive: true, force: true });
+      };
+    } catch (error) {
+      if (!isFileSystemError(error, "EEXIST")) throw error;
+    }
+
+    const status = await getReclaimStatus(lockPath);
+    if (status.reclaimable && (await tryReclaimStateLock(lockPath, status.allowMissingOwner))) {
+      continue;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out acquiring quota reset notification state lock: ${lockPath}`);
+    }
+    await delay(LOCK_RETRY_DELAY_MS);
+  }
+}
+
 function didReset(previous: ResetObservation, current: ResetObservation, nowMs: number): boolean {
   const transitionAge = nowMs - previous.resetAtMs;
   return (
@@ -117,21 +274,41 @@ function didReset(previous: ResetObservation, current: ResetObservation, nowMs: 
   );
 }
 
-export async function observeQuotaResetNotifications(params: {
+function updateObservation(
+  previous: ResetObservation | undefined,
+  current: ResetObservation,
+  nowMs: number,
+): { observation: ResetObservation; notify: boolean } {
+  if (!previous) return { observation: current, notify: false };
+  if (current.resetAtMs < previous.resetAtMs || current.observedAtMs < previous.observedAtMs) {
+    return { observation: previous, notify: false };
+  }
+
+  if (current.resetAtMs === previous.resetAtMs) {
+    if (current.resetAtMs <= nowMs && previous.observedAtMs <= previous.resetAtMs) {
+      return { observation: previous, notify: false };
+    }
+    return {
+      observation: { ...current, notifiedResetAtMs: previous.notifiedResetAtMs },
+      notify: false,
+    };
+  }
+
+  if (nowMs < previous.resetAtMs) return { observation: previous, notify: false };
+
+  const notify = didReset(previous, current, nowMs);
+  return {
+    observation: notify ? { ...current, notifiedResetAtMs: previous.resetAtMs } : current,
+    notify,
+  };
+}
+
+function collectCandidates(params: {
   providers: QuotaResetProviderResult[];
   windows: readonly QuotaResetWindow[];
-  nowMs?: number;
-  statePath?: string;
-}): Promise<QuotaResetNotice[]> {
-  const nowMs = params.nowMs ?? Date.now();
-  const statePath = params.statePath ?? getStatePath();
-  const state = await readState(statePath);
-  const observations = Object.fromEntries(
-    Object.entries(state.observations).filter(
-      ([, observation]) => nowMs - observation.observedAtMs <= MAX_OBSERVATION_AGE_MS,
-    ),
-  );
-  const notices: QuotaResetNotice[] = [];
+  nowMs: number;
+}): Map<string, ResetCandidate[]> {
+  const candidates = new Map<string, ResetCandidate[]>();
 
   for (const provider of params.providers) {
     for (const entry of provider.result.entries) {
@@ -147,33 +324,73 @@ export async function observeQuotaResetNotifications(params: {
       if (!Number.isFinite(resetAtMs)) continue;
 
       const key = getIdentity(provider.providerId, entry, window);
-      const previous = observations[key];
-      const current: ResetObservation = {
-        resetAtMs,
-        percentRemaining: entry.percentRemaining,
-        observedAtMs: nowMs,
-      };
-
-      if (previous && didReset(previous, current, nowMs)) {
-        current.notifiedResetAtMs = previous.resetAtMs;
-        notices.push({
+      const candidate: ResetCandidate = {
+        current: {
+          resetAtMs,
+          percentRemaining: entry.percentRemaining,
+          observedAtMs: params.nowMs,
+        },
+        notice: {
           providerId: provider.providerId,
           label: entry.group?.trim() || getQuotaProviderDisplayLabel(provider.providerId),
           window,
           percentRemaining: entry.percentRemaining,
-        });
-      }
-
-      observations[key] = current;
+        },
+      };
+      const matching = candidates.get(key);
+      if (matching) matching.push(candidate);
+      else candidates.set(key, [candidate]);
     }
   }
 
-  await writeJsonAtomic(
-    statePath,
-    { version: STATE_VERSION, observations } satisfies ResetNotificationState,
-    { trailingNewline: true, directoryMode: 0o700, fileMode: 0o600 },
-  );
-  return notices;
+  return candidates;
+}
+
+export async function observeQuotaResetNotifications(params: {
+  providers: QuotaResetProviderResult[];
+  windows: readonly QuotaResetWindow[];
+  nowMs?: number;
+  statePath?: string;
+}): Promise<QuotaResetNotice[]> {
+  const nowMs = params.nowMs ?? Date.now();
+  const statePath = params.statePath ?? getStatePath();
+  const candidates = collectCandidates({
+    providers: params.providers,
+    windows: params.windows,
+    nowMs,
+  });
+  const releaseLock = await acquireStateLock(statePath);
+
+  try {
+    const state = await readState(statePath);
+    const observations = Object.fromEntries(
+      Object.entries(state.observations).filter(
+        ([, observation]) => nowMs - observation.observedAtMs <= MAX_OBSERVATION_AGE_MS,
+      ),
+    );
+    const notices: QuotaResetNotice[] = [];
+
+    for (const [key, matching] of candidates) {
+      if (matching.length !== 1) {
+        delete observations[key];
+        continue;
+      }
+      const candidate = matching[0];
+      if (!candidate) continue;
+      const update = updateObservation(observations[key], candidate.current, nowMs);
+      observations[key] = update.observation;
+      if (update.notify) notices.push(candidate.notice);
+    }
+
+    await writeJsonAtomic(
+      statePath,
+      { version: STATE_VERSION, observations } satisfies ResetNotificationState,
+      { trailingNewline: true, directoryMode: 0o700, fileMode: 0o600 },
+    );
+    return notices;
+  } finally {
+    await releaseLock();
+  }
 }
 
 export function formatQuotaResetNotification(notices: readonly QuotaResetNotice[]): string | null {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,14 @@ export type PricingSnapshotSource = "auto" | "bundled" | "runtime";
 export type PercentDisplayMode = "remaining" | "used";
 export type SessionTokenScope = "current" | "tree";
 export type OpenCodeGoWindowKey = "rolling" | "weekly" | "monthly";
+export type QuotaResetWindow = "fiveHour" | "hourly" | "daily" | "weekly" | "monthly" | "yearly";
+
+export interface QuotaResetNotificationsConfig {
+  /** Whether successful quota-window resets emit a one-shot toast. */
+  enabled: boolean;
+  /** Window classes eligible for reset notifications. */
+  windows: QuotaResetWindow[];
+}
 
 export interface PricingSnapshotConfig {
   source: PricingSnapshotSource;
@@ -78,6 +86,9 @@ export interface QuotaToastConfig {
 
   /** If false, never show popup toasts (commands/tools still work). */
   enableToast: boolean;
+
+  /** Opt-in, persisted notifications when selected quota windows reset. */
+  resetNotifications: QuotaResetNotificationsConfig;
 
   /** Where deterministic native TUI command output appears. */
   tuiCommandDisplay: TuiCommandDisplay;
@@ -197,6 +208,10 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
   enabled: true,
 
   enableToast: true,
+  resetNotifications: {
+    enabled: false,
+    windows: ["weekly"],
+  },
   tuiCommandDisplay: "inline",
   formatStyle: DEFAULT_QUOTA_FORMAT_STYLE,
   percentDisplayMode: "remaining",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -46,6 +46,10 @@ import {
 } from "./lib/quota-providers.js";
 import { collectQuotaRenderData, type SessionModelMeta } from "./lib/quota-render-data.js";
 import {
+  formatQuotaResetNotification,
+  observeQuotaResetNotifications,
+} from "./lib/quota-reset-notifications.js";
+import {
   createQuotaRuntimeRequestContext,
   type QuotaRuntimeContext,
   resolveQuotaRuntimeContext,
@@ -193,6 +197,7 @@ type QuotaMessageFetchResult = {
   retryReason?: DeferredQuotaRefreshReason;
   hasQuotaRows: boolean;
   detectedProviderIds: string[];
+  resetNotification?: string;
 };
 
 const DEFERRED_QUOTA_REFRESH_DELAYS_MS = [3_000, 15_000, 60_000, 300_000] as const;
@@ -841,8 +846,33 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
       bypassProviderCache: params.bypassProviderCache,
       providers: runtime.providers,
     });
-    const { selection, availability, active, attemptedAny, hasExplicitProviderIssues, data } =
-      quotaResult;
+    const {
+      selection,
+      availability,
+      active,
+      providerResults,
+      attemptedAny,
+      hasExplicitProviderIssues,
+      data,
+    } = quotaResult;
+    let resetNotification: string | undefined;
+    if (
+      runtimeConfig.enableToast &&
+      runtimeConfig.resetNotifications.enabled &&
+      providerResults.length > 0
+    ) {
+      try {
+        const notices = await observeQuotaResetNotifications({
+          providers: providerResults,
+          windows: runtimeConfig.resetNotifications.windows,
+        });
+        resetNotification = formatQuotaResetNotification(notices) ?? undefined;
+      } catch (error) {
+        await log("Failed to observe quota reset transitions", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     if (selection?.isAutoMode) {
       await reconcileDetectedProviderConfig(active.map((provider) => provider.id));
     }
@@ -881,6 +911,7 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
         retryReason: retryableNoProviders ? "no_available_providers" : undefined,
         hasQuotaRows: false,
         detectedProviderIds,
+        resetNotification,
       };
     }
 
@@ -906,6 +937,7 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
           retryReason: retryableMaskedProviderFailure ? "provider_fetch_failed" : undefined,
           hasQuotaRows: true,
           detectedProviderIds,
+          resetNotification,
         };
       }
 
@@ -920,6 +952,7 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
         retryReason: retryableMaskedProviderFailure ? "provider_fetch_failed" : undefined,
         hasQuotaRows: true,
         detectedProviderIds,
+        resetNotification,
       };
     }
 
@@ -961,6 +994,7 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
         retryReason,
         hasQuotaRows: false,
         detectedProviderIds,
+        resetNotification,
       };
     }
 
@@ -989,6 +1023,7 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
           : undefined,
       hasQuotaRows: false,
       detectedProviderIds,
+      resetNotification,
     };
   }
 
@@ -1145,6 +1180,20 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
             [],
         );
         await log("Displayed quota toast", { message, trigger });
+        if (fetchResult?.resetNotification) {
+          await typedClient.tui.showToast({
+            body: {
+              title: "Quota available",
+              message: sanitizeDisplayText(fetchResult.resetNotification),
+              variant: "success",
+              duration: config.toastDurationMs,
+            },
+          });
+          await log("Displayed quota reset notification", {
+            message: fetchResult.resetNotification,
+            trigger,
+          });
+        }
       } catch (err) {
         await log("Failed to show toast", {
           error: err instanceof Error ? err.message : String(err),

--- a/tests/helpers/plugin-test-harness.ts
+++ b/tests/helpers/plugin-test-harness.ts
@@ -220,6 +220,13 @@ export function makeQuotaToastTestConfig(
           : DEFAULT_CONFIG.enabledProviders,
     googleModels: [...(overrides.googleModels ?? DEFAULT_CONFIG.googleModels)],
     opencodeGoWindows: [...(overrides.opencodeGoWindows ?? DEFAULT_CONFIG.opencodeGoWindows)],
+    resetNotifications: {
+      ...DEFAULT_CONFIG.resetNotifications,
+      ...overrides.resetNotifications,
+      windows: [
+        ...(overrides.resetNotifications?.windows ?? DEFAULT_CONFIG.resetNotifications.windows),
+      ],
+    },
     pricingSnapshot: {
       ...DEFAULT_CONFIG.pricingSnapshot,
       ...overrides.pricingSnapshot,

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -92,6 +92,50 @@ describe("loadConfig", () => {
     expect(removedKey.meta.configIssues).toEqual([]);
   });
 
+  it("defaults and validates quota reset notifications with provenance", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.resetNotifications).toEqual({
+      enabled: false,
+      windows: ["weekly"],
+    });
+
+    const configured = await loadSdkConfig({
+      resetNotifications: {
+        enabled: true,
+        windows: ["weekly", "monthly", "weekly"],
+      },
+    });
+    expect(configured.config.resetNotifications).toEqual({
+      enabled: true,
+      windows: ["weekly", "monthly"],
+    });
+    expect(configured.meta.settingSources).toEqual({
+      "resetNotifications.enabled": "client.config.get",
+      "resetNotifications.windows": "client.config.get",
+    });
+    expect(configured.meta.networkSettingSources).toEqual({});
+
+    const invalid = await loadSdkConfig({
+      resetNotifications: { enabled: "yes", windows: ["rolling"] },
+    });
+    expect(invalid.config.resetNotifications).toEqual({
+      enabled: false,
+      windows: ["weekly"],
+    });
+    expect(invalid.meta.configIssues).toEqual([
+      {
+        path: "client.config.get",
+        key: "resetNotifications.enabled",
+        message: "expected boolean",
+      },
+      {
+        path: "client.config.get",
+        key: "resetNotifications.windows",
+        message: "expected a non-empty array of: fiveHour, hourly, daily, weekly, monthly, yearly",
+      },
+    ]);
+  });
+
   it("defaults and validates session token scope with provenance", async () => {
     const defaults = await loadSdkConfig({});
     expect(defaults.config.sessionTokenScope).toBe("current");

--- a/tests/lib.quota-reset-notifications.test.ts
+++ b/tests/lib.quota-reset-notifications.test.ts
@@ -1,0 +1,162 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { QuotaResetProviderResult } from "../src/lib/quota-reset-notifications.js";
+import {
+  formatQuotaResetNotification,
+  observeQuotaResetNotifications,
+} from "../src/lib/quota-reset-notifications.js";
+
+const created: string[] = [];
+
+async function statePath(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "opencode-quota-reset-"));
+  created.push(root);
+  return join(root, "state.json");
+}
+
+function provider(params: {
+  percentRemaining: number;
+  resetAtMs: number;
+  sourceId?: string;
+  label?: string;
+  resultType?: "quota" | "usage";
+}): QuotaResetProviderResult {
+  return {
+    providerId: "openai",
+    result: {
+      attempted: true,
+      errors: [],
+      entries: [
+        {
+          name: "OpenAI",
+          group: params.sourceId ? `OpenAI (${params.sourceId})` : "OpenAI",
+          label: params.label ?? "7d",
+          percentRemaining: params.percentRemaining,
+          resetTimeIso: new Date(params.resetAtMs).toISOString(),
+          accounting: {
+            resultType: params.resultType ?? "quota",
+            acquisitionMethod: "remote_api",
+            ownership: "maintained",
+            authority: "provider_reported",
+            sourceId: params.sourceId,
+          },
+        },
+      ],
+    },
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(created.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe("quota reset notifications", () => {
+  it("uses the first observation as a baseline and notifies once after a crossed weekly reset", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    const nextReset = firstReset + 7 * 24 * 60 * 60 * 1000;
+
+    expect(
+      await observeQuotaResetNotifications({
+        providers: [provider({ percentRemaining: 12, resetAtMs: firstReset })],
+        windows: ["weekly"],
+        nowMs: start,
+        statePath: path,
+      }),
+    ).toEqual([]);
+
+    const notices = await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 100, resetAtMs: nextReset })],
+      windows: ["weekly"],
+      nowMs: firstReset + 60_000,
+      statePath: path,
+    });
+    expect(notices).toEqual([
+      {
+        providerId: "openai",
+        label: "OpenAI",
+        window: "weekly",
+        percentRemaining: 100,
+      },
+    ]);
+    expect(formatQuotaResetNotification(notices)).toBe(
+      "Weekly quota reset: OpenAI is available again (100% remaining).",
+    );
+
+    expect(
+      await observeQuotaResetNotifications({
+        providers: [provider({ percentRemaining: 100, resetAtMs: nextReset })],
+        windows: ["weekly"],
+        nowMs: firstReset + 120_000,
+        statePath: path,
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not notify before the previous reset is crossed or when quota did not improve", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 25, resetAtMs: firstReset })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    expect(
+      await observeQuotaResetNotifications({
+        providers: [provider({ percentRemaining: 100, resetAtMs: firstReset + 604_800_000 })],
+        windows: ["weekly"],
+        nowMs: start + 30 * 60 * 1000,
+        statePath: path,
+      }),
+    ).toEqual([]);
+  });
+
+  it("filters window and accounting types", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const reset = start + 60 * 60 * 1000;
+
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: reset, label: "Monthly" })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: reset, resultType: "usage" })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    expect(JSON.parse(await readFile(path, "utf8")).observations).toEqual({});
+  });
+
+  it("keeps accounts independent without persisting source identifiers", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const reset = start + 60 * 60 * 1000;
+    const sources = ["work@example.com", "personal@example.com"];
+
+    await observeQuotaResetNotifications({
+      providers: sources.map((sourceId) =>
+        provider({ percentRemaining: 5, resetAtMs: reset, sourceId }),
+      ),
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    const state = await readFile(path, "utf8");
+    expect(Object.keys(JSON.parse(state).observations)).toHaveLength(2);
+    expect(state).not.toContain("work@example.com");
+    expect(state).not.toContain("personal@example.com");
+  });
+});

--- a/tests/lib.quota-reset-notifications.test.ts
+++ b/tests/lib.quota-reset-notifications.test.ts
@@ -1,4 +1,6 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -20,19 +22,24 @@ async function statePath(): Promise<string> {
 function provider(params: {
   percentRemaining: number;
   resetAtMs: number;
+  providerId?: string;
   sourceId?: string;
+  name?: string;
+  group?: string;
   label?: string;
   resultType?: "quota" | "usage";
 }): QuotaResetProviderResult {
+  const providerId = params.providerId ?? "openai";
+  const name = params.name ?? (providerId === "openai" ? "OpenAI" : "Anthropic");
   return {
-    providerId: "openai",
+    providerId,
     result: {
       attempted: true,
       errors: [],
       entries: [
         {
-          name: "OpenAI",
-          group: params.sourceId ? `OpenAI (${params.sourceId})` : "OpenAI",
+          name,
+          group: params.group ?? (params.sourceId ? `${name} (${params.sourceId})` : name),
           label: params.label ?? "7d",
           percentRemaining: params.percentRemaining,
           resetTimeIso: new Date(params.resetAtMs).toISOString(),
@@ -54,7 +61,7 @@ afterEach(async () => {
 });
 
 describe("quota reset notifications", () => {
-  it("uses the first observation as a baseline and notifies once after a crossed weekly reset", async () => {
+  it("uses the first observation as a baseline and persists one acknowledgement", async () => {
     const path = await statePath();
     const start = Date.UTC(2026, 0, 1, 12);
     const firstReset = start + 60 * 60 * 1000;
@@ -95,6 +102,198 @@ describe("quota reset notifications", () => {
         statePath: path,
       }),
     ).toEqual([]);
+  });
+
+  it("reclaims a lock left by an exited process", async () => {
+    const path = await statePath();
+    const lockPath = `${path}.lock`;
+    await mkdir(lockPath, { mode: 0o700 });
+    const exitedOwner = spawn(process.execPath, ["-e", ""]);
+    const exitedPid = exitedOwner.pid;
+    if (!exitedPid) throw new Error("Failed to start lock-owner test process");
+    await once(exitedOwner, "exit");
+    await writeFile(
+      join(lockPath, "owner.json"),
+      JSON.stringify({ token: "exited-owner", pid: exitedPid, createdAtMs: Date.now() }),
+    );
+
+    const start = Date.UTC(2026, 0, 1, 12);
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: start + 60 * 60 * 1000 })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    expect(Object.keys(JSON.parse(await readFile(path, "utf8")).observations)).toHaveLength(1);
+    await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("serializes concurrent observers so the same reset is notified once", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    const nextReset = firstReset + 7 * 24 * 60 * 60 * 1000;
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: firstReset })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    const results = await Promise.all(
+      [1, 2].map(() =>
+        observeQuotaResetNotifications({
+          providers: [provider({ percentRemaining: 100, resetAtMs: nextReset })],
+          windows: ["weekly"],
+          nowMs: firstReset + 60_000,
+          statePath: path,
+        }),
+      ),
+    );
+
+    expect(results.flat()).toHaveLength(1);
+  });
+
+  it("preserves disjoint observations written concurrently", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const reset = start + 60 * 60 * 1000;
+
+    await Promise.all(
+      ["work@example.com", "personal@example.com"].map((sourceId) =>
+        observeQuotaResetNotifications({
+          providers: [provider({ percentRemaining: 5, resetAtMs: reset, sourceId })],
+          windows: ["weekly"],
+          nowMs: start,
+          statePath: path,
+        }),
+      ),
+    );
+
+    const state = JSON.parse(await readFile(path, "utf8"));
+    expect(Object.keys(state.observations)).toHaveLength(2);
+  });
+
+  it("preserves a pre-boundary baseline while a provider still reports the expired reset", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    const nextReset = firstReset + 7 * 24 * 60 * 60 * 1000;
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: firstReset })],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    await observeQuotaResetNotifications({
+      providers: [provider({ percentRemaining: 10, resetAtMs: firstReset })],
+      windows: ["weekly"],
+      nowMs: firstReset + 60_000,
+      statePath: path,
+    });
+
+    expect(
+      await observeQuotaResetNotifications({
+        providers: [provider({ percentRemaining: 100, resetAtMs: nextReset })],
+        windows: ["weekly"],
+        nowMs: firstReset + 120_000,
+        statePath: path,
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("keeps identity stable when presentation labels change", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    const nextReset = firstReset + 7 * 24 * 60 * 60 * 1000;
+    await observeQuotaResetNotifications({
+      providers: [
+        provider({
+          percentRemaining: 10,
+          resetAtMs: firstReset,
+          sourceId: "account-1",
+          name: "Old provider name",
+          group: "Old account label",
+          label: "7d",
+        }),
+      ],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    const notices = await observeQuotaResetNotifications({
+      providers: [
+        provider({
+          percentRemaining: 100,
+          resetAtMs: nextReset,
+          sourceId: "account-1",
+          name: "New provider name",
+          group: "New account label",
+          label: "weekly",
+        }),
+      ],
+      windows: ["weekly"],
+      nowMs: firstReset + 60_000,
+      statePath: path,
+    });
+
+    expect(notices).toEqual([
+      expect.objectContaining({ providerId: "openai", label: "New account label" }),
+    ]);
+  });
+
+  it("skips ambiguous rows instead of attributing one series to another", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const reset = start + 60 * 60 * 1000;
+
+    await observeQuotaResetNotifications({
+      providers: [
+        provider({ percentRemaining: 5, resetAtMs: reset, name: "First" }),
+        provider({ percentRemaining: 15, resetAtMs: reset, name: "Second" }),
+      ],
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    expect(JSON.parse(await readFile(path, "utf8")).observations).toEqual({});
+  });
+
+  it("aggregates providers that reset together", async () => {
+    const path = await statePath();
+    const start = Date.UTC(2026, 0, 1, 12);
+    const firstReset = start + 60 * 60 * 1000;
+    const nextReset = firstReset + 7 * 24 * 60 * 60 * 1000;
+    const initial = [
+      provider({ percentRemaining: 5, resetAtMs: firstReset, providerId: "openai" }),
+      provider({ percentRemaining: 15, resetAtMs: firstReset, providerId: "anthropic" }),
+    ];
+    await observeQuotaResetNotifications({
+      providers: initial,
+      windows: ["weekly"],
+      nowMs: start,
+      statePath: path,
+    });
+
+    const notices = await observeQuotaResetNotifications({
+      providers: [
+        provider({ percentRemaining: 100, resetAtMs: nextReset, providerId: "openai" }),
+        provider({ percentRemaining: 100, resetAtMs: nextReset, providerId: "anthropic" }),
+      ],
+      windows: ["weekly"],
+      nowMs: firstReset + 60_000,
+      statePath: path,
+    });
+
+    expect(notices).toHaveLength(2);
+    expect(formatQuotaResetNotification(notices)).toBe(
+      "Quota reset: OpenAI, Anthropic are available again.",
+    );
   });
 
   it("does not notify before the previous reset is crossed or when quota did not improve", async () => {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -70,6 +70,8 @@ const mocks = vi.hoisted(() => ({
   resolveAlibabaCodingPlanAuthCached: vi.fn(),
   fetchSessionTokensForDisplay: vi.fn(),
   reconcileDetectedProvidersInGlobalConfig: vi.fn(),
+  observeQuotaResetNotifications: vi.fn(),
+  formatQuotaResetNotification: vi.fn(),
 }));
 
 vi.mock("@opencode-ai/plugin", () => createPluginToolMockModule());
@@ -102,6 +104,11 @@ vi.mock("../src/lib/opencode-config-providers.js", () => ({
   reconcileDetectedProvidersInGlobalConfig: mocks.reconcileDetectedProvidersInGlobalConfig,
 }));
 
+vi.mock("../src/lib/quota-reset-notifications.js", () => ({
+  observeQuotaResetNotifications: mocks.observeQuotaResetNotifications,
+  formatQuotaResetNotification: mocks.formatQuotaResetNotification,
+}));
+
 describe("/quota command behavior", () => {
   let savedConfigDir: string | undefined;
 
@@ -123,6 +130,8 @@ describe("/quota command behavior", () => {
       addedProviderIds: [],
       changed: false,
     });
+    mocks.observeQuotaResetNotifications.mockResolvedValue([]);
+    mocks.formatQuotaResetNotification.mockReturnValue(null);
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });
     const { __resetQuotaStateForTests } = await import("../src/lib/quota-state.js");
     __resetQuotaStateForTests();
@@ -394,6 +403,64 @@ describe("/quota command behavior", () => {
     const message = getToastMessage(client);
     expect(message).toContain("19% used");
     expect(message).not.toContain("81% left");
+  });
+
+  it("shows one additional success toast when an enabled quota reset is observed", async () => {
+    mocks.loadConfig.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      enabled: true,
+      enableToast: true,
+      resetNotifications: { enabled: true, windows: ["weekly"] },
+      enabledProviders: ["openai"],
+      showOnIdle: true,
+      showSessionTokens: false,
+      minIntervalMs: 60_000,
+    });
+    const provider = {
+      id: "openai",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      fetch: vi.fn().mockResolvedValue({
+        attempted: true,
+        entries: [
+          {
+            accounting: TEST_ACCOUNTING,
+            name: "OpenAI",
+            label: "7d",
+            percentRemaining: 100,
+            resetTimeIso: "2099-01-01T00:00:00.000Z",
+          },
+        ],
+        errors: [],
+      }),
+    };
+    mocks.getProviders.mockReturnValue([provider]);
+    mocks.observeQuotaResetNotifications.mockResolvedValue([
+      { providerId: "openai", label: "OpenAI", window: "weekly", percentRemaining: 100 },
+    ]);
+    mocks.formatQuotaResetNotification.mockReturnValue(
+      "Weekly quota reset: OpenAI is available again (100% remaining).",
+    );
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const client = createClient();
+    const hooks = await QuotaToastPlugin({ client } as any);
+    await hooks.event?.({
+      event: { type: "session.idle", properties: { sessionID: "session-reset" } },
+    } as any);
+
+    expect(mocks.observeQuotaResetNotifications).toHaveBeenCalledWith({
+      providers: [expect.objectContaining({ providerId: "openai" })],
+      windows: ["weekly"],
+    });
+    expect(client.tui.showToast).toHaveBeenCalledTimes(2);
+    expect(client.tui.showToast).toHaveBeenLastCalledWith({
+      body: {
+        title: "Quota available",
+        message: "Weekly quota reset: OpenAI is available again (100% remaining).",
+        variant: "success",
+        duration: 9000,
+      },
+    });
   });
 
   it("honors percentDisplayMode for /quota output", async () => {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -400,6 +400,7 @@ describe("/quota command behavior", () => {
     } as any);
 
     expect(client.tui.showToast).toHaveBeenCalledTimes(1);
+    expect(mocks.observeQuotaResetNotifications).not.toHaveBeenCalled();
     const message = getToastMessage(client);
     expect(message).toContain("19% used");
     expect(message).not.toContain("81% left");
@@ -452,6 +453,7 @@ describe("/quota command behavior", () => {
       providers: [expect.objectContaining({ providerId: "openai" })],
       windows: ["weekly"],
     });
+    expect(provider.fetch).toHaveBeenCalledTimes(1);
     expect(client.tui.showToast).toHaveBeenCalledTimes(2);
     expect(client.tui.showToast).toHaveBeenLastCalledWith({
       body: {


### PR DESCRIPTION
## Summary

Add opt-in, provider-neutral reset notifications for quota windows.

The observer reuses already-fetched provider results, records a hashed account/window identity in local state, and emits one aggregated success toast only after the previous reset boundary is crossed, the provider advertises a newer reset, and remaining quota increases. It adds no provider requests and defaults to disabled.

```jsonc
{
  "resetNotifications": {
    "enabled": true,
    "windows": ["weekly"]
  }
}
```

## Linked Issue

Fixes #199

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.11
- Why this version is relevant to the fix: it provides the production TUI success-toast surface used by the notification. The behavior was first validated with a local multi-account quota prototype before being generalized here.

## Verification

- `pnpm verify` passed through the repository pre-push hook on Node 24/Linux
- Includes Biome, TypeScript 7 typecheck, build, all 1,809 tests, cross-surface tests, and package-content checks
- Added detector, persistence, configuration, account-isolation, and server-toast integration coverage

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] Provider Changes does not apply; no provider implementation or credential flow changed
