### PR TITLE
Resolve Kimi K3 token pricing

### DIFF
--- a/src/data/modelsdev-pricing.min.json
+++ b/src/data/modelsdev-pricing.min.json
@@ -329,6 +329,11 @@
         "input": 0.6,
         "output": 3,
         "cache_read": 0.1
+      },
+      "kimi-k3": {
+        "input": 3,
+        "output": 15,
+        "cache_read": 0.3
       }
     },
     "openai": {

--- a/src/lib/quota-stats.ts
+++ b/src/lib/quota-stats.ts
@@ -190,6 +190,7 @@ const SOURCE_PROVIDER_ALIASES: Record<string, string> = {
   "copilot-chat": "openai",
   chatgpt: "openai",
   codex: "openai",
+  "kimi-for-coding": "moonshotai",
   "zai-coding-plan": "zai",
   glm: "zai",
 };
@@ -263,6 +264,9 @@ function moonshotaiPricingCandidates(model: string): string[] {
     if (freeCandidate.includes(".")) {
       candidates.push(freeCandidate.replace(/\./g, "-"));
     }
+  }
+  if (model === "k3" || model === "k3-256k") {
+    candidates.push("kimi-k3");
   }
   return candidates.filter((value, index, list) => list.indexOf(value) === index);
 }

--- a/tests/pricing-resolver.coverage.test.ts
+++ b/tests/pricing-resolver.coverage.test.ts
@@ -155,6 +155,36 @@ describe("resolvePricingKey snapshot coverage", () => {
     expect(lookupCost("openai", "gpt-4o-mini")).not.toBeNull();
   });
 
+  it("maps documented Kimi Code K3 models to authoritative pricing", () => {
+    for (const modelID of ["k3", "k3-256k"]) {
+      expect(
+        resolvePricingKey({
+          providerID: "kimi-for-coding",
+          modelID,
+        }),
+      ).toEqual({
+        ok: true,
+        key: { provider: "moonshotai", model: "kimi-k3" },
+        method: "source_provider",
+      });
+    }
+
+    expect(lookupCost("moonshotai", "kimi-k3")).toEqual({
+      input: 3,
+      output: 15,
+      cache_read: 0.3,
+    });
+
+    for (const modelID of ["k3-free", "k3-256k-free", "k3-preview"]) {
+      expect(
+        resolvePricingKey({
+          providerID: "kimi-for-coding",
+          modelID,
+        }).ok,
+      ).toBe(false);
+    }
+  });
+
   it("maps cursor local and api-pool models into deterministic pricing keys", () => {
     const auto = resolvePricingKey({
       providerID: "cursor",


### PR DESCRIPTION
## Summary

- add official Kimi K3 input, cached-input, and output prices
- map documented Kimi Code `k3` and `k3-256k` IDs
- keep undocumented near-matches unresolved

## Checks

- focused pricing tests: 27/27 passed
- typecheck passed
- build passed
- full suite: 1,847/1,847 passed

Closes #205