### PR TITLE
feat: add 9Router provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Use the CLI for scripts, CI, or a quick terminal check outside OpenCode.
 
 | Provider           | Auth/setup                                                     | Data from          | Reports            |
 | ------------------ | -------------------------------------------------------------- | ------------------ | ------------------ |
+| 9Router            | [Needs setup](docs/readme/providers.md#9router)                | Remote API         | Quota              |
 | Anthropic (Claude) | [Needs setup](docs/readme/providers.md#anthropic-claude)       | Local CLI/OAuth    | Quota              |
 | Chutes AI          | Automatic                                                      | Remote API         | Quota              |
 | Cursor             | [Needs setup](docs/readme/providers.md#cursor)                 | Local estimate     | Budget and spend   |

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -21,6 +21,7 @@ Most providers work automatically. `Automatic` means OpenCode Quota reuses the c
 
 | Provider           | Auth/setup                             | Data from          | Reports            |
 | ------------------ | -------------------------------------- | ------------------ | ------------------ |
+| 9Router            | [Needs setup](#9router)                 | Remote API         | Quota              |
 | Anthropic (Claude) | [Needs setup](#anthropic-claude)       | Local CLI/OAuth    | Quota              |
 | Chutes AI          | Automatic                              | Remote API         | Quota              |
 | Cursor             | [Needs setup](#cursor)                 | Local estimate     | Budget and spend   |
@@ -594,3 +595,19 @@ You can instead create `~/.config/opencode/opencode-quota/opencode.json`:
 ```
 
 Set `opencodeMonthlyLimit` in `opencode-quota/quota-toast.json` to override the monthly budget from the billing page. Without a monthly limit, the provider shows the current balance only.
+
+### 9Router
+
+Enable the canonical `9router` provider and configure the 9Router management API with environment variables:
+
+```jsonc
+{
+  "enabledProviders": ["9router"],
+  "nineRouter": {
+    "providers": ["codex", "kiro"],
+    "display": "perConnection"
+  }
+}
+```
+
+Set `OPENCODE_NINEROUTER_URL` and `OPENCODE_NINEROUTER_API_KEY`. `nineRouter.providers` is an empty array discovers all active upstream providers. Values are normalized, deduplicated, and ordered before use. `display` is `perConnection` or `unified`.

--- a/scripts/copy-data.mjs
+++ b/scripts/copy-data.mjs
@@ -1,5 +1,5 @@
-import { copyFile, mkdir } from "fs/promises";
-import { dirname, join } from "path";
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 const files = [
   {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,6 +22,7 @@ import { cloneQuotaProviders, validateQuotaProviders } from "./quota-providers.j
 import type {
   CursorQuotaPlan,
   GoogleModelId,
+  NineRouterDisplay,
   PercentDisplayMode,
   PricingSnapshotSource,
   QuotaToastConfig,
@@ -81,6 +82,8 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "export.enabled",
   "export.path",
   "telemetry.enabled",
+  "nineRouter.providers",
+  "nineRouter.display",
 ] as const;
 
 export type QuotaToastSettingSourceKey = (typeof QUOTA_TOAST_SETTING_SOURCE_KEYS)[number];
@@ -132,6 +135,8 @@ const NETWORK_SETTING_SOURCE_KEYS = [
   "showOnQuestion",
   "showOnCompact",
   "showOnBothFail",
+  "nineRouter.providers",
+  "nineRouter.display",
 ] as const satisfies readonly QuotaToastSettingSourceKey[];
 
 type PricingSnapshotPatch = Partial<QuotaToastConfig["pricingSnapshot"]>;
@@ -141,6 +146,7 @@ type MaintainerAnnouncementsPatch = Partial<QuotaToastConfig["maintainerAnnounce
 type LayoutPatch = Partial<QuotaToastConfig["layout"]>;
 type ExportConfigPatch = Partial<QuotaToastConfig["export"]>;
 type TelemetryConfigPatch = Partial<QuotaToastConfig["telemetry"]>;
+type NineRouterPatch = Partial<QuotaToastConfig["nineRouter"]>;
 
 type ValidatedQuotaToastPatch = {
   enabled?: boolean;
@@ -176,6 +182,7 @@ type ValidatedQuotaToastPatch = {
   layout?: LayoutPatch;
   export?: ExportConfigPatch;
   telemetry?: TelemetryConfigPatch;
+  nineRouter?: NineRouterPatch;
 };
 
 type ConfigLayerScope = "global" | "workspace";
@@ -240,6 +247,38 @@ function isValidTuiCommandDisplay(value: unknown): value is TuiCommandDisplay {
 
 function isValidSessionTokenScope(value: unknown): value is SessionTokenScope {
   return value === "current" || value === "tree";
+}
+function isValidNineRouterDisplay(value: unknown): value is NineRouterDisplay {
+  return value === "perConnection" || value === "unified";
+}
+function hasNineRouterControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159);
+  });
+}
+export function canonicalizeNineRouterProviders(value: readonly unknown[]): string[] {
+  const providers = new Set<string>();
+  let all = false;
+  for (const item of value) {
+    const provider = normalizeOptionalString(item)?.toLowerCase();
+    if (provider === "all") {
+      all = true;
+      continue;
+    }
+    if (
+      !provider ||
+      hasNineRouterControlCharacter(provider) ||
+      Array.from(provider).length > 128 ||
+      providers.size === 32
+    )
+      continue;
+    providers.add(provider);
+  }
+  return providers.size ? [...providers].sort() : all ? ["all"] : [];
+}
+export function serializeNineRouterProviderSelection(providers: readonly string[]): string {
+  return JSON.stringify(canonicalizeNineRouterProviders(providers));
 }
 
 function isPositiveNumber(value: unknown): value is number {
@@ -328,6 +367,7 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
     layout: { ...config.layout },
     export: { ...config.export },
     telemetry: { ...config.telemetry },
+    nineRouter: { ...config.nineRouter, providers: [...config.nineRouter.providers] },
   };
 }
 
@@ -540,6 +580,34 @@ function extractTelemetryConfigPatch(value: unknown): TelemetryConfigPatch | und
 
   if (hasOwnKey(value, "enabled") && typeof value.enabled === "boolean") {
     patch.enabled = value.enabled;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
+}
+function extractNineRouterPatch(
+  value: unknown,
+  reportIssue?: (key: string, message: string) => void,
+): NineRouterPatch | undefined {
+  if (!isPlainObject(value)) {
+    reportIssue?.("nineRouter", "expected an object");
+    return undefined;
+  }
+
+  const patch: NineRouterPatch = {};
+  if (hasOwnKey(value, "providers")) {
+    if (Array.isArray(value.providers)) {
+      patch.providers = canonicalizeNineRouterProviders(value.providers);
+    } else {
+      reportIssue?.("nineRouter.providers", "expected an array of provider ids");
+    }
+  }
+
+  if (hasOwnKey(value, "display")) {
+    if (isValidNineRouterDisplay(value.display)) {
+      patch.display = value.display;
+    } else {
+      reportIssue?.("nineRouter.display", 'expected "perConnection" or "unified"');
+    }
   }
 
   return Object.keys(patch).length > 0 ? patch : undefined;
@@ -775,6 +843,10 @@ function extractValidatedQuotaToastPatch(
     if (telemetry) {
       patch.telemetry = telemetry;
     }
+  }
+  if (hasOwnKey(quotaToastConfig, "nineRouter")) {
+    const nineRouter = extractNineRouterPatch(quotaToastConfig.nineRouter, reportIssue);
+    if (nineRouter) patch.nineRouter = nineRouter;
   }
 
   return patch;
@@ -1027,6 +1099,16 @@ function applyValidatedQuotaToastPatch(
   if (patch.telemetry && hasOwnKey(patch.telemetry, "enabled")) {
     config.telemetry.enabled = patch.telemetry.enabled!;
     applySettingSource(settingSources, "telemetry.enabled", sourcePath);
+  }
+  if (patch.nineRouter) {
+    if (patch.nineRouter.providers !== undefined) {
+      config.nineRouter.providers = [...patch.nineRouter.providers];
+      applySettingSource(settingSources, "nineRouter.providers", sourcePath);
+    }
+    if (patch.nineRouter.display !== undefined) {
+      config.nineRouter.display = patch.nineRouter.display;
+      applySettingSource(settingSources, "nineRouter.display", sourcePath);
+    }
   }
 }
 

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -1,7 +1,7 @@
 import type { QuotaProviderDefinition } from "./quota-providers.js";
 import type { QuotaTelemetryToken } from "./quota-telemetry.js";
 import type { RuntimeProviderIdResolver } from "./runtime-provider-ids.js";
-import type { CursorQuotaPlan, OpenCodeGoWindowKey } from "./types.js";
+import type { CursorQuotaPlan, NineRouterConfig, OpenCodeGoWindowKey } from "./types.js";
 
 /**
  * Normalized quota output model.
@@ -234,6 +234,7 @@ export interface QuotaProviderContext {
     enabledProviders: string[] | "auto";
     quotaProviders?: QuotaProviderDefinition[];
     telemetryToken?: QuotaTelemetryToken;
+    nineRouter: Readonly<NineRouterConfig>;
   };
 }
 
@@ -249,4 +250,6 @@ export interface QuotaProvider {
 
   /** Optional provider match for onlyCurrentModel filtering */
   matchesCurrentModel?: (model: string, context?: QuotaProviderMatchContext) => boolean;
+
+  cacheIdentity?: (ctx: QuotaProviderContext) => string;
 }

--- a/src/lib/nine-router-http.ts
+++ b/src/lib/nine-router-http.ts
@@ -1,0 +1,91 @@
+import { REQUEST_TIMEOUT_MS } from "./types.js";
+
+export const NINE_ROUTER_MAX_BODY_BYTES = 256 * 1024;
+
+export type NineRouterHttpResult =
+  | { readonly success: true; readonly body: unknown }
+  | { readonly success: false; readonly error: string; readonly retryAfterMs?: number };
+
+async function readBoundedJson(response: Response): Promise<NineRouterHttpResult> {
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (!contentType || (contentType !== "application/json" && !contentType.endsWith("+json"))) {
+    return { success: false, error: "Expected a JSON response" };
+  }
+  const declaredSize = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredSize) && declaredSize > NINE_ROUTER_MAX_BODY_BYTES) {
+    return { success: false, error: "Response exceeded 262144 bytes" };
+  }
+  const reader = response.body?.getReader();
+  if (!reader) return { success: false, error: "Invalid JSON response" };
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      size += chunk.value.byteLength;
+      if (size > NINE_ROUTER_MAX_BODY_BYTES) {
+        await reader.cancel();
+        return { success: false, error: "Response exceeded 262144 bytes" };
+      }
+      chunks.push(chunk.value);
+    }
+  } catch {
+    return { success: false, error: "Failed to read nineRouter response" };
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return { success: true, body: JSON.parse(new TextDecoder().decode(bytes)) };
+  } catch {
+    return { success: false, error: "Invalid JSON response" };
+  }
+}
+
+function parseRetryAfterMs(value: string | null): number | undefined {
+  const seconds = Number(value?.trim());
+  return Number.isFinite(seconds) && seconds > 0 ? Math.min(seconds * 1000, 900000) : undefined;
+}
+
+export function createNineRouterManagementRequest(
+  root: string,
+  key: string,
+): (path: string, timeoutMs?: number) => Promise<NineRouterHttpResult> {
+  return async (path, timeoutMs = REQUEST_TIMEOUT_MS) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const response = await fetch(`${root}${path}`, {
+        method: "GET",
+        redirect: "manual",
+        signal: controller.signal,
+        headers: { Authorization: `Bearer ${key}`, Accept: "application/json" },
+      });
+      if (response.redirected || (response.status >= 300 && response.status < 400)) {
+        return { success: false, error: "Redirect rejected" };
+      }
+      if (!response.ok) {
+        const retryAfterMs = parseRetryAfterMs(response.headers.get("retry-after"));
+        return {
+          success: false,
+          error: `HTTP ${response.status}`,
+          ...(retryAfterMs ? { retryAfterMs } : {}),
+        };
+      }
+      return readBoundedJson(response);
+    } catch (error) {
+      if (controller.signal.aborted || (error instanceof Error && error.name === "AbortError")) {
+        return { success: false, error: `Request timeout after ${Math.round(timeoutMs / 1000)}s` };
+      }
+      return { success: false, error: "Failed to read nineRouter response" };
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/src/lib/nine-router.ts
+++ b/src/lib/nine-router.ts
@@ -1,0 +1,315 @@
+import { sanitizeSingleLineDisplayText } from "./display-sanitize.js";
+import type { NineRouterHttpResult } from "./nine-router-http.js";
+import { createNineRouterManagementRequest } from "./nine-router-http.js";
+
+export { NINE_ROUTER_MAX_BODY_BYTES } from "./nine-router-http.js";
+
+function hasControlCharacter(value: string): boolean {
+  return Array.from(value).some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159);
+  });
+}
+const MAX_CONNECTIONS = 500;
+const MAX_DISCOVERY_CONNECTIONS = 5000;
+const MAX_DISCOVERY_PAGES = 10;
+
+export type NineRouterAccount = {
+  readonly id: string;
+  readonly provider: string;
+  readonly name?: string;
+  readonly displayName?: string;
+  readonly email?: string;
+};
+export type NineRouterUsageWindow = {
+  readonly kind: string;
+  readonly percentRemaining: number;
+  readonly resetTimeIso?: string;
+};
+type NineRouterConfig = {
+  readonly request: (path: string, timeoutMs?: number) => Promise<NineRouterHttpResult>;
+};
+export type NineRouterConfigResult =
+  | { readonly success: true; readonly root: string }
+  | { readonly success: false; readonly error: string };
+export type NineRouterAccountsResult =
+  | {
+      readonly success: true;
+      readonly accounts: readonly NineRouterAccount[];
+      readonly errors?: readonly { readonly error: string }[];
+    }
+  | { readonly success: false; readonly error: string; readonly retryAfterMs?: number };
+export type NineRouterUsageResult =
+  | {
+      readonly success: true;
+      readonly windows: readonly NineRouterUsageWindow[];
+      readonly errors?: readonly { readonly error: string }[];
+    }
+  | {
+      readonly success: false;
+      readonly error: string;
+      readonly retryAfterMs?: number;
+      readonly safeDisplayMessage?: true;
+    };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+function isLoopback(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
+}
+function safeConfigError(): NineRouterConfigResult {
+  return { success: false, error: "nineRouter management configuration is invalid" };
+}
+function safeConnectionId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const id = value.trim();
+  return id && id.length <= 256 && !hasControlCharacter(id) ? id : null;
+}
+function safeProvider(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const provider = value.trim().toLowerCase();
+  return provider && Array.from(provider).length <= 128 && !hasControlCharacter(provider)
+    ? provider
+    : null;
+}
+function safeQuotaKey(value: string): string | null {
+  const key = value.trim();
+  return key && Array.from(key).length <= 128 && !hasControlCharacter(key) ? key : null;
+}
+function safeMessage(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const message = sanitizeSingleLineDisplayText(value);
+  return message && Array.from(message).length <= 500 ? message : null;
+}
+function safeLabel(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const label = sanitizeSingleLineDisplayText(value);
+  return label && Array.from(label).length <= 256 ? label : null;
+}
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+function safePagination(
+  value: unknown,
+  page: number,
+): { readonly total: number; readonly totalPages: number } | null {
+  if (!isRecord(value)) return null;
+  const responsePage = value.page,
+    responsePageSize = value.pageSize,
+    total = value.total,
+    totalPages = value.totalPages;
+  if (
+    !isInteger(responsePage) ||
+    responsePage !== page ||
+    !isInteger(responsePageSize) ||
+    responsePageSize !== MAX_CONNECTIONS ||
+    !isInteger(total) ||
+    total < 0 ||
+    total > MAX_DISCOVERY_CONNECTIONS ||
+    !isInteger(totalPages) ||
+    totalPages < 0 ||
+    totalPages > MAX_DISCOVERY_PAGES ||
+    (total === 0 ? totalPages > 1 : totalPages !== Math.ceil(total / responsePageSize)) ||
+    (total > 0 && responsePage > totalPages)
+  )
+    return null;
+  return { total, totalPages };
+}
+const managementConfigs = new WeakMap<object, NineRouterConfig>();
+export function resolveNineRouterConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): NineRouterConfigResult {
+  const rootValue = env.OPENCODE_NINEROUTER_URL?.trim(),
+    key = env.OPENCODE_NINEROUTER_API_KEY?.trim();
+  if (!rootValue || !key) return safeConfigError();
+  let root: URL;
+  try {
+    root = new URL(rootValue);
+  } catch {
+    return safeConfigError();
+  }
+  const pathname = root.pathname.replace(/\/+$/u, "") || "/";
+  if (
+    root.username ||
+    root.password ||
+    root.search ||
+    root.hash ||
+    (root.protocol !== "https:" && !(root.protocol === "http:" && isLoopback(root.hostname))) ||
+    pathname.toLowerCase() === "/v1"
+  )
+    return safeConfigError();
+  const normalizedRoot = `${root.origin}${pathname === "/" ? "" : pathname}`;
+  const result: NineRouterConfigResult = { success: true, root: normalizedRoot };
+  managementConfigs.set(result, {
+    request: createNineRouterManagementRequest(normalizedRoot, key),
+  });
+  return result;
+}
+function configFromResult(result: NineRouterConfigResult): NineRouterConfig | null {
+  return result.success ? (managementConfigs.get(result) ?? null) : null;
+}
+export async function fetchNineRouterAccounts(
+  result: NineRouterConfigResult,
+  provider?: string,
+): Promise<NineRouterAccountsResult> {
+  const config = configFromResult(result);
+  if (!config) return { success: false, error: "nineRouter management configuration is invalid" };
+  const requestedProvider = provider === undefined ? undefined : safeProvider(provider);
+  if (requestedProvider === null)
+    return { success: false, error: "Invalid nineRouter provider response" };
+  const accounts: NineRouterAccount[] = [],
+    errors: { error: string }[] = [],
+    connectionIds = new Set<string>();
+  let total: number | null = null,
+    totalPages: number | null = null;
+  for (let page = 1; totalPages === null || page <= totalPages; page += 1) {
+    const providerQuery =
+      requestedProvider === undefined ? "" : `provider=${encodeURIComponent(requestedProvider)}&`;
+    const response = await config.request(
+      `/api/providers/client?${providerQuery}accountStatus=active&page=${page}&pageSize=500&sort=priority`,
+    );
+    if (!response.success) return response;
+    if (!isRecord(response.body) || !Array.isArray(response.body.connections))
+      return { success: false, error: "Invalid nineRouter provider response" };
+    const pagination = safePagination(response.body.pagination, page);
+    if (
+      !pagination ||
+      (total !== null && pagination.total !== total) ||
+      (totalPages !== null && pagination.totalPages !== totalPages) ||
+      response.body.connections.length > MAX_CONNECTIONS
+    )
+      return { success: false, error: "Invalid nineRouter provider response" };
+    total = pagination.total;
+    totalPages = pagination.totalPages;
+    if (totalPages === 0) break;
+    for (const value of response.body.connections) {
+      const id = isRecord(value) ? safeConnectionId(value.id) : null,
+        connectionProvider = isRecord(value) ? safeProvider(value.provider) : null,
+        active = isRecord(value) && value.isActive !== false;
+      if (
+        !id ||
+        !connectionProvider ||
+        !active ||
+        (requestedProvider !== undefined && connectionProvider !== requestedProvider)
+      ) {
+        errors.push({ error: "Invalid account identifier" });
+        continue;
+      }
+      if (connectionIds.has(id)) continue;
+      connectionIds.add(id);
+      const name = safeLabel(value.name),
+        displayName = safeLabel(value.displayName),
+        email = safeLabel(value.email);
+      accounts.push({
+        id,
+        provider: connectionProvider,
+        ...(name ? { name } : {}),
+        ...(displayName ? { displayName } : {}),
+        ...(email ? { email } : {}),
+      });
+    }
+  }
+  return { success: true, accounts, ...(errors.length ? { errors } : {}) };
+}
+function parseResetTime(value: unknown): string | undefined {
+  const timestamp =
+      typeof value === "string"
+        ? Date.parse(value)
+        : typeof value === "number"
+          ? value * (value < 1e12 ? 1000 : 1)
+          : Number.NaN,
+    date = new Date(timestamp);
+  return Number.isFinite(timestamp) && timestamp > 0 && Number.isFinite(date.getTime())
+    ? date.toISOString()
+    : undefined;
+}
+function parseResetAfterSeconds(value: unknown): string | undefined {
+  const timestamp =
+      typeof value === "number" && Number.isFinite(value) ? Date.now() + value * 1000 : Number.NaN,
+    date = new Date(timestamp);
+  return Number.isFinite(timestamp) && timestamp > 0 && Number.isFinite(date.getTime())
+    ? date.toISOString()
+    : undefined;
+}
+function parseQuota(key: string, value: unknown): NineRouterUsageWindow | null {
+  if (!isRecord(value)) return null;
+  const percent =
+    value.unlimited === true
+      ? 100
+      : typeof value.remainingPercentage === "number" && Number.isFinite(value.remainingPercentage)
+        ? value.remainingPercentage
+        : typeof value.used_percent === "number" && Number.isFinite(value.used_percent)
+          ? 100 - value.used_percent
+          : typeof value.percent_used === "number" && Number.isFinite(value.percent_used)
+            ? 100 - value.percent_used
+            : typeof value.used === "number" &&
+                Number.isFinite(value.used) &&
+                typeof value.total === "number" &&
+                Number.isFinite(value.total) &&
+                value.total > 0
+              ? (100 * (value.total - value.used)) / value.total
+              : Number.NaN;
+  if (!Number.isFinite(percent)) return null;
+  const resetTimeIso =
+    value.resetAt !== undefined
+      ? parseResetTime(value.resetAt)
+      : value.reset_at !== undefined
+        ? parseResetTime(value.reset_at)
+        : value.resets_at !== undefined
+          ? parseResetTime(value.resets_at)
+          : value.reset_after_seconds !== undefined
+            ? parseResetAfterSeconds(value.reset_after_seconds)
+            : undefined;
+  return {
+    kind: key,
+    percentRemaining: Math.min(100, Math.max(0, percent)),
+    ...(resetTimeIso ? { resetTimeIso } : {}),
+  };
+}
+export async function fetchNineRouterUsage(
+  result: NineRouterConfigResult,
+  id: string,
+  timeoutMs?: number,
+): Promise<NineRouterUsageResult> {
+  const config = configFromResult(result);
+  if (!config) return { success: false, error: "nineRouter management configuration is invalid" };
+  const safeId = safeConnectionId(id);
+  if (!safeId) return { success: false, error: "Invalid account identifier" };
+  const response = await config.request(`/api/usage/${encodeURIComponent(safeId)}`, timeoutMs);
+  if (!response.success) return response;
+  if (!isRecord(response.body) || !isRecord(response.body.quotas)) {
+    const message = isRecord(response.body) ? safeMessage(response.body.message) : null;
+    return {
+      success: false,
+      error: message ?? "Invalid nineRouter usage response",
+      ...(message ? { safeDisplayMessage: true as const } : {}),
+    };
+  }
+  const keys = new Map<string, string>(),
+    collisions = new Set<string>();
+  for (const rawKey of Object.keys(response.body.quotas)) {
+    const key = safeQuotaKey(rawKey);
+    if (!key) continue;
+    const prior = keys.get(key);
+    if (prior !== undefined && prior !== rawKey) collisions.add(key);
+    keys.set(key, rawKey);
+  }
+  const windows: NineRouterUsageWindow[] = [];
+  for (const [key, rawKey] of keys) {
+    if (collisions.has(key)) continue;
+    const quota = parseQuota(key, response.body.quotas[rawKey]);
+    if (quota) windows.push(quota);
+  }
+  const errors = collisions.size
+    ? [{ error: "Ambiguous nineRouter quota key after normalization" }]
+    : [];
+  if (windows.length || errors.length)
+    return { success: true, windows, ...(errors.length ? { errors } : {}) };
+  const message = safeMessage(response.body.message);
+  return {
+    success: false,
+    error: message ?? "Invalid nineRouter usage response",
+    ...(message ? { safeDisplayMessage: true as const } : {}),
+  };
+}

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -70,6 +70,16 @@ const PROVIDER_CATALOG_SOURCE = {
       quota: "remote_api",
     },
   },
+  "9router": {
+    label: "nineRouter",
+    runtimeIds: ["9router"],
+    synonyms: [],
+    shape: {
+      autoSetup: "manual_env_config",
+      authentication: "external_api_key",
+      quota: "remote_api",
+    },
+  },
   openrouter: {
     label: "OpenRouter",
     runtimeIds: ["openrouter"],

--- a/src/lib/quota-dialog-commands.ts
+++ b/src/lib/quota-dialog-commands.ts
@@ -582,6 +582,7 @@ export async function buildStatusReportData(params: {
     settingSources: params.runtime.configMeta.settingSources,
     configIssues: params.runtime.configMeta.configIssues,
     enabledProviders: runtimeConfig.enabledProviders,
+    nineRouter: runtimeConfig.nineRouter,
     googleModels: runtimeConfig.googleModels,
     anthropicBinaryPath: runtimeConfig.anthropicBinaryPath,
     cursorPlan: runtimeConfig.cursorPlan,

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -172,6 +172,9 @@ export async function resolveQuotaRenderSelection(params: {
     currentProviderID = request.sessionMeta.providerID;
   }
 
+  if (!config.enabled) return null;
+
+  const allProviders = params.providers ?? getProviders();
   const ctx = createQuotaProviderRuntimeContext({
     client,
     config,
@@ -184,10 +187,8 @@ export async function resolveQuotaRenderSelection(params: {
         providerID: currentProviderID,
       },
     },
+    providers: allProviders,
   });
-  if (!config.enabled) return null;
-
-  const allProviders = params.providers ?? getProviders();
   const isAutoMode = config.enabledProviders === "auto";
   const providers = isAutoMode
     ? allProviders
@@ -311,6 +312,7 @@ export async function collectQuotaStatusLiveProbes(params: {
         providerID: currentProviderID,
       },
     },
+    providers: params.providers,
   });
 
   const resultsByProviderId = new Map<string, Promise<QuotaProviderResult>>();

--- a/src/lib/quota-runtime-context.ts
+++ b/src/lib/quota-runtime-context.ts
@@ -68,6 +68,8 @@ export async function resolveQuotaRuntimeContext(
     (await loadConfig(params.client, configMeta, {
       configRootDir: roots.configRoot,
     }));
+  const providers = params.providers ?? getProviders();
+  const resolveRuntimeProviderIds = createRuntimeProviderIdResolver(params.client);
   let sessionMeta = params.sessionMeta;
   if (
     !sessionMeta &&
@@ -85,6 +87,8 @@ export async function resolveQuotaRuntimeContext(
       client: params.client,
       config,
       session: { sessionMeta },
+      providers,
+      resolveRuntimeProviderIds,
     });
   }
 
@@ -93,8 +97,8 @@ export async function resolveQuotaRuntimeContext(
     roots,
     config,
     configMeta,
-    providers: params.providers ?? getProviders(),
-    resolveRuntimeProviderIds: createRuntimeProviderIdResolver(params.client),
+    providers,
+    resolveRuntimeProviderIds,
     session: {
       sessionID: params.sessionID,
       sessionMeta,
@@ -118,12 +122,10 @@ export function createQuotaProviderRuntimeContext(runtime: {
   session: QuotaRuntimeContext["session"];
   resolveRuntimeProviderIds: RuntimeProviderIdResolver;
   configMeta?: Pick<LoadConfigMeta, "settingSources">;
+  providers?: QuotaProvider[];
   configureTelemetry?: boolean;
 }): QuotaProviderContext {
-  const telemetryToken =
-    runtime.configureTelemetry === false ? undefined : configureRuntimeTelemetry(runtime);
-
-  return {
+  const context: QuotaProviderContext = {
     client: runtime.client,
     resolveRuntimeProviderIds: runtime.resolveRuntimeProviderIds,
     config: {
@@ -141,18 +143,43 @@ export function createQuotaProviderRuntimeContext(runtime: {
       enabledProviders:
         runtime.config.enabledProviders === "auto" ? "auto" : [...runtime.config.enabledProviders],
       quotaProviders: cloneQuotaProviders(runtime.config.quotaProviders),
-      telemetryToken,
+      nineRouter: {
+        ...runtime.config.nineRouter,
+        providers: [...runtime.config.nineRouter.providers],
+      },
       currentModel: runtime.session.sessionMeta?.modelID,
       currentProviderID: runtime.session.sessionMeta?.providerID,
     },
   };
+  if (runtime.configureTelemetry !== false) {
+    context.config.telemetryToken = configureRuntimeTelemetry({
+      ...runtime,
+      providers: runtime.providers ?? getProviders(),
+      context,
+    });
+  }
+  return context;
 }
 
 function configureRuntimeTelemetry(runtime: {
   client: QuotaRuntimeClient;
   config: QuotaToastConfig;
   session: QuotaRuntimeContext["session"];
+  providers: QuotaProvider[];
+  resolveRuntimeProviderIds: RuntimeProviderIdResolver;
+  context?: QuotaProviderContext;
 }) {
+  const context =
+    runtime.context ??
+    createQuotaProviderRuntimeContext({
+      ...runtime,
+      configureTelemetry: false,
+    });
+  const enabledProviders = runtime.providers.filter(
+    (provider) =>
+      runtime.config.enabledProviders === "auto" ||
+      runtime.config.enabledProviders.includes(provider.id),
+  );
   const telemetryEnabled = runtime.config.enabled && runtime.config.telemetry?.enabled === true;
   const telemetryIdentity = createHash("sha256")
     .update(
@@ -172,6 +199,7 @@ function configureRuntimeTelemetry(runtime: {
         runtime.config.opencodeGoWindows,
         runtime.config.opencodeMonthlyLimit,
         runtime.config.onlyCurrentModel,
+        enabledProviders.map((provider) => [provider.id, provider.cacheIdentity?.(context) ?? ""]),
         runtime.session.sessionMeta?.providerID,
         runtime.session.sessionMeta?.modelID,
       ]),

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -63,7 +63,10 @@ export function cloneQuotaProviderResult(result: QuotaProviderResult): QuotaProv
 export function buildQuotaProviderStateCacheKey(
   providerId: string,
   ctx: QuotaProviderContext,
-  options: { runtimeEligibleQuotaProviders?: readonly QuotaProviderDefinition[] } = {},
+  options: {
+    runtimeEligibleQuotaProviders?: readonly QuotaProviderDefinition[];
+    providerCacheIdentity?: string;
+  } = {},
 ): string {
   const googleModels = ctx.config.googleModels.join(",");
   const cursorPlan = ctx.config.cursorPlan;
@@ -91,7 +94,10 @@ export function buildQuotaProviderStateCacheKey(
       ])}`
     : "";
 
-  return `${providerId}${quotaProvidersIdentity}${runtimeEligibleIdentity}|anthropicBinaryPath=${anthropicBinaryPath}|googleModels=${googleModels}|cursorPlan=${cursorPlan}|cursorIncludedApiUsd=${cursorIncludedApiUsd}|cursorBillingCycleStartDay=${cursorBillingCycleStartDay}|opencodeGoWindows=${opencodeGoWindows}|onlyCurrentModel=${onlyCurrentModel}|currentModel=${currentModel}|currentProviderID=${currentProviderID}`;
+  const providerCacheIdentity = options.providerCacheIdentity
+    ? `|providerCacheIdentity=${options.providerCacheIdentity}`
+    : "";
+  return `${providerId}${quotaProvidersIdentity}${runtimeEligibleIdentity}${providerCacheIdentity}|anthropicBinaryPath=${anthropicBinaryPath}|googleModels=${googleModels}|cursorPlan=${cursorPlan}|cursorIncludedApiUsd=${cursorIncludedApiUsd}|cursorBillingCycleStartDay=${cursorBillingCycleStartDay}|opencodeGoWindows=${opencodeGoWindows}|onlyCurrentModel=${onlyCurrentModel}|currentModel=${currentModel}|currentProviderID=${currentProviderID}`;
 }
 
 function getQuotaProviderCacheDir(): string {
@@ -587,8 +593,10 @@ export async function fetchQuotaProviderResult(params: {
     provider.id === QUOTA_PROVIDERS_AGGREGATE_ID &&
     runtimeEligibleQuotaProviders?.some((definition) => definition.mode === "local-estimate") ===
       true;
+  const providerCacheIdentity = provider.cacheIdentity?.(ctx);
   const key = buildQuotaProviderStateCacheKey(provider.id, ctx, {
     runtimeEligibleQuotaProviders,
+    ...(providerCacheIdentity ? { providerCacheIdentity } : {}),
   });
   const now = Date.now();
   const packageVersion = await getQuotaProviderCachePackageVersion();
@@ -704,8 +712,10 @@ export async function readCachedProviderResult(params: {
   if (runtimeEligibleQuotaProviders === null) {
     return { hit: false };
   }
+  const providerCacheIdentity = params.provider.cacheIdentity?.(params.ctx);
   const key = buildQuotaProviderStateCacheKey(params.provider.id, params.ctx, {
     runtimeEligibleQuotaProviders,
+    ...(providerCacheIdentity ? { providerCacheIdentity } : {}),
   });
   const now = Date.now();
 

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -1,6 +1,7 @@
 import { stat } from "fs/promises";
 import { getProviders } from "../providers/registry.js";
 import {
+  canonicalizeNineRouterProviders,
   type LoadConfigIssue,
   QUOTA_TOAST_SETTING_SOURCE_KEYS,
   type QuotaToastSettingSources,
@@ -30,6 +31,7 @@ import {
   readPricingRefreshState,
   hasProvider as snapshotHasProvider,
 } from "./modelsdev-pricing.js";
+import { resolveNineRouterConfig } from "./nine-router.js";
 import { getAuthPath, getAuthPaths } from "./opencode-auth.js";
 import { getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
 import {
@@ -46,6 +48,7 @@ import { totalTokenBuckets } from "./token-buckets.js";
 import type {
   CursorQuotaPlan,
   MaintainerAnnouncementsConfig,
+  NineRouterConfig,
   OpenCodeGoWindowKey,
   PricingSnapshotSource,
 } from "./types.js";
@@ -667,6 +670,7 @@ export async function buildQuotaStatusReport(params: {
     quotaPluginConfigPaths: string[];
   };
   enabledProviders: string[] | "auto";
+  nineRouter: NineRouterConfig;
   googleModels: readonly string[];
   anthropicBinaryPath?: string;
   cursorPlan: CursorQuotaPlan;
@@ -827,6 +831,48 @@ export async function buildQuotaStatusReport(params: {
     ]),
   );
   sections.push(createKvSection("paths", "paths:", pathsRows));
+
+  const nineRouterRootConfigured = Boolean(process.env.OPENCODE_NINEROUTER_URL?.trim());
+  const nineRouterKeyConfigured = Boolean(process.env.OPENCODE_NINEROUTER_API_KEY?.trim());
+  const nineRouterConfig = resolveNineRouterConfig();
+  const nineRouterRootValidation = resolveNineRouterConfig({
+    ...process.env,
+    OPENCODE_NINEROUTER_API_KEY: "status",
+  });
+  const nineRouterConfiguration = !nineRouterRootConfigured
+    ? "missing_root"
+    : !nineRouterKeyConfigured
+      ? "missing_api_key"
+      : nineRouterConfig.success
+        ? "configured"
+        : "invalid_root";
+  const nineRouterRows: ReportKvRow[] = [
+    { key: "management_root", value: nineRouterRootConfigured ? "configured" : "missing" },
+    { key: "api_key", value: nineRouterKeyConfigured ? "configured" : "missing" },
+    { key: "configuration", value: nineRouterConfiguration },
+    {
+      key: "selected_providers",
+      value: canonicalizeNineRouterProviders(params.nineRouter.providers).join(",") || "(all)",
+    },
+    { key: "display_mode", value: params.nineRouter.display },
+    {
+      key: "config_provenance",
+      value: `providers=${params.settingSources?.["nineRouter.providers"] ?? "(default)"} display=${params.settingSources?.["nineRouter.display"] ?? "(default)"}`,
+    },
+    { key: "root_valid", value: nineRouterRootValidation.success ? "true" : "false" },
+    { key: "fixed_endpoints", value: "provider_list | connection_usage" },
+    {
+      key: "probe_outcome",
+      value: getLiveProbeState(findProviderLiveProbe("9router", params.providerLiveProbes)),
+    },
+  ];
+  if (!nineRouterConfig.success) {
+    nineRouterRows.push({
+      key: "setup",
+      value: "set OPENCODE_NINEROUTER_URL and OPENCODE_NINEROUTER_API_KEY",
+    });
+  }
+  sections.push(createKvSection("9router", "9router:", nineRouterRows));
 
   for (const [id, providerId] of [
     ["openai", "openai"],

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,12 @@ export type PricingSnapshotSource = "auto" | "bundled" | "runtime";
 export type PercentDisplayMode = "remaining" | "used";
 export type SessionTokenScope = "current" | "tree";
 export type OpenCodeGoWindowKey = "rolling" | "weekly" | "monthly";
+export type NineRouterDisplay = "perConnection" | "unified";
+
+export interface NineRouterConfig {
+  providers: string[];
+  display: NineRouterDisplay;
+}
 
 export interface PricingSnapshotConfig {
   source: PricingSnapshotSource;
@@ -181,6 +187,8 @@ export interface QuotaToastConfig {
   /** Opt-in quota metrics through the host's global OpenTelemetry MeterProvider. */
   telemetry: QuotaTelemetryConfig;
 
+  nineRouter: NineRouterConfig;
+
   /** Responsive toast layout breakpoints (not used by the fixed-width TUI sidebar). */
   layout: {
     /** Default max width target for toast formatting */
@@ -249,6 +257,10 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
   },
   telemetry: {
     enabled: false,
+  },
+  nineRouter: {
+    providers: [],
+    display: "perConnection",
   },
   layout: {
     maxWidth: 50,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@
  * Supports GitHub Copilot and Google (via opencode-antigravity-auth).
  */
 
+import { createHash } from "node:crypto";
 import { isMainThread } from "node:worker_threads";
 import type { Plugin } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
@@ -17,7 +18,11 @@ import {
 import { getOrFetchWithCacheControl } from "./lib/cache.js";
 import { handled } from "./lib/command-handled.js";
 import { shouldRegisterServerSlashCommands } from "./lib/command-surfaces.js";
-import { createLoadConfigMeta, type LoadConfigMeta } from "./lib/config.js";
+import {
+  createLoadConfigMeta,
+  type LoadConfigMeta,
+  serializeNineRouterProviderSelection,
+} from "./lib/config.js";
 import { findGitWorktreeRoot, getEffectiveConfigRoot } from "./lib/config-file-utils.js";
 import { isCursorModelId, isCursorProviderId } from "./lib/cursor-pricing.js";
 import { sanitizeDisplayText } from "./lib/display-sanitize.js";
@@ -32,6 +37,7 @@ import {
   setPricingSnapshotAutoRefresh,
   setPricingSnapshotSelection,
 } from "./lib/modelsdev-pricing.js";
+import { resolveNineRouterConfig } from "./lib/nine-router.js";
 import { reconcileDetectedProvidersInGlobalConfig } from "./lib/opencode-config-providers.js";
 import {
   buildQuotaDialogCommandOutput,
@@ -737,6 +743,10 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
     const enabledProviders =
       config.enabledProviders === "auto" ? "auto" : config.enabledProviders.join(",");
     const googleModels = config.googleModels.join(",");
+    const nineRouter = resolveNineRouterConfig();
+    const nineRouterRoot = nineRouter.success ? nineRouter.root : "";
+    const nineRouterKey = process.env.OPENCODE_NINEROUTER_API_KEY?.trim() ?? "";
+    const hash = (value: string) => createHash("sha256").update(value).digest("hex");
     const currentModel =
       config.onlyCurrentModel && params.sessionID ? (params.sessionMeta?.modelID ?? "") : "";
     const currentProviderID =
@@ -757,6 +767,10 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
       `cursorPlan=${config.cursorPlan}`,
       `cursorIncludedApiUsd=${config.cursorIncludedApiUsd ?? ""}`,
       `cursorBillingCycleStartDay=${config.cursorBillingCycleStartDay ?? ""}`,
+      `nineRouterRootSha256=${hash(`9router:root:${nineRouterRoot}`)}`,
+      `nineRouterKeySha256=${hash(`9router:key:${nineRouterKey}`)}`,
+      `nineRouterProvidersSha256=${hash(`9router:providers:${serializeNineRouterProviderSelection(config.nineRouter.providers)}`)}`,
+      `nineRouterDisplaySha256=${hash(`9router:display:${config.nineRouter.display.toLowerCase()}`)}`,
     ].join("|");
   }
 

--- a/src/providers/nine-router.ts
+++ b/src/providers/nine-router.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+import {
+  canonicalizeNineRouterProviders,
+  serializeNineRouterProviderSelection,
+} from "../lib/config.js";
+import type {
+  QuotaProvider,
+  QuotaProviderContext,
+  QuotaProviderResult,
+  QuotaToastEntry,
+} from "../lib/entries.js";
+import {
+  fetchNineRouterAccounts,
+  fetchNineRouterUsage,
+  type NineRouterAccount,
+  type NineRouterUsageWindow,
+  resolveNineRouterConfig,
+} from "../lib/nine-router.js";
+import { modelProviderMatchesRuntimeId } from "../lib/provider-model-matching.js";
+import { attemptedResult, notAttemptedResult } from "./result-helpers.js";
+
+const ACCOUNTING = {
+  resultType: "rate_limit",
+  acquisitionMethod: "remote_api",
+  ownership: "maintained",
+  authority: "provider_reported",
+} as const;
+const USAGE_CONCURRENCY = 4;
+const UUID_LABEL = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function accountLabel(account: NineRouterAccount, index: number): string {
+  for (const value of [account.displayName, account.name]) {
+    const label = value?.trim();
+    if (
+      label &&
+      !label.includes("@") &&
+      !UUID_LABEL.test(label) &&
+      label.toLowerCase() !== account.id.toLowerCase()
+    ) {
+      return label;
+    }
+  }
+  if (account.email?.includes("@")) {
+    const [local, domain] = account.email.split("@", 2);
+    return `${local.slice(0, 3)}..${domain}`;
+  }
+  return `Account ${index + 1}`;
+}
+
+function accountProvider(account: NineRouterAccount, providers: readonly string[]): string | null {
+  return account.provider || (providers.length === 1 ? (providers[0] ?? null) : null);
+}
+
+async function mapAtMostFour<T, R>(
+  values: readonly T[],
+  mapper: (value: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < values.length) {
+      const index = nextIndex++;
+      const value = values[index];
+      if (value === undefined) continue;
+      results[index] = await mapper(value, index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(USAGE_CONCURRENCY, values.length) }, worker));
+  return results;
+}
+
+export const nineRouterProvider: QuotaProvider = {
+  id: "9router",
+
+  async isAvailable(_ctx: QuotaProviderContext): Promise<boolean> {
+    return resolveNineRouterConfig().success;
+  },
+
+  cacheIdentity(ctx: QuotaProviderContext): string {
+    const resolved = resolveNineRouterConfig();
+    const key = process.env.OPENCODE_NINEROUTER_API_KEY?.trim();
+    if (!resolved.success || !key) return "";
+    const providers = serializeNineRouterProviderSelection(ctx.config.nineRouter.providers);
+    const display = ctx.config.nineRouter.display.trim().toLowerCase();
+    return `root_sha256=${digest(`9router:root:${resolved.root}`)};key_sha256=${digest(`9router:key:${key}`)};providers_sha256=${digest(`9router:providers:${providers}`)};display_sha256=${digest(`9router:display:${display}`)}`;
+  },
+
+  matchesCurrentModel(model: string): boolean {
+    return modelProviderMatchesRuntimeId(model, "9router");
+  },
+
+  async fetch(ctx: QuotaProviderContext): Promise<QuotaProviderResult> {
+    const config = resolveNineRouterConfig();
+    if (!config.success) return notAttemptedResult();
+    const selection = canonicalizeNineRouterProviders(ctx.config.nineRouter.providers);
+    const providers = selection.filter((provider) => provider !== "all");
+    if (selection.length > 0 && providers.length === 0) return attemptedResult([], []);
+
+    let accountResults: Array<Awaited<ReturnType<typeof fetchNineRouterAccounts>> | null>;
+    try {
+      accountResults =
+        providers.length === 0
+          ? [await fetchNineRouterAccounts(config)]
+          : await mapAtMostFour(providers, async (provider) => {
+              try {
+                return await fetchNineRouterAccounts(config, provider);
+              } catch {
+                return null;
+              }
+            });
+    } catch {
+      return attemptedResult([], []);
+    }
+
+    const accountIds = new Set<string>();
+    const accounts: NineRouterAccount[] = [];
+    for (const accountResult of accountResults) {
+      if (!accountResult?.success) continue;
+      for (const account of accountResult.accounts) {
+        if (accountIds.has(account.id)) continue;
+        accountIds.add(account.id);
+        accounts.push(account);
+      }
+    }
+
+    const outcomes = await mapAtMostFour(accounts, async (account, index) => {
+      try {
+        return {
+          account,
+          index,
+          usage: await fetchNineRouterUsage(config, account.id, ctx.config.requestTimeoutMs),
+        };
+      } catch {
+        return { account, index, usage: { success: false as const, error: "unavailable" } };
+      }
+    });
+    const entries: QuotaToastEntry[] = [];
+    const labels = new Map<string, number>();
+    const windowsByKey = new Map<string, NineRouterUsageWindow[]>();
+
+    for (const outcome of outcomes) {
+      if (!outcome.usage.success || outcome.usage.windows.length === 0) continue;
+      const provider = accountProvider(outcome.account, providers);
+      if (!provider) continue;
+      const baseLabel = accountLabel(outcome.account, outcome.index);
+      const labelKey = `${provider}\u0000${baseLabel}`;
+      const count = (labels.get(labelKey) ?? 0) + 1;
+      labels.set(labelKey, count);
+      const displayLabel = count === 1 ? baseLabel : `${baseLabel} (${count})`;
+
+      if (ctx.config.nineRouter.display === "unified") {
+        for (const window of outcome.usage.windows) {
+          const key = `${provider}\u0000${window.kind}`;
+          const contributors = windowsByKey.get(key) ?? [];
+          contributors.push(window);
+          windowsByKey.set(key, contributors);
+        }
+        continue;
+      }
+
+      const sourceId = digest(`9router:connection:${provider}:${outcome.account.id}`);
+      for (const window of outcome.usage.windows) {
+        entries.push({
+          accounting: { ...ACCOUNTING, sourceId },
+          name: `${provider} / ${displayLabel} ${window.kind}`,
+          group: `${provider} / ${displayLabel}`,
+          label: `${window.kind}:`,
+          percentRemaining: window.percentRemaining,
+          resetTimeIso: window.resetTimeIso,
+        });
+      }
+    }
+
+    for (const [key, contributors] of windowsByKey) {
+      const [provider, windowKind] = key.split("\u0000", 2);
+      if (!provider || !windowKind) continue;
+      const resets = contributors
+        .map((contributor) => contributor.resetTimeIso)
+        .filter((resetTimeIso): resetTimeIso is string => resetTimeIso !== undefined)
+        .sort();
+      entries.push({
+        accounting: { ...ACCOUNTING, sourceId: digest(`9router:unified:${provider}`) },
+        name: `nineRouter (${provider}) ${windowKind}`,
+        group: `nineRouter (${provider})`,
+        label: `${windowKind}:`,
+        percentRemaining:
+          contributors.reduce((sum, contributor) => sum + contributor.percentRemaining, 0) /
+          contributors.length,
+        ...(resets[0] ? { resetTimeIso: resets[0] } : {}),
+      });
+    }
+    return attemptedResult(entries, []);
+  },
+};

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -22,6 +22,7 @@ import {
   minimaxCodingPlanProvider,
 } from "./minimax-coding-plan.js";
 import { nanoGptProvider } from "./nanogpt.js";
+import { nineRouterProvider } from "./nine-router.js";
 import { ollamaCloudProvider } from "./ollama-cloud.js";
 import { openaiProvider } from "./openai.js";
 import { opencodeGoProvider } from "./opencode-go.js";
@@ -40,6 +41,7 @@ export function getProviders(): QuotaProvider[] {
     anthropicProvider,
     copilotProvider,
     openaiProvider,
+    nineRouterProvider,
     openRouterProvider,
     kiloProvider,
     cursorProvider,

--- a/tests/helpers/plugin-test-harness.ts
+++ b/tests/helpers/plugin-test-harness.ts
@@ -101,6 +101,30 @@ export function createPluginToolMockModule() {
 export function createConfigModuleMock(loadConfig: MockFunction) {
   return {
     loadConfig,
+    serializeNineRouterProviderSelection: (providers: readonly string[]) => {
+      const canonical = new Set<string>();
+      let all = false;
+      for (const provider of providers) {
+        const normalized = provider.trim().toLowerCase();
+        if (normalized === "all") {
+          all = true;
+          continue;
+        }
+        if (
+          !normalized ||
+          Array.from(normalized).some((character) => {
+            const codePoint = character.codePointAt(0) ?? 0;
+            return codePoint <= 31 || (codePoint >= 127 && codePoint <= 159);
+          }) ||
+          Array.from(normalized).length > 128 ||
+          canonical.size === 32
+        ) {
+          continue;
+        }
+        canonical.add(normalized);
+      }
+      return JSON.stringify(canonical.size > 0 ? [...canonical].sort() : all ? ["all"] : []);
+    },
     createLoadConfigMeta: () => ({
       source: "defaults",
       paths: [],

--- a/tests/helpers/provider-assertions.ts
+++ b/tests/helpers/provider-assertions.ts
@@ -63,6 +63,14 @@ export const PROVIDER_ACCOUNTING_LEDGER: Record<string, Array<QuotaToastEntry["a
       authority: "provider_reported",
     },
   ],
+  "9router": [
+    {
+      resultType: "rate_limit",
+      acquisitionMethod: "remote_api",
+      ownership: "maintained",
+      authority: "provider_reported",
+    },
+  ],
   openrouter: [
     {
       resultType: "budget",

--- a/tests/helpers/quota-status-test-harness.ts
+++ b/tests/helpers/quota-status-test-harness.ts
@@ -94,6 +94,7 @@ export function makeQuotaStatusReportParams(
     configSource: "test",
     configPaths: [],
     enabledProviders,
+    nineRouter: { providers: [], display: "perConnection" },
     googleModels: ["CLAUDE"],
     cursorPlan: "none",
     pricingSnapshotSource: "auto",

--- a/tests/lib.config.integration.test.ts
+++ b/tests/lib.config.integration.test.ts
@@ -143,6 +143,46 @@ describe("loadConfig integration runtime-path resolution", () => {
     expect(meta.workspaceConfigPaths.some((path) => path.includes("quota-toast.jsonc"))).toBe(true);
   });
 
+  it("overrides lower nineRouter providers with an explicit all selection", async () => {
+    const env = process.env as NodeJS.ProcessEnv;
+    const globalDir = getOpencodeRuntimeDirCandidates({ env, homeDir: tempDir }).configDirs[0]!;
+    writeQuotaToastConfig(globalDir, { nineRouter: { providers: [" KIRO ", "codex"] } });
+    writeQuotaSidecarConfig(workspaceDir, { nineRouter: { providers: [], display: "unified" } });
+
+    const meta = createLoadConfigMeta();
+    const config = await loadConfig(undefined, meta, { configRootDir: workspaceDir });
+
+    expect(config.nineRouter).toEqual({ providers: [], display: "unified" });
+    expect(meta.settingSources["nineRouter.providers"]).toBe(
+      quotaSidecarConfigSource(workspaceDir),
+    );
+    expect(meta.settingSources["nineRouter.display"]).toBe(quotaSidecarConfigSource(workspaceDir));
+    expect(meta.networkSettingSources["nineRouter.providers"]).toBe(
+      quotaSidecarConfigSource(workspaceDir),
+    );
+    expect(meta.networkSettingSources["nineRouter.display"]).toBe(
+      quotaSidecarConfigSource(workspaceDir),
+    );
+  });
+
+  it("merges nineRouter providers and display across global and workspace sources", async () => {
+    const env = process.env as NodeJS.ProcessEnv;
+    const globalDir = getOpencodeRuntimeDirCandidates({ env, homeDir: tempDir }).configDirs[0]!;
+    writeQuotaSidecarConfig(globalDir, { nineRouter: { providers: [" KIRO ", "codex"] } });
+    writeQuotaToastConfig(workspaceDir, { nineRouter: { display: "unified" } });
+
+    const meta = createLoadConfigMeta();
+    const config = await loadConfig(undefined, meta, { configRootDir: workspaceDir });
+
+    expect(config.nineRouter).toEqual({ providers: ["codex", "kiro"], display: "unified" });
+    expect(meta.settingSources["nineRouter.providers"]).toBe(quotaSidecarConfigSource(globalDir));
+    expect(meta.settingSources["nineRouter.display"]).toBe(quotaConfigSource(workspaceDir));
+    expect(meta.networkSettingSources["nineRouter.providers"]).toBe(
+      quotaSidecarConfigSource(globalDir),
+    );
+    expect(meta.networkSettingSources["nineRouter.display"]).toBe(quotaConfigSource(workspaceDir));
+  });
+
   it("loads a custom provider after init creates a manual-mode JSONC sidecar", async () => {
     const env = process.env as NodeJS.ProcessEnv;
     const configDir = getOpencodeRuntimeDirCandidates({ env, homeDir: tempDir }).configDirs[0]!;

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -21,7 +21,12 @@ vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirCandidates: () => runtimeDirs.value,
 }));
 
-import { createLoadConfigMeta, loadConfig } from "../src/lib/config.js";
+import {
+  canonicalizeNineRouterProviders,
+  createLoadConfigMeta,
+  loadConfig,
+  serializeNineRouterProviderSelection,
+} from "../src/lib/config.js";
 import { DEFAULT_CONFIG } from "../src/lib/types.js";
 
 describe("loadConfig", () => {
@@ -120,6 +125,90 @@ describe("loadConfig", () => {
         message: 'expected "current" or "tree"',
       },
     ]);
+  });
+
+  it("uses plural nineRouter provider selections and ignores the singular legacy spelling", async () => {
+    const configured = await loadSdkConfig({
+      nineRouter: { providers: [" Codex ", "codex", "kiro"], display: "unified" },
+    });
+    expect(configured.config.nineRouter).toEqual({
+      providers: ["codex", "kiro"],
+      display: "unified",
+    });
+    expect(configured.meta.settingSources).toEqual({
+      "nineRouter.providers": "client.config.get",
+      "nineRouter.display": "client.config.get",
+    });
+    const singular = await loadSdkConfig({ nineRouter: { provider: "codex" } });
+    expect(singular.config.nineRouter).toEqual(DEFAULT_CONFIG.nineRouter);
+  });
+
+  it("reports malformed nineRouter fields without replacing valid lower-layer fields", async () => {
+    const malformed = await loadSdkConfig({ nineRouter: [] });
+    expect(malformed.meta.configIssues).toEqual([
+      {
+        path: "client.config.get",
+        key: "nineRouter",
+        message: "expected an object",
+      },
+    ]);
+
+    const sidecarPath = join(isolatedCwd, "opencode-quota", "quota-toast.json");
+    const globalDir = join(isolatedCwd, "global");
+    const globalConfigPath = join(globalDir, "opencode.json");
+    runtimeDirs.value.configDirs = [globalDir];
+    mkdirSync(globalDir, { recursive: true });
+    mkdirSync(join(isolatedCwd, "opencode-quota"), { recursive: true });
+    writeFileSync(
+      globalConfigPath,
+      JSON.stringify({
+        experimental: { quotaToast: { nineRouter: { providers: ["kiro"], display: "unified" } } },
+      }),
+      "utf8",
+    );
+    writeFileSync(
+      sidecarPath,
+      JSON.stringify({ nineRouter: { providers: "kiro", display: "perConnection" } }),
+      "utf8",
+    );
+
+    const meta = createLoadConfigMeta();
+    const config = await loadConfig(undefined, meta, { cwd: isolatedCwd });
+
+    expect(config.nineRouter).toEqual({ providers: ["kiro"], display: "perConnection" });
+    expect(meta.settingSources).toMatchObject({
+      "nineRouter.providers": `${globalConfigPath} (experimental.quotaToast)`,
+      "nineRouter.display": quotaSidecarConfigSource(isolatedCwd),
+    });
+    expect(meta.configIssues).toContainEqual({
+      path: quotaSidecarConfigSource(isolatedCwd),
+      key: "nineRouter.providers",
+      message: "expected an array of provider ids",
+    });
+  });
+
+  it("canonicalizes bounded plural nineRouter selections for stable identities", () => {
+    const overlongProvider = "a".repeat(129);
+    const providers = canonicalizeNineRouterProviders([
+      "codex\nunsafe",
+      overlongProvider,
+      " KIRO ",
+      "codex",
+      "kiro",
+      ...Array.from({ length: 40 }, (_, index) => `provider-${index.toString().padStart(2, "0")}`),
+    ]);
+
+    expect(providers).toEqual([
+      "codex",
+      "kiro",
+      ...Array.from({ length: 30 }, (_, index) => `provider-${index.toString().padStart(2, "0")}`),
+    ]);
+    expect(serializeNineRouterProviderSelection(["kiro", "codex", "KIRO"])).toBe(
+      '["codex","kiro"]',
+    );
+    expect(canonicalizeNineRouterProviders(["all", "codex"])).toEqual(["codex"]);
+    expect(canonicalizeNineRouterProviders([" ALL "])).toEqual(["all"]);
+    expect(serializeNineRouterProviderSelection([])).toBe("[]");
   });
 
   it("defaults maintainer announcements config and accepts validated nested overrides", async () => {
@@ -343,6 +432,8 @@ describe("loadConfig", () => {
     first.tuiCompactStatus.maxWidth = 1;
     first.maintainerAnnouncements.enabled = false;
     first.maintainerAnnouncements.home = false;
+    first.nineRouter.providers.push("kiro");
+    first.nineRouter.display = "unified";
 
     const second = await loadConfig(undefined, undefined, { cwd: isolatedCwd });
     expect(second.tuiSidebarPanel).toEqual(DEFAULT_CONFIG.tuiSidebarPanel);
@@ -360,6 +451,9 @@ describe("loadConfig", () => {
       enabled: true,
       home: true,
     });
+    expect(second.nineRouter).toEqual(DEFAULT_CONFIG.nineRouter);
+    expect(second.nineRouter).not.toBe(DEFAULT_CONFIG.nineRouter);
+    expect(DEFAULT_CONFIG.nineRouter).toEqual({ providers: [], display: "perConnection" });
   });
 
   it("defaults requestTimeoutMs to 5000 and accepts positive finite overrides", async () => {

--- a/tests/lib.nine-router.test.ts
+++ b/tests/lib.nine-router.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchNineRouterAccounts,
+  fetchNineRouterUsage,
+  NINE_ROUTER_MAX_BODY_BYTES,
+  resolveNineRouterConfig,
+} from "../src/lib/nine-router.js";
+
+const ROOT = "https://router.example/management/";
+const KEY = "test-9router-key";
+const ID = "A0B1C2D3-E4F5-4A6B-8C9D-0E1F2A3B4C5D";
+
+function json(body: unknown, init: ResponseInit = {}): Response {
+  const headers = new Headers(init.headers);
+  headers.set("content-type", headers.get("content-type") ?? "application/json");
+  return new Response(JSON.stringify(body), { ...init, headers });
+}
+
+function env(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  return { OPENCODE_NINEROUTER_URL: ROOT, OPENCODE_NINEROUTER_API_KEY: KEY, ...overrides };
+}
+
+function account(id = ID, provider = "codex"): Record<string, unknown> {
+  return {
+    id,
+    provider,
+    name: "Codex account",
+    displayName: "Codex account",
+    email: "person@example.test",
+    isActive: true,
+  };
+}
+
+function listing(
+  connections: readonly Record<string, unknown>[],
+  pagination: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    connections,
+    pagination: {
+      page: 1,
+      pageSize: 500,
+      total: connections.length,
+      totalPages: 1,
+      ...pagination,
+    },
+  };
+}
+
+function configured() {
+  const config = resolveNineRouterConfig(env());
+  if (!config.success) throw new Error("valid fixture configuration required");
+  return config;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("nineRouter management client", () => {
+  it("normalizes secure roots and never exposes the API key", () => {
+    const result = resolveNineRouterConfig(env());
+    expect(result).toEqual({ success: true, root: "https://router.example/management" });
+    expect(JSON.stringify(result)).not.toContain(KEY);
+  });
+
+  it.each([
+    ["missing root", env({ OPENCODE_NINEROUTER_URL: undefined })],
+    ["missing key", env({ OPENCODE_NINEROUTER_API_KEY: undefined })],
+    ["credentials", env({ OPENCODE_NINEROUTER_URL: "https://user:pass@router.example" })],
+    ["query", env({ OPENCODE_NINEROUTER_URL: "https://router.example/?key=private" })],
+    ["fragment", env({ OPENCODE_NINEROUTER_URL: "https://router.example/#private" })],
+    ["API endpoint", env({ OPENCODE_NINEROUTER_URL: "https://router.example/v1" })],
+    ["remote HTTP", env({ OPENCODE_NINEROUTER_URL: "http://router.example" })],
+  ])("rejects %s without leaking configuration", (_name, input) => {
+    const result = resolveNineRouterConfig(input);
+    expect(result).toEqual(expect.objectContaining({ success: false }));
+    expect(JSON.stringify(result)).not.toContain(KEY);
+    expect(JSON.stringify(result)).not.toContain("router.example");
+  });
+
+  it.each([
+    "http://localhost:20128",
+    "http://127.0.0.1:20128",
+    "http://[::1]:20128",
+  ])("accepts loopback HTTP root %s", (root) =>
+    expect(resolveNineRouterConfig(env({ OPENCODE_NINEROUTER_URL: root }))).toEqual({
+      success: true,
+      root,
+    }));
+
+  it("requests the encoded account list with Bearer authorization", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(json(listing([account()])));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchNineRouterAccounts(configured(), "codex")).resolves.toMatchObject({
+      success: true,
+      accounts: [{ id: ID, provider: "codex" }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://router.example/management/api/providers/client?provider=codex&accountStatus=active&page=1&pageSize=500&sort=priority",
+      expect.objectContaining({
+        headers: { Authorization: `Bearer ${KEY}`, Accept: "application/json" },
+      }),
+    );
+  });
+
+  it("paginates, retains first connection identifiers, and preserves account provider", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        json(listing([account("first"), account("duplicate")], { total: 501, totalPages: 2 })),
+      )
+      .mockResolvedValueOnce(
+        json(
+          listing([account("duplicate"), account("second", "kiro")], {
+            page: 2,
+            total: 501,
+            totalPages: 2,
+          }),
+        ),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const result = await fetchNineRouterAccounts(configured());
+    expect(result).toMatchObject({
+      success: true,
+      accounts: [{ id: "first" }, { id: "duplicate" }, { id: "second", provider: "kiro" }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["bad totals", listing([account()], { total: 501, totalPages: 1 })],
+    ["bad page size", listing([account()], { pageSize: 499 })],
+    ["excess rows", listing(Array.from({ length: 501 }, (_, index) => account(`id-${index}`)))],
+    ["account cap", listing([account()], { total: 5001, totalPages: 11 })],
+    ["page cap", listing([account()], { total: 5000, totalPages: 11 })],
+  ])("rejects inconsistent pagination for %s before another request", async (_name, body) => {
+    const fetchMock = vi.fn().mockResolvedValue(json(body));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchNineRouterAccounts(configured(), "codex")).resolves.toEqual({
+      success: false,
+      error: "Invalid nineRouter provider response",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("filters unsafe, inactive, and provider-mismatched accounts without leaking data", async () => {
+    const unsafeProvider = "unsafe\u0000provider";
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          json(
+            listing([
+              { ...account("unsafe"), provider: unsafeProvider },
+              { ...account("other"), provider: "other" },
+              { ...account("inactive"), isActive: false },
+              { ...account("good", " KIRO / test ") },
+            ]),
+          ),
+        ),
+    );
+    const result = await fetchNineRouterAccounts(configured(), "kiro / test");
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: true,
+        accounts: [expect.objectContaining({ id: "good", provider: "kiro / test" })],
+        errors: [
+          { error: "Invalid account identifier" },
+          { error: "Invalid account identifier" },
+          { error: "Invalid account identifier" },
+        ],
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain(unsafeProvider);
+  });
+
+  it("keeps complete 500-row pages and percent-encodes opaque usage identifiers", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        json(
+          listing(
+            Array.from({ length: 500 }, (_, index) => account(`id-${index}`)),
+            { total: 500 },
+          ),
+        ),
+      )
+      .mockResolvedValueOnce(json({ quotas: { weekly: { used: 25, total: 100 } } }));
+    vi.stubGlobal("fetch", fetchMock);
+    const accounts = await fetchNineRouterAccounts(configured(), "codex");
+    expect(accounts).toMatchObject({
+      success: true,
+      accounts: expect.arrayContaining([expect.objectContaining({ id: "id-499" })]),
+    });
+    await expect(fetchNineRouterUsage(configured(), "kiro/connection id")).resolves.toMatchObject({
+      success: true,
+      windows: [{ kind: "weekly", percentRemaining: 75 }],
+    });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      expect.stringContaining(encodeURIComponent("kiro/connection id")),
+      expect.anything(),
+    );
+  });
+
+  it("parses trusted percentage variants, caps values, and calculates duration resets", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-03T12:00:00.000Z"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        json({
+          quotas: {
+            unlimited: { unlimited: true },
+            remaining: { remainingPercentage: 125 },
+            usedPercent: { used_percent: 125 },
+            percentUsed: { percent_used: -5 },
+            quantity: { used: 2, total: 8 },
+            duration: { remainingPercentage: 70, reset_after_seconds: 600 },
+          },
+        }),
+      ),
+    );
+    await expect(fetchNineRouterUsage(configured(), ID)).resolves.toEqual({
+      success: true,
+      windows: [
+        { kind: "unlimited", percentRemaining: 100 },
+        { kind: "remaining", percentRemaining: 100 },
+        { kind: "usedPercent", percentRemaining: 0 },
+        { kind: "percentUsed", percentRemaining: 100 },
+        { kind: "quantity", percentRemaining: 75 },
+        { kind: "duration", percentRemaining: 70, resetTimeIso: "2026-08-03T12:10:00.000Z" },
+      ],
+    });
+  });
+
+  it("drops unsafe and normalized-colliding quota keys without returning raw input", async () => {
+    const unsafe = "unsafe\u0000key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        json({
+          quotas: {
+            " exact ": { used_percent: 20 },
+            exact: { used_percent: 30 },
+            [unsafe]: { used_percent: 40 },
+            Good: { used_percent: 60 },
+          },
+        }),
+      ),
+    );
+    const result = await fetchNineRouterUsage(configured(), ID);
+    expect(result).toEqual({
+      success: true,
+      windows: [{ kind: "Good", percentRemaining: 40 }],
+      errors: [{ error: "Ambiguous nineRouter quota key after normalization" }],
+    });
+    expect(JSON.stringify(result)).not.toContain(unsafe);
+  });
+
+  it.each([
+    "private\u0000id",
+    "x".repeat(257),
+    "  ",
+  ])("rejects unsafe usage identifier %j without a request", async (id) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchNineRouterUsage(configured(), id)).resolves.toEqual({
+      success: false,
+      error: "Invalid account identifier",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes message-only errors and rejects malformed responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(json({ message: "ignore\nprivate\u0000body" }))
+        .mockResolvedValueOnce(
+          new Response("{", { headers: { "content-type": "application/json" } }),
+        )
+        .mockResolvedValueOnce(
+          new Response("x".repeat(NINE_ROUTER_MAX_BODY_BYTES + 1), {
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+    );
+    await expect(fetchNineRouterUsage(configured(), ID)).resolves.toEqual({
+      success: false,
+      error: "ignore privatebody",
+      safeDisplayMessage: true,
+    });
+    await expect(fetchNineRouterUsage(configured(), ID)).resolves.toEqual(
+      expect.objectContaining({ success: false }),
+    );
+    await expect(fetchNineRouterUsage(configured(), ID)).resolves.toEqual(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  it.each([
+    401, 403, 429, 503,
+  ])("returns safe HTTP %i failure and bounded retry metadata", async (status) => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(new Response("private", { status, headers: { "Retry-After": "45" } })),
+    );
+    await expect(fetchNineRouterUsage(configured(), ID)).resolves.toEqual({
+      success: false,
+      error: `HTTP ${status}`,
+      retryAfterMs: 45_000,
+    });
+  });
+
+  it("converts aborted requests into bounded timeout failures", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) =>
+            init.signal?.addEventListener("abort", () =>
+              reject(new DOMException("aborted", "AbortError")),
+            ),
+          ),
+      ),
+    );
+    const pending = fetchNineRouterUsage(configured(), ID, 10);
+    await vi.advanceTimersByTimeAsync(11);
+    await expect(pending).resolves.toEqual({ success: false, error: "Request timeout after 0s" });
+  });
+});

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -36,6 +36,12 @@ describe("provider-metadata", () => {
         quota: "remote_api",
       },
       {
+        id: "9router",
+        autoSetup: "manual_env_config",
+        authentication: "external_api_key",
+        quota: "remote_api",
+      },
+      {
         id: "openrouter",
         autoSetup: "yes",
         authentication: "opencode_auth_api_key",

--- a/tests/lib.quota-export.test.ts
+++ b/tests/lib.quota-export.test.ts
@@ -37,7 +37,16 @@ vi.mock("../src/lib/quota-state.js", async () => {
 // --------------- imports ---------------
 
 import { writeJsonAtomic } from "../src/lib/atomic-json.js";
-import { buildQuotaExport, resolveExportPath, writeQuotaExport } from "../src/lib/quota-export.js";
+import { createLoadConfigMeta } from "../src/lib/config.js";
+import {
+  buildQuotaExport,
+  createExportProviderContext,
+  resolveExportPath,
+  writeQuotaExport,
+} from "../src/lib/quota-export.js";
+import { createQuotaProviderRuntimeContext } from "../src/lib/quota-runtime-context.js";
+import { createRuntimeProviderIdResolver } from "../src/lib/runtime-provider-ids.js";
+import { DEFAULT_CONFIG } from "../src/lib/types.js";
 import {
   accountingContractExport,
   accountingContractResult,
@@ -88,6 +97,45 @@ describe("resolveExportPath", () => {
     );
     expect(resolveExportPath("/etc/opencode/export.json")).toBe("/etc/opencode/export.json");
     expect(resolveExportPath("relative/path/quota.json")).toBe("relative/path/quota.json");
+  });
+});
+
+describe("createExportProviderContext", () => {
+  it("retains the writer's immutable nineRouter cache identity without telemetry ownership", () => {
+    const client = createMockContext().client;
+    const config = {
+      ...DEFAULT_CONFIG,
+      onlyCurrentModel: true,
+      nineRouter: { providers: ["kiro"], display: "unified" as const },
+      telemetry: { enabled: true },
+    };
+    const runtime = {
+      client,
+      roots: { workspaceRoot: "/tmp/workspace", configRoot: "/tmp/workspace" },
+      config,
+      configMeta: createLoadConfigMeta(),
+      providers: [],
+      resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
+      session: { sessionID: "session", sessionMeta: { providerID: "9router" } },
+    };
+
+    const context = createExportProviderContext(runtime);
+    const writerContext = createQuotaProviderRuntimeContext(runtime);
+    const provider = {
+      id: "identity-provider",
+      isAvailable: vi.fn(),
+      fetch: vi.fn(),
+      cacheIdentity: (providerContext: typeof context) =>
+        JSON.stringify(providerContext.config.nineRouter),
+    };
+    const writerIdentity = provider.cacheIdentity(writerContext);
+    const exportIdentity = provider.cacheIdentity(context);
+    config.nineRouter.providers.push("codex");
+
+    expect(exportIdentity).toBe(writerIdentity);
+    expect(context.config.nineRouter).toEqual({ providers: ["kiro"], display: "unified" });
+    expect(context.config.onlyCurrentModel).toBe(false);
+    expect(context.config.telemetryToken).toBeUndefined();
   });
 });
 

--- a/tests/lib.quota-runtime-context.test.ts
+++ b/tests/lib.quota-runtime-context.test.ts
@@ -17,6 +17,7 @@ vi.mock("os", async (importOriginal) => {
 
 import { createLoadConfigMeta } from "../src/lib/config.js";
 import { resolveRuntimeContextRoots } from "../src/lib/config-file-utils.js";
+import { resolveQuotaRenderSelection } from "../src/lib/quota-render-data.js";
 import {
   createQuotaProviderRuntimeContext,
   type QuotaRuntimeClient,
@@ -24,7 +25,7 @@ import {
 } from "../src/lib/quota-runtime-context.js";
 import { __resetQuotaTelemetryForTests } from "../src/lib/quota-telemetry.js";
 import { createRuntimeProviderIdResolver } from "../src/lib/runtime-provider-ids.js";
-import { DEFAULT_CONFIG } from "../src/lib/types.js";
+import { DEFAULT_CONFIG, type QuotaToastConfig } from "../src/lib/types.js";
 
 function quotaConfigSource(dir: string): string {
   return join(dir, "opencode.json") + " (experimental.quotaToast)";
@@ -236,6 +237,61 @@ describe("quota runtime context", () => {
     expect(createContext(true, ["openai"]).config.telemetryToken).not.toEqual(first);
     expect(client.config.get).not.toHaveBeenCalled();
     expect(client.config.providers).not.toHaveBeenCalled();
+  });
+
+  it("scopes telemetry owners to provider cache identity changes", () => {
+    const client = createClient();
+    let identity = "root_sha256=one;key_sha256=one";
+    const provider = {
+      id: "identity-provider",
+      isAvailable: vi.fn(),
+      fetch: vi.fn(),
+      cacheIdentity: vi.fn(() => identity),
+    };
+    const createContext = () =>
+      createQuotaProviderRuntimeContext({
+        client,
+        resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
+        providers: [provider],
+        config: {
+          ...DEFAULT_CONFIG,
+          enabled: true,
+          enabledProviders: [provider.id],
+          telemetry: { enabled: true },
+        },
+        session: {},
+      });
+
+    const first = createContext().config.telemetryToken;
+    expect(createContext().config.telemetryToken).toEqual(first);
+    identity = "root_sha256=two;key_sha256=one";
+    expect(createContext().config.telemetryToken).not.toEqual(first);
+    expect(provider.cacheIdentity).toHaveBeenCalled();
+  });
+
+  it("deep-copies nineRouter providers into render and runtime provider contexts", async () => {
+    const config: QuotaToastConfig = {
+      ...DEFAULT_CONFIG,
+      nineRouter: { providers: ["kiro"], display: "unified" },
+    };
+    const client = createClient();
+    const renderSelection = await resolveQuotaRenderSelection({ client, config, providers: [] });
+    const runtimeContext = createQuotaProviderRuntimeContext({
+      client,
+      resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
+      config,
+      session: {},
+    });
+
+    config.nineRouter.providers.push("codex");
+    renderSelection?.ctx.config.nineRouter.providers.push("gemini");
+
+    expect(renderSelection?.ctx.config.nineRouter).toEqual({
+      providers: ["kiro", "gemini"],
+      display: "unified",
+    });
+    expect(runtimeContext.config.nineRouter).toEqual({ providers: ["kiro"], display: "unified" });
+    expect(config.nineRouter).toEqual({ providers: ["kiro", "codex"], display: "unified" });
   });
 
   it("copies default request timeout without marking it explicitly configured", () => {

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -153,6 +153,8 @@ vi.mock("../src/lib/quota-stats.js", () => ({
 describe("buildQuotaStatusReport", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", "");
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", "");
   });
 
   it("uses a Unicode ellipsis for truncated pricing diagnostic lists", async () => {
@@ -233,6 +235,73 @@ describe("buildQuotaStatusReport", () => {
     });
     expect(configuredReport).toContain("- googleModels: CLAUDE,G3PRO");
     expect(configuredReport).toContain(`- googleModels_source: configuration file (${configPath})`);
+  });
+
+  it("reports nineRouter setup, probe state, and provenance without exposing management secrets", async () => {
+    const root = "https://router.example.test/management";
+    const key = "9router-status-secret";
+    const account = "private-account-id";
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", root);
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", key);
+
+    const report = await buildProviderStatusReport("9router", {
+      nineRouter: { providers: [" KIRO ", "codex", "kiro"], display: "unified" },
+      settingSources: {
+        "nineRouter.providers": "/tmp/project/opencode-quota/quota-toast.jsonc",
+        "nineRouter.display": "/tmp/project/opencode-quota/quota-toast.jsonc",
+      },
+      providerLiveProbes: [
+        makeProviderPartialProbe(
+          "9router",
+          {},
+          {
+            entries: [{ accounting: QUOTA_ACCOUNTING, name: account, percentRemaining: 60 }],
+            errors: [{ label: "nineRouter", message: "one connection unavailable" }],
+          },
+        ),
+      ],
+    });
+
+    expectReportSection(
+      report,
+      "9router:",
+      [
+        "- management_root: configured",
+        "- api_key: configured",
+        "- configuration: configured",
+        "- selected_providers: codex,kiro",
+        "- display_mode: unified",
+        "- config_provenance: providers=/tmp/project/opencode-quota/quota-toast.jsonc display=/tmp/project/opencode-quota/quota-toast.jsonc",
+        "- root_valid: true",
+        "- fixed_endpoints: provider_list | connection_usage",
+        "- probe_outcome: partial",
+      ],
+      [root, key, account, "Bearer"],
+    );
+  });
+
+  it("reports invalid nineRouter setup without invoking a live network probe", async () => {
+    const root = "https://user:password@router.example.test";
+    const key = "9router-invalid-secret";
+    const fetchMock = vi.fn();
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", root);
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", key);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const report = await buildProviderStatusReport("9router");
+
+    expectReportSection(
+      report,
+      "9router:",
+      [
+        "- configuration: invalid_root",
+        "- root_valid: false",
+        "- setup: set OPENCODE_NINEROUTER_URL and OPENCODE_NINEROUTER_API_KEY",
+        "- probe_outcome: unavailable",
+      ],
+      [root, key, "Bearer"],
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("keeps the raw Antigravity family in live quota diagnostics", async () => {
@@ -1375,6 +1444,18 @@ describe("buildQuotaStatusReport", () => {
       - alibaba_api_key_auth_paths: /tmp/auth.json
       - alibaba_coding_plan: (none)
 
+      9router:
+      - management_root: missing
+      - api_key: missing
+      - configuration: missing_root
+      - selected_providers: (all)
+      - display_mode: perConnection
+      - config_provenance: providers=(default) display=(default)
+      - root_valid: false
+      - fixed_endpoints: provider_list | connection_usage
+      - probe_outcome: unavailable
+      - setup: set OPENCODE_NINEROUTER_URL and OPENCODE_NINEROUTER_API_KEY
+
       openai:
       - auth_configured: false
       - auth_source: (none)
@@ -1383,19 +1464,7 @@ describe("buildQuotaStatusReport", () => {
       - account_email: (none)
       - account_id: (none)
 
-      anthropic:
-      - cli_installed: true
-      - cli_version: 1.2.3
-      - auth_status: authenticated
-      - quota_supported: false
-      - quota_source: (none)
-      - checked_commands: claude --version | claude auth status --json
-      - message: Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback. Claude credentials file not found at /Users/test/.claude/.credentials.json.
-
-      cursor:
-      - plan: none
-      - included_api_usd: (none)
-      - billing_cycle_start_day: (calendar month)"
+      anthropic:"
     `);
 
     const titles = report
@@ -1405,6 +1474,7 @@ describe("buildQuotaStatusReport", () => {
     expect(titles).toMatchInlineSnapshot(`
       "toast:
 paths:
+9router:
 openai:
 anthropic:
 cursor:

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -1023,6 +1023,57 @@ describe("/quota command behavior", () => {
     expect(provider.fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("partitions rendered nineRouter toast cache by hashed management and display inputs", async () => {
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", "https://router.example.test/management");
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", "render-cache-secret");
+    mocks.loadConfig.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      enabled: true,
+      enabledProviders: ["9router"],
+      nineRouter: { providers: ["kiro"], display: "perConnection" },
+      showOnIdle: true,
+      showOnCompact: false,
+      showOnQuestion: false,
+      showSessionTokens: false,
+      minIntervalMs: 60_000,
+    });
+
+    const provider = {
+      id: "9router",
+      cacheIdentity: () => process.env.OPENCODE_NINEROUTER_URL ?? "",
+      isAvailable: vi.fn().mockResolvedValue(true),
+      fetch: vi
+        .fn()
+        .mockResolvedValueOnce({
+          attempted: true,
+          entries: [{ accounting: TEST_ACCOUNTING, name: "Kiro", percentRemaining: 80 }],
+          errors: [],
+        })
+        .mockResolvedValueOnce({
+          attempted: true,
+          entries: [{ accounting: TEST_ACCOUNTING, name: "Codex", percentRemaining: 40 }],
+          errors: [],
+        }),
+    };
+    mocks.getProviders.mockReturnValue([provider]);
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const client = createClient({ modelID: "9router/gpt-5", providerID: "9router" });
+    const hooks = await QuotaToastPlugin({ client } as any);
+    const event = { event: { type: "session.idle", properties: { sessionID: "session-9router" } } };
+
+    await hooks.event?.(event as any);
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", "https://other-router.example.test/management");
+    await hooks.event?.(event as any);
+
+    expect(client.tui.showToast).toHaveBeenCalledTimes(2);
+    expect(getToastMessage(client, 0)).toContain("80% left");
+    expect(getToastMessage(client, 1)).toContain("40% left");
+    expect(provider.fetch).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(client.tui.showToast.mock.calls)).not.toContain("render-cache-secret");
+    expect(JSON.stringify(client.tui.showToast.mock.calls)).not.toContain("router.example.test");
+  });
+
   it("does not cache rendered error-only toast results", async () => {
     mocks.loadConfig.mockResolvedValueOnce({
       ...DEFAULT_CONFIG,

--- a/tests/providers.nine-router.test.ts
+++ b/tests/providers.nine-router.test.ts
@@ -1,0 +1,268 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { QuotaProviderContext } from "../src/lib/entries.js";
+import { DEFAULT_CONFIG } from "../src/lib/types.js";
+
+const mocks = vi.hoisted(() => ({
+  accounts: vi.fn(),
+  resolve: vi.fn(),
+  usage: vi.fn(),
+}));
+
+vi.mock("../src/lib/nine-router.js", () => ({
+  fetchNineRouterAccounts: mocks.accounts,
+  fetchNineRouterUsage: mocks.usage,
+  resolveNineRouterConfig: mocks.resolve,
+}));
+
+import { nineRouterProvider } from "../src/providers/nine-router.js";
+
+const ROOT = "https://router.example.test";
+const KEY = "task-four-key-must-not-leak";
+const ACCOUNT_IDS = [
+  "11111111-1111-4111-8111-111111111111",
+  "22222222-2222-4222-8222-222222222222",
+  "33333333-3333-4333-8333-333333333333",
+  "44444444-4444-4444-8444-444444444444",
+  "55555555-5555-4555-8555-555555555555",
+] as const;
+
+function configured() {
+  return { success: true as const, root: ROOT };
+}
+
+function quota(percentRemaining: number) {
+  return { success: true as const, windows: [{ kind: "weekly", percentRemaining }] };
+}
+
+function context(
+  providers: readonly string[] = ["codex"],
+  display: "perConnection" | "unified" = "perConnection",
+): QuotaProviderContext {
+  return {
+    client: {
+      config: {
+        providers: async () => ({ data: { providers: [] } }),
+        get: async () => ({ data: {} }),
+      },
+    },
+    resolveRuntimeProviderIds: async () => new Set(),
+    config: {
+      ...DEFAULT_CONFIG,
+      nineRouter: { providers: [...providers], display },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("nineRouter provider", () => {
+  it("is available only with valid management configuration and matches nineRouter models", async () => {
+    mocks.resolve.mockReturnValueOnce({ success: false, error: "invalid" });
+    await expect(nineRouterProvider.isAvailable(context())).resolves.toBe(false);
+    mocks.resolve.mockReturnValueOnce(configured());
+    await expect(nineRouterProvider.isAvailable(context())).resolves.toBe(true);
+    expect(nineRouterProvider.matchesCurrentModel?.("9router/gpt-5")).toBe(true);
+    expect(nineRouterProvider.matchesCurrentModel?.("openai/gpt-5")).toBe(false);
+  });
+
+  it("uses a domain-separated private cache identity", () => {
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", KEY);
+    mocks.resolve.mockReturnValue(configured());
+    const identity = nineRouterProvider.cacheIdentity?.(context(["codex"]));
+    const rootDigest = createHash("sha256").update(`9router:root:${ROOT}`).digest("hex");
+    const keyDigest = createHash("sha256").update(`9router:key:${KEY}`).digest("hex");
+    expect(identity).toBe(
+      `root_sha256=${rootDigest};key_sha256=${keyDigest};providers_sha256=${createHash("sha256").update('9router:providers:["codex"]').digest("hex")};display_sha256=${createHash("sha256").update("9router:display:perconnection").digest("hex")}`,
+    );
+    expect(identity).not.toContain(ROOT);
+    expect(identity).not.toContain(KEY);
+  });
+
+  it("maps separate accounts with safe labels and private source identities", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: [
+        { id: ACCOUNT_IDS[0], provider: "codex", displayName: "Team Alpha" },
+        { id: ACCOUNT_IDS[1], provider: "codex", email: "person@example.test" },
+      ],
+    });
+    mocks.usage.mockResolvedValueOnce(quota(80)).mockResolvedValueOnce(quota(10));
+    const result = await nineRouterProvider.fetch(context());
+    expect(result).toMatchObject({
+      attempted: true,
+      errors: [],
+      entries: [
+        expect.objectContaining({ group: "codex / Team Alpha", percentRemaining: 80 }),
+        expect.objectContaining({ group: "codex / per..example.test", percentRemaining: 10 }),
+      ],
+    });
+    expect(JSON.stringify(result)).not.toContain(ACCOUNT_IDS[0]);
+    expect(JSON.stringify(result)).not.toContain("person@example.test");
+  });
+
+  it("caps usage calls at four, preserves successful entries, and suppresses failures", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: ACCOUNT_IDS.map((id) => ({ id, provider: "codex" })),
+    });
+    let inFlight = 0;
+    let maximumInFlight = 0;
+    mocks.usage.mockImplementation(async (_config, id: string) => {
+      inFlight += 1;
+      maximumInFlight = Math.max(maximumInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      inFlight -= 1;
+      return id === ACCOUNT_IDS[2]
+        ? { success: false as const, error: "private failure" }
+        : quota(60);
+    });
+    const result = await nineRouterProvider.fetch(context());
+    expect(maximumInFlight).toBeLessThanOrEqual(4);
+    expect(result.entries).toHaveLength(4);
+    expect(JSON.stringify(result)).not.toContain("private failure");
+  });
+
+  it("omits failed and zero-window usage responses without fabricating quota", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: [{ id: ACCOUNT_IDS[0], provider: "codex", email: "private@example.test" }],
+    });
+    mocks.usage
+      .mockResolvedValueOnce({ success: false, error: "private" })
+      .mockResolvedValueOnce({ success: true, windows: [] });
+    const failed = await nineRouterProvider.fetch(context());
+    const empty = await nineRouterProvider.fetch(context());
+    expect(failed).toEqual({ attempted: true, entries: [], errors: [] });
+    expect(empty).toEqual({ attempted: true, entries: [], errors: [] });
+  });
+
+  it("rejects UUID and account-id labels", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: [
+        { id: ACCOUNT_IDS[0], provider: "codex", displayName: ACCOUNT_IDS[0].toUpperCase() },
+        { id: ACCOUNT_IDS[1], provider: "codex", name: "AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA" },
+      ],
+    });
+    mocks.usage.mockResolvedValue(quota(42));
+    const result = await nineRouterProvider.fetch(context());
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ group: "codex / Account 1" }),
+        expect.objectContaining({ group: "codex / Account 2" }),
+      ]),
+    );
+    expect(JSON.stringify(result)).not.toContain(ACCOUNT_IDS[0]);
+  });
+
+  it("keeps duplicate labels scoped by provider and source", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: [
+        { id: ACCOUNT_IDS[0], provider: "kiro", displayName: "Shared" },
+        { id: ACCOUNT_IDS[1], provider: "kiro", displayName: "Shared" },
+      ],
+    });
+    mocks.usage.mockResolvedValue(quota(80));
+    const result = await nineRouterProvider.fetch(context(["kiro"]));
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ group: "kiro / Shared" }),
+        expect.objectContaining({ group: "kiro / Shared (2)" }),
+      ]),
+    );
+    expect(result.entries[0]?.accounting.sourceId).not.toBe(result.entries[1]?.accounting.sourceId);
+  });
+
+  it("averages unified exact keys, preserves case distinctions, and uses earliest reset", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({
+      success: true,
+      accounts: ACCOUNT_IDS.slice(0, 2).map((id) => ({ id, provider: "kiro" })),
+    });
+    mocks.usage
+      .mockResolvedValueOnce({
+        success: true,
+        windows: [
+          { kind: "Weekly", percentRemaining: 80, resetTimeIso: "2026-01-02T00:00:00.000Z" },
+          { kind: "weekly", percentRemaining: 100 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        windows: [
+          { kind: "Weekly", percentRemaining: 40, resetTimeIso: "2026-01-01T00:00:00.000Z" },
+          { kind: "weekly", percentRemaining: 60 },
+        ],
+      });
+    const result = await nineRouterProvider.fetch(context(["kiro"], "unified"));
+    expect(result.entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          group: "nineRouter (kiro)",
+          label: "Weekly:",
+          percentRemaining: 60,
+          resetTimeIso: "2026-01-01T00:00:00.000Z",
+        }),
+        expect.objectContaining({ label: "weekly:", percentRemaining: 80 }),
+      ]),
+    );
+  });
+
+  it("requests empty selections once, canonical explicit providers separately, and reserved all never", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    mocks.accounts.mockResolvedValue({ success: true, accounts: [] });
+    await nineRouterProvider.fetch(context([]));
+    await nineRouterProvider.fetch(context([" KIRO ", "all", "codex", "kiro"]));
+    await nineRouterProvider.fetch(context([" ALL ", "all"]));
+    expect(mocks.accounts.mock.calls).toEqual([
+      [configured()],
+      [configured(), "codex"],
+      [configured(), "kiro"],
+    ]);
+  });
+
+  it("limits explicit account lists to four, isolates failures, and deduplicates IDs first-wins", async () => {
+    mocks.resolve.mockReturnValue(configured());
+    const started: string[] = [];
+    mocks.accounts.mockImplementation(async (_config, provider?: string) => {
+      if (!provider) return { success: true as const, accounts: [] };
+      started.push(provider);
+      return provider === "alpha"
+        ? { success: false as const, error: "private" }
+        : {
+            success: true as const,
+            accounts: [
+              { id: ACCOUNT_IDS[0], provider, displayName: "Shared" },
+              { id: ACCOUNT_IDS[0], provider: "ignored" },
+            ],
+          };
+    });
+    mocks.usage.mockResolvedValue(quota(70));
+    const result = await nineRouterProvider.fetch(
+      context(["gamma", "alpha", "epsilon", "beta", "delta"]),
+    );
+    expect(started.slice(0, 4)).toEqual(["alpha", "beta", "delta", "epsilon"]);
+    expect(started).toHaveLength(5);
+    expect(mocks.usage).toHaveBeenCalledTimes(1);
+    expect(result.entries).toHaveLength(1);
+  });
+
+  it("returns unattempted when management configuration is invalid", async () => {
+    mocks.resolve.mockReturnValue({ success: false, error: "invalid" });
+    await expect(nineRouterProvider.fetch(context())).resolves.toEqual({
+      attempted: false,
+      entries: [],
+      errors: [],
+    });
+  });
+});

--- a/tests/providers.registry.test.ts
+++ b/tests/providers.registry.test.ts
@@ -7,6 +7,7 @@ const EXPECTED_PROVIDER_ORDER = [
   "anthropic",
   "copilot",
   "openai",
+  "9router",
   "openrouter",
   "kilo",
   "cursor",

--- a/tests/quota-render-data.test.ts
+++ b/tests/quota-render-data.test.ts
@@ -10,12 +10,13 @@ const TEST_ACCOUNTING = {
   authority: "provider_reported",
 } as const;
 
-const { mockProviders } = vi.hoisted(() => ({
+const { mockGetProviders, mockProviders } = vi.hoisted(() => ({
+  mockGetProviders: vi.fn(),
   mockProviders: [] as any[],
 }));
 
 vi.mock("../src/providers/registry.js", () => ({
-  getProviders: () => mockProviders,
+  getProviders: mockGetProviders,
 }));
 
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
@@ -64,6 +65,8 @@ const TEST_CLIENT = {
 describe("collectQuotaRenderData shared quota state", () => {
   beforeEach(async () => {
     mockProviders.length = 0;
+    mockGetProviders.mockReturnValue(mockProviders);
+    mockGetProviders.mockClear();
     vi.restoreAllMocks();
     __resetQuotaStateForTests();
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });
@@ -109,6 +112,18 @@ describe("collectQuotaRenderData shared quota state", () => {
         percentRemaining: 42,
       },
     ]);
+  });
+
+  it("does not resolve the global provider registry when quota rendering is disabled", async () => {
+    const result = await collectQuotaRenderData({
+      client: TEST_CLIENT,
+      config: renderConfig({ enabled: false }),
+      surfaceExplicitProviderIssues: true,
+      formatStyle: "allWindows",
+    });
+
+    expect(mockGetProviders).not.toHaveBeenCalled();
+    expect(result.selection).toBeNull();
   });
 
   it("returns allWindowsData when includeAllWindowsData is true and style is singleWindow", async () => {

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, readdir, rm, writeFile } from "fs/promises";
+import { createHash } from "crypto";
+import { mkdir, readdir, readFile, rm, writeFile } from "fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { validateQuotaProviders } from "../src/lib/quota-providers.js";
@@ -37,6 +38,12 @@ function createTestContext() {
   } as any;
 }
 
+function providerCacheIdentity(root: string, apiKey: string): string {
+  const rootDigest = createHash("sha256").update(`9router:root:${root}`).digest("hex");
+  const keyDigest = createHash("sha256").update(`9router:key:${apiKey}`).digest("hex");
+  return `root_sha256=${rootDigest};key_sha256=${keyDigest}`;
+}
+
 describe("quota-state shared cache", () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
@@ -64,6 +71,164 @@ describe("quota-state shared cache", () => {
     } as any);
 
     expect(singleWindowKey).toBe(allWindowsKey);
+  });
+
+  it("preserves the exact legacy cache key for providers without a cache identity hook", async () => {
+    const { buildQuotaProviderStateCacheKey } = await import("../src/lib/quota-state.js");
+
+    expect(buildQuotaProviderStateCacheKey("synthetic", createTestContext())).toBe(
+      "synthetic|anthropicBinaryPath=claude|googleModels=CLAUDE|cursorPlan=none|cursorIncludedApiUsd=|cursorBillingCycleStartDay=|opencodeGoWindows=|onlyCurrentModel=no|currentModel=|currentProviderID=",
+    );
+  });
+
+  it("partitions nineRouter identity by root, key, canonical providers, and display using digests", async () => {
+    const { nineRouterProvider } = await import("../src/providers/nine-router.js");
+    const root = "https://management.example.test/api";
+    const key = "task-cache-api-key-must-not-leak";
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", root);
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", key);
+    const contextFor = (providers: readonly string[], display: "perConnection" | "unified") => ({
+      ...createTestContext(),
+      config: { ...createTestContext().config, nineRouter: { providers, display } },
+    });
+
+    const canonical = nineRouterProvider.cacheIdentity?.(contextFor([" KIRO "], "unified"));
+    const normalized = nineRouterProvider.cacheIdentity?.(contextFor(["kiro"], "unified"));
+    const reordered = nineRouterProvider.cacheIdentity?.(contextFor(["codex", "kiro"], "unified"));
+    const duplicated = nineRouterProvider.cacheIdentity?.(
+      contextFor(["KIRO", "codex", "codex"], "unified"),
+    );
+    const perConnection = nineRouterProvider.cacheIdentity?.(contextFor(["kiro"], "perConnection"));
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", "https://other.example.test/api");
+    const otherRoot = nineRouterProvider.cacheIdentity?.(contextFor(["kiro"], "unified"));
+    vi.stubEnv("OPENCODE_NINEROUTER_URL", root);
+    vi.stubEnv("OPENCODE_NINEROUTER_API_KEY", "other-task-cache-key");
+    const otherKey = nineRouterProvider.cacheIdentity?.(contextFor(["kiro"], "unified"));
+
+    expect(canonical).toBe(normalized);
+    expect(reordered).toBe(duplicated);
+    expect(canonical).not.toBe(reordered);
+    expect(canonical).not.toBe(perConnection);
+    expect(canonical).not.toBe(otherRoot);
+    expect(canonical).not.toBe(otherKey);
+    for (const identity of [canonical, reordered, perConnection, otherRoot, otherKey]) {
+      expect(identity).toMatch(
+        /^root_sha256=[a-f0-9]{64};key_sha256=[a-f0-9]{64};providers_sha256=[a-f0-9]{64};display_sha256=[a-f0-9]{64}$/,
+      );
+      expect(identity).not.toContain(root);
+      expect(identity).not.toContain(key);
+      expect(identity).not.toContain("kiro");
+      expect(identity).not.toContain("codex");
+    }
+  });
+
+  it("partitions in-memory and persisted cache entries by provider-supplied identity", async () => {
+    const { __resetQuotaStateForTests, fetchQuotaProviderResult } = await import(
+      "../src/lib/quota-state.js"
+    );
+    __resetQuotaStateForTests();
+    const identityA = providerCacheIdentity("https://management-a.example/v1", "secret-a");
+    const identityB = providerCacheIdentity("https://management-b.example/v1", "secret-a");
+    const identityC = providerCacheIdentity("https://management-a.example/v1", "secret-b");
+    let fetchCount = 0;
+    const providerFor = (cacheIdentity: string) => ({
+      id: "identity-provider",
+      isAvailable: vi.fn(),
+      cacheIdentity: () => cacheIdentity,
+      fetch: vi.fn(async () => ({
+        attempted: true,
+        entries: [
+          {
+            accounting: TEST_ACCOUNTING,
+            name: `Identity ${++fetchCount}`,
+            percentRemaining: 50,
+          },
+        ],
+        errors: [],
+      })),
+    });
+    const firstProvider = providerFor(identityA);
+    const duplicateProvider = providerFor(identityA);
+
+    const first = await fetchQuotaProviderResult({
+      provider: firstProvider,
+      ctx: createTestContext(),
+      ttlMs: 60_000,
+    });
+    const duplicate = await fetchQuotaProviderResult({
+      provider: duplicateProvider,
+      ctx: createTestContext(),
+      ttlMs: 60_000,
+    });
+    await fetchQuotaProviderResult({
+      provider: providerFor(identityB),
+      ctx: createTestContext(),
+      ttlMs: 60_000,
+    });
+    await fetchQuotaProviderResult({
+      provider: providerFor(identityC),
+      ctx: createTestContext(),
+      ttlMs: 60_000,
+    });
+    const inMemory = await fetchQuotaProviderResult({
+      provider: providerFor(identityA),
+      ctx: createTestContext(),
+      ttlMs: 60_000,
+    });
+
+    expect(first.entries[0]?.name).toBe("Identity 1");
+    expect(duplicate.entries[0]?.name).toBe("Identity 1");
+    expect(inMemory.entries[0]?.name).toBe("Identity 1");
+    expect(firstProvider.fetch).toHaveBeenCalledOnce();
+    expect(duplicateProvider.fetch).not.toHaveBeenCalled();
+    expect(fetchCount).toBe(3);
+
+    const cacheDir = `${TEST_RUNTIME_ROOT}/cache/quota-provider-state`;
+    const cacheFiles = await readdir(cacheDir);
+    const serializedEntries = await Promise.all(
+      cacheFiles.map((file) => readFile(`${cacheDir}/${file}`, "utf-8")),
+    );
+    expect(serializedEntries).toHaveLength(3);
+    expect(serializedEntries).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(identityA),
+        expect.stringContaining(identityB),
+        expect.stringContaining(identityC),
+      ]),
+    );
+    const serializedCache = JSON.stringify({ cacheFiles, serializedEntries });
+    for (const raw of [
+      "https://management-a.example/v1",
+      "https://management-b.example/v1",
+      "secret-a",
+      "secret-b",
+    ]) {
+      expect(serializedCache).not.toContain(raw);
+    }
+
+    vi.resetModules();
+    const quotaState = await import("../src/lib/quota-state.js");
+    await expect(
+      quotaState.readCachedProviderResult({
+        provider: providerFor(identityA),
+        ctx: createTestContext(),
+        ttlMs: 60_000,
+      }),
+    ).resolves.toMatchObject({ hit: true, result: { entries: [{ name: "Identity 1" }] } });
+    await expect(
+      quotaState.readCachedProviderResult({
+        provider: providerFor(identityB),
+        ctx: createTestContext(),
+        ttlMs: 60_000,
+      }),
+    ).resolves.toMatchObject({ hit: true, result: { entries: [{ name: "Identity 2" }] } });
+    await expect(
+      quotaState.readCachedProviderResult({
+        provider: providerFor(identityC),
+        ctx: createTestContext(),
+        ttlMs: 60_000,
+      }),
+    ).resolves.toMatchObject({ hit: true, result: { entries: [{ name: "Identity 3" }] } });
   });
 
   it("uses identical cache identity for alias-normalized and canonical definitions", async () => {

--- a/tests/readme-provider-ledger.test.ts
+++ b/tests/readme-provider-ledger.test.ts
@@ -75,6 +75,7 @@ describe("README provider ledger", () => {
   it("keeps audience tables alphabetized with intentional duplicates", () => {
     const expectedProviders = [
       [
+        "9Router",
         "Anthropic (Claude)",
         "Chutes AI",
         "Cursor",

--- a/tests/tui-dist-packaging.test.ts
+++ b/tests/tui-dist-packaging.test.ts
@@ -59,5 +59,5 @@ describe("tui dist packaging", () => {
       id: "@slkiser/opencode-quota",
     });
     expect(typeof mod.default.tui).toBe("function");
-  });
+  }, 10_000);
 });


### PR DESCRIPTION
## Summary

Adds first-class 9Router quota support across configuration, provider discovery, runtime reporting, CLI/TUI/server surfaces, documentation, and tests. Users can configure the 9Router endpoint and API key, query quota data remotely, and see clear diagnostics when setup or requests fail.

This PR is intentionally scoped to 9Router support and its required cross-surface plumbing.

## Linked Issue

No issue is linked. Rationale: this is a focused provider integration adding user-requested 9Router quota visibility, with setup documentation and regression coverage included in the same change.

## OpenCode Validation

- Current production released OpenCode version tested: OpenCode plugin API `1.18.11` (the repository-pinned production dependency)
- Why this version is relevant to the fix: 9Router integration uses the current provider/plugin contracts and all command, runtime, TUI, and packaging checks pass against the pinned version.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply

The provider template does not apply directly because 9Router uses its own endpoint/configuration flow and quota response contract rather than the template provider implementation. Equivalent auth/configuration, provider, integration, surface, and regression tests are included.

## Verification

- `pnpm run verify:typescript-version`
- `pnpm run verify:v4-history`
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test` (166 files, 1,860 tests)
- `pnpm run test:four-surfaces`
- `pnpm run verify:package-contents`

Note: the literal `pnpm verify` invocation is blocked locally by an untracked `.omo` session artifact being included by the repository-wide Biome glob; tracked-file Biome checks pass with only existing warnings.