### PR TITLE
Notify when quota windows reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ More ways to use it:
 - Send quota data to monitoring tools with optional OpenTelemetry metrics
 - Run the same slash commands in the TUI, Web, and Desktop
 - Tune reset countdown precision without changing the default compact display
-- Opt in to popup notifications when selected quota windows reset with [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again); they reuse existing quota checks
+- Get a popup when quota becomes available again for the windows you choose via [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again)
 - Choose current-session or descendant-tree token totals across `/quota`, toasts, the sidebar, and the compact input line
 - Diagnose authentication, quota sources, pricing, and maintainer notices
 


### PR DESCRIPTION
## Summary

- preserve the reset-notification implementation from #200
- serialize persisted observations and protect monotonic baselines
- use stable provider, source, window, and account identities
- document the opt-in setting with direct README copy

## Checks

- focused reset/config/plugin/runtime suites: 86/86 passed
- README consistency tests: 17/17 passed
- typecheck passed
- build passed
- full suite: 1,816/1,816 passed
- GitHub README preview rendered successfully

Supersedes #200.
Closes #199.