### PR TITLE
feat(tui): render quota progress bar under the prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ More ways to use it:
 - Send quota data to monitoring tools with optional OpenTelemetry metrics
 - Run the same slash commands in the TUI, Web, and Desktop
 - Tune reset countdown precision without changing the default compact display
-- Opt in to popup notifications when selected quota windows reset with [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again); they reuse existing quota checks
+- Get a popup when quota becomes available again for the windows you choose via [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again)
+- Add a quota bar below the TUI prompt via [`tuiPromptBar.enabled`](docs/readme/configuration.md#tui-settings)
 - Choose current-session or descendant-tree token totals across `/quota`, toasts, the sidebar, and the compact input line
 - Diagnose authentication, quota sources, pricing, and maintainer notices
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -367,7 +367,7 @@ Existing `experimental.quotaToast` settings remain supported. Quota settings do 
 | `tuiCompactStatus.suppressWhenNativeProviderQuota` | `true`               | Hide the Compact status line when OpenCode exposes native provider-quota support.                                                                                                                             |
 | `tuiCompactStatus.maxWidth`                        | `96`                 | Maximum Compact status line text width.                                                                                                                                                                       |
 | `tuiCompactStatus.formatStyle`                     | (root `formatStyle`) | Override `formatStyle` for the Compact status line only. Useful when you want `singleWindow` on the compact line while the sidebar shows `allWindows`.                                                        |
-| `tuiPromptBar.enabled`                             | `true`               | Show a compact quota progress bar under the TUI prompt. Prefers the 5h window entry and shows remaining percent plus reset countdown. When disabled, the prompt falls back to the compact status line.      |
+| `tuiPromptBar.enabled`                             | `false`              | Show an opt-in quota progress bar below the TUI prompt. It prefers the 5h window and replaces the Compact line below the session input. Sidebar, Home, toasts, and slash-command output are unchanged. |
 
 ### Maintainer announcement settings
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -30,6 +30,7 @@ Strict `.json` files also work. Run `/quota_status` if you are unsure which file
 | Turn popup quota notifications on or off   | `enableToast`                 |
 | Notify when weekly quota resets            | `resetNotifications.enabled`  |
 | Turn the compact quota line on or off      | `tuiCompactStatus.enabled`    |
+| Show a quota progress bar under the prompt | `tuiPromptBar.enabled`        |
 | Show or hide session input/output tokens   | `showSessionTokens`           |
 | Include descendant/subagent session tokens | `sessionTokenScope: "tree"`   |
 
@@ -54,6 +55,8 @@ The installer chooses `allWindows` by default. If the setting is absent, the bui
   "enableToast": false,
   "resetNotifications": { "enabled": false, "windows": ["weekly"] },
   "tuiCompactStatus": { "enabled": false },
+  // Show a quota progress bar under the prompt.
+  "tuiPromptBar": { "enabled": true },
 }
 ```
 
@@ -364,6 +367,7 @@ Existing `experimental.quotaToast` settings remain supported. Quota settings do 
 | `tuiCompactStatus.suppressWhenNativeProviderQuota` | `true`               | Hide the Compact status line when OpenCode exposes native provider-quota support.                                                                                                                             |
 | `tuiCompactStatus.maxWidth`                        | `96`                 | Maximum Compact status line text width.                                                                                                                                                                       |
 | `tuiCompactStatus.formatStyle`                     | (root `formatStyle`) | Override `formatStyle` for the Compact status line only. Useful when you want `singleWindow` on the compact line while the sidebar shows `allWindows`.                                                        |
+| `tuiPromptBar.enabled`                             | `true`               | Show a compact quota progress bar under the TUI prompt. Prefers the 5h window entry and shows remaining percent plus reset countdown. When disabled, the prompt falls back to the compact status line.      |
 
 ### Maintainer announcement settings
 

--- a/docs/readme/manual-install.md
+++ b/docs/readme/manual-install.md
@@ -97,6 +97,7 @@ Put these settings in `quota-toast.jsonc`, not `tui.jsonc`.
 | Sidebar panel               | `tuiSidebarPanel.enabled: true`          |
 | Popup quota notifications   | `enableToast: true`                      |
 | Compact quota line          | `tuiCompactStatus.enabled: true`         |
+| Quota bar under the prompt  | `tuiPromptBar.enabled: true`             |
 | Slash results with messages | `tuiCommandDisplay: "inline"`            |
 | Slash results in a popup    | `tuiCommandDisplay: "dialog"`            |
 | Manual slash commands only  | Disable sidebar, toast, and compact line |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -76,6 +76,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "tuiCompactStatus.suppressWhenNativeProviderQuota",
   "tuiCompactStatus.maxWidth",
   "tuiCompactStatus.formatStyle",
+  "tuiPromptBar.enabled",
   "maintainerAnnouncements.enabled",
   "maintainerAnnouncements.home",
   "layout.maxWidth",
@@ -141,6 +142,7 @@ type PricingSnapshotPatch = Partial<QuotaToastConfig["pricingSnapshot"]>;
 type QuotaResetNotificationsPatch = Partial<QuotaToastConfig["resetNotifications"]>;
 type TuiSidebarPanelPatch = Partial<QuotaToastConfig["tuiSidebarPanel"]>;
 type TuiCompactStatusPatch = Partial<QuotaToastConfig["tuiCompactStatus"]>;
+type TuiPromptBarPatch = Partial<QuotaToastConfig["tuiPromptBar"]>;
 type MaintainerAnnouncementsPatch = Partial<QuotaToastConfig["maintainerAnnouncements"]>;
 type LayoutPatch = Partial<QuotaToastConfig["layout"]>;
 type ExportConfigPatch = Partial<QuotaToastConfig["export"]>;
@@ -177,6 +179,7 @@ type ValidatedQuotaToastPatch = {
   sessionTokenScope?: SessionTokenScope;
   tuiSidebarPanel?: TuiSidebarPanelPatch;
   tuiCompactStatus?: TuiCompactStatusPatch;
+  tuiPromptBar?: TuiPromptBarPatch;
   maintainerAnnouncements?: MaintainerAnnouncementsPatch;
   layout?: LayoutPatch;
   export?: ExportConfigPatch;
@@ -333,6 +336,7 @@ function cloneConfig(config: QuotaToastConfig): QuotaToastConfig {
     pricingSnapshot: { ...config.pricingSnapshot },
     tuiSidebarPanel: { ...config.tuiSidebarPanel },
     tuiCompactStatus: { ...config.tuiCompactStatus },
+    tuiPromptBar: { ...config.tuiPromptBar },
     maintainerAnnouncements: { ...config.maintainerAnnouncements },
     layout: { ...config.layout },
     export: { ...config.export },
@@ -516,6 +520,20 @@ function extractTuiCompactStatusPatch(value: unknown): TuiCompactStatusPatch | u
   const compactFormatStyle = getExplicitFormatStyle(value);
   if (compactFormatStyle) {
     patch.formatStyle = compactFormatStyle;
+  }
+
+  return Object.keys(patch).length > 0 ? patch : undefined;
+}
+
+function extractTuiPromptBarPatch(value: unknown): TuiPromptBarPatch | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const patch: TuiPromptBarPatch = {};
+
+  if (hasOwnKey(value, "enabled") && typeof value.enabled === "boolean") {
+    patch.enabled = value.enabled;
   }
 
   return Object.keys(patch).length > 0 ? patch : undefined;
@@ -805,6 +823,13 @@ function extractValidatedQuotaToastPatch(
     }
   }
 
+  if (hasOwnKey(quotaToastConfig, "tuiPromptBar")) {
+    const tuiPromptBar = extractTuiPromptBarPatch(quotaToastConfig.tuiPromptBar);
+    if (tuiPromptBar) {
+      patch.tuiPromptBar = tuiPromptBar;
+    }
+  }
+
   if (hasOwnKey(quotaToastConfig, "maintainerAnnouncements")) {
     const maintainerAnnouncements = extractMaintainerAnnouncementsPatch(
       quotaToastConfig.maintainerAnnouncements,
@@ -1049,6 +1074,13 @@ function applyValidatedQuotaToastPatch(
     if (hasOwnKey(patch.tuiCompactStatus, "formatStyle")) {
       config.tuiCompactStatus.formatStyle = patch.tuiCompactStatus.formatStyle!;
       applySettingSource(settingSources, "tuiCompactStatus.formatStyle", sourcePath);
+    }
+  }
+
+  if (patch.tuiPromptBar) {
+    if (hasOwnKey(patch.tuiPromptBar, "enabled")) {
+      config.tuiPromptBar.enabled = patch.tuiPromptBar.enabled!;
+      applySettingSource(settingSources, "tuiPromptBar.enabled", sourcePath);
     }
   }
 

--- a/src/lib/tui-panel-state.ts
+++ b/src/lib/tui-panel-state.ts
@@ -35,7 +35,7 @@ export type PromptBarState =
   | { status: "loading" | "disabled" }
   | {
       status: "ready";
-      entry: PromptBarEntry;
+      entry?: PromptBarEntry;
       percentDisplayMode?: PercentDisplayMode;
       resetTimeDecimals?: number;
     };

--- a/src/lib/tui-panel-state.ts
+++ b/src/lib/tui-panel-state.ts
@@ -1,4 +1,5 @@
 import { sanitizeSingleLineDisplayText } from "./display-sanitize.js";
+import type { PercentDisplayMode } from "./types.js";
 
 const SIDEBAR_LOADING_LINE = "Loading…";
 const SIDEBAR_UNAVAILABLE_LINE = "Unavailable";
@@ -22,6 +23,22 @@ export type HomeBottomState =
   | { status: "loading"; announcementText?: string; compact: CompactStatusState }
   | { status: "disabled"; announcementText?: string; compact: CompactStatusState }
   | { status: "ready"; announcementText?: string; compact: CompactStatusState };
+
+export type PromptBarEntry = {
+  label?: string;
+  name?: string;
+  percentRemaining?: number;
+  resetTimeIso?: string;
+};
+
+export type PromptBarState =
+  | { status: "loading" | "disabled" }
+  | {
+      status: "ready";
+      entry: PromptBarEntry;
+      percentDisplayMode?: PercentDisplayMode;
+      resetTimeDecimals?: number;
+    };
 
 export function shouldRenderSidebarPanel(panel: SidebarPanelState): boolean {
   return panel.status !== "disabled";

--- a/src/lib/tui-runtime.ts
+++ b/src/lib/tui-runtime.ts
@@ -1,5 +1,6 @@
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import { type RuntimeContextRootHints, resolveRuntimeContextRoots } from "./config-file-utils.js";
+import { isPercentEntry } from "./entries.js";
 import {
   BUNDLED_MAINTAINER_ANNOUNCEMENTS,
   formatMaintainerAnnouncementHomeCountLine,
@@ -8,6 +9,7 @@ import {
   type MaintainerAnnouncement,
 } from "./maintainer-announcements.js";
 import { getQuotaProviderShape, normalizeQuotaProviderId } from "./provider-metadata.js";
+import { classifyQuotaWindowText } from "./quota-entry-display.js";
 import {
   buildQuotaExport,
   createExportProviderContext,
@@ -15,7 +17,11 @@ import {
   writeQuotaExport,
 } from "./quota-export.js";
 import { resolveQuotaFormatStyle } from "./quota-format-style.js";
-import type { CollectQuotaRenderDataResult, SessionModelMeta } from "./quota-render-data.js";
+import type {
+  CollectQuotaRenderDataResult,
+  QuotaRenderData,
+  SessionModelMeta,
+} from "./quota-render-data.js";
 import { collectConcreteEnabledProviderIds, collectQuotaRenderData } from "./quota-render-data.js";
 import type { QuotaRuntimeContext } from "./quota-runtime-context.js";
 import {
@@ -25,7 +31,13 @@ import {
 } from "./quota-runtime-context.js";
 import { buildCompactQuotaStatusLine } from "./tui-compact-format.js";
 import { hasNativeProviderQuotaClient } from "./tui-native-provider-quota.js";
-import type { CompactStatusState, HomeBottomState, SidebarPanelState } from "./tui-panel-state.js";
+import type {
+  CompactStatusState,
+  HomeBottomState,
+  PromptBarEntry,
+  PromptBarState,
+  SidebarPanelState,
+} from "./tui-panel-state.js";
 import { buildSidebarQuotaPanelLines, TUI_SIDEBAR_MAX_WIDTH } from "./tui-sidebar-format.js";
 import type { TuiCommandDisplay } from "./types.js";
 
@@ -191,6 +203,10 @@ export type TuiCompactStatusRegistration = {
   suppressedByNativeProviderQuota: boolean;
 };
 
+export type TuiPromptBarRegistration = {
+  enabled: boolean;
+};
+
 export type TuiMaintainerAnnouncementsRegistration = {
   homeBottom: boolean;
 };
@@ -199,6 +215,7 @@ export type TuiSurfaceRegistration = {
   commandDisplay: TuiCommandDisplay;
   sidebar: TuiSidebarPanelRegistration;
   compact: TuiCompactStatusRegistration;
+  promptBar: TuiPromptBarRegistration;
   announcements: TuiMaintainerAnnouncementsRegistration;
   homeBottom: boolean;
 };
@@ -206,6 +223,7 @@ export type TuiSurfaceRegistration = {
 export type TuiSessionQuotaSurfaces = {
   sidebar: SidebarPanelState;
   compact: CompactStatusState;
+  promptBar: PromptBarState;
 };
 
 export type TuiInitialRuntimeSeed = Readonly<
@@ -241,10 +259,15 @@ function isSessionCompactEnabled(runtime: QuotaRuntimeContext): boolean {
   );
 }
 
+function isSessionPromptBarEnabled(runtime: QuotaRuntimeContext): boolean {
+  return runtime.config.enabled && runtime.config.tuiPromptBar.enabled;
+}
+
 function buildDisabledSessionQuotaSurfaces(): TuiSessionQuotaSurfaces {
   return {
     sidebar: { status: "disabled", lines: [] },
     compact: { status: "disabled" },
+    promptBar: { status: "disabled" },
   };
 }
 
@@ -346,6 +369,53 @@ function buildSidebarPanelFromData(params: {
   };
 }
 
+function pickPromptBarEntry(data: QuotaRenderData | null): PromptBarEntry | undefined {
+  if (!data || !Array.isArray(data.entries)) {
+    return undefined;
+  }
+
+  let fallback: PromptBarEntry | undefined;
+  for (const entry of data.entries) {
+    if (!isPercentEntry(entry)) {
+      continue;
+    }
+    const kind = classifyQuotaWindowText(entry.label ?? "") ?? classifyQuotaWindowText(entry.name);
+    if (kind === "five_hour") {
+      return entry;
+    }
+    if (!fallback || (entry.percentRemaining ?? 0) < (fallback.percentRemaining ?? 0)) {
+      fallback = entry;
+    }
+  }
+  return fallback;
+}
+
+function buildPromptBarFromData(params: {
+  runtime: QuotaRuntimeContext;
+  result: CollectQuotaRenderDataResult;
+  enabled: boolean;
+}): PromptBarState {
+  if (!params.enabled) {
+    return { status: "disabled" };
+  }
+
+  if (params.result.selection?.waitingForCurrentSelection) {
+    return { status: "loading" };
+  }
+
+  const entry = pickPromptBarEntry(params.result.data);
+  if (!entry) {
+    return { status: "loading" };
+  }
+
+  return {
+    status: "ready",
+    entry,
+    percentDisplayMode: params.runtime.config.percentDisplayMode,
+    resetTimeDecimals: params.runtime.config.resetTimeDecimals,
+  };
+}
+
 async function collectTuiQuotaRenderData(params: {
   runtime: QuotaRuntimeContext;
   request: ReturnType<typeof createQuotaRuntimeRequestContext>;
@@ -411,6 +481,9 @@ export async function resolveTuiSurfaceRegistration(
       hasNativeProviderQuota,
       suppressedByNativeProviderQuota,
     },
+    promptBar: {
+      enabled: runtime.config.enabled && runtime.config.tuiPromptBar.enabled,
+    },
     announcements: {
       homeBottom: announcementHomeBottom,
     },
@@ -446,8 +519,9 @@ export async function loadTuiSessionQuotaSurfaces(params: {
 
   const sidebarEnabled = isSessionSidebarEnabled(runtime);
   const compactEnabled = isSessionCompactEnabled(runtime);
+  const promptBarEnabled = isSessionPromptBarEnabled(runtime);
 
-  if (!sidebarEnabled && !compactEnabled) {
+  if (!sidebarEnabled && !compactEnabled && !promptBarEnabled) {
     return buildDisabledSessionQuotaSurfaces();
   }
 
@@ -465,6 +539,11 @@ export async function loadTuiSessionQuotaSurfaces(params: {
       result,
       enabled: compactEnabled,
       formatStyle: compactFormatStyle,
+    }),
+    promptBar: buildPromptBarFromData({
+      runtime,
+      result,
+      enabled: promptBarEnabled,
     }),
   };
 }

--- a/src/lib/tui-runtime.ts
+++ b/src/lib/tui-runtime.ts
@@ -376,14 +376,17 @@ function pickPromptBarEntry(data: QuotaRenderData | null): PromptBarEntry | unde
 
   let fallback: PromptBarEntry | undefined;
   for (const entry of data.entries) {
-    if (!isPercentEntry(entry)) {
+    if (!isPercentEntry(entry) || !Number.isFinite(entry.percentRemaining)) {
       continue;
     }
     const kind = classifyQuotaWindowText(entry.label ?? "") ?? classifyQuotaWindowText(entry.name);
     if (kind === "five_hour") {
       return entry;
     }
-    if (!fallback || (entry.percentRemaining ?? 0) < (fallback.percentRemaining ?? 0)) {
+    if (
+      !fallback ||
+      entry.percentRemaining < (fallback.percentRemaining ?? Number.POSITIVE_INFINITY)
+    ) {
       fallback = entry;
     }
   }
@@ -403,14 +406,10 @@ function buildPromptBarFromData(params: {
     return { status: "loading" };
   }
 
-  const entry = pickPromptBarEntry(params.result.data);
-  if (!entry) {
-    return { status: "loading" };
-  }
-
+  const entry = pickPromptBarEntry(params.result.allWindowsData ?? params.result.data);
   return {
     status: "ready",
-    entry,
+    ...(entry ? { entry } : {}),
     percentDisplayMode: params.runtime.config.percentDisplayMode,
     resetTimeDecimals: params.runtime.config.resetTimeDecimals,
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,10 @@ export interface TuiCompactStatusConfig {
   formatStyle?: QuotaFormatStyle;
 }
 
+export interface TuiPromptBarConfig {
+  enabled: boolean;
+}
+
 export interface QuotaExportConfig {
   /** Whether to write the export file after each background refresh. Default: false. */
   enabled: boolean;
@@ -183,6 +187,9 @@ export interface QuotaToastConfig {
   /** Opt-in compact quota/status text for TUI prompt/home surfaces. */
   tuiCompactStatus: TuiCompactStatusConfig;
 
+  /** Quota progress bar rendered under the TUI prompt. */
+  tuiPromptBar: TuiPromptBarConfig;
+
   /** Bundled-only maintainer announcement surfaces. */
   maintainerAnnouncements: MaintainerAnnouncementsConfig;
 
@@ -253,6 +260,9 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
     sessionPrompt: true,
     suppressWhenNativeProviderQuota: true,
     maxWidth: 96,
+  },
+  tuiPromptBar: {
+    enabled: true,
   },
   maintainerAnnouncements: {
     enabled: true,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -262,7 +262,7 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
     maxWidth: 96,
   },
   tuiPromptBar: {
-    enabled: true,
+    enabled: false,
   },
   maintainerAnnouncements: {
     enabled: true,

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -546,7 +546,7 @@ function buildPromptBarParts(params: {
   return {
     label: windowLabel,
     barText,
-    meta: [percent.replace(/\s+left$/u, ""), reset].filter(Boolean).join(" · "),
+    meta: [percent.replace(/\s+left$/u, ""), reset].filter(Boolean).join(" | "),
   };
 }
 

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -8,18 +8,21 @@ import type {
 } from "@opencode-ai/plugin/tui";
 import type { JSX } from "@opentui/solid";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
+import { formatDisplayedPercentLabel, formatResetCountdown } from "./lib/format-utils.js";
 import {
   buildQuotaDialogCommandOutput,
   QUOTA_DIALOG_COMMANDS,
   type QuotaDialogCommandId,
   type QuotaDialogCommandSpec,
 } from "./lib/quota-dialog-commands.js";
+import { extractSingleWindowWindowLabel } from "./lib/quota-entry-display.js";
 import type { SessionTokenError } from "./lib/quota-status.js";
 import { disposeQuotaTelemetryOwner } from "./lib/quota-telemetry.js";
 import { getSidebarBodyLineColor } from "./lib/tui-line-style.js";
 import type {
   CompactStatusState,
   HomeBottomState,
+  PromptBarState,
   SidebarPanelState,
 } from "./lib/tui-panel-state.js";
 import {
@@ -65,6 +68,7 @@ type SessionQuotaResource = {
   sessionID: string;
   sidebar: () => SidebarPanelState;
   compact: () => CompactStatusState;
+  promptBar: () => PromptBarState;
   retain: () => SessionQuotaResource;
   release: () => void;
 };
@@ -108,6 +112,7 @@ const FALLBACK_SURFACE_REGISTRATION: TuiSurfaceRegistration = {
     hasNativeProviderQuota: false,
     suppressedByNativeProviderQuota: false,
   },
+  promptBar: { enabled: false },
   announcements: { homeBottom: false },
   homeBottom: false,
 };
@@ -168,6 +173,7 @@ function createSessionQuotaResource(
     lines: [],
   });
   const [compact, setCompact] = createSignal<CompactStatusState>({ status: "loading" });
+  const [promptBar, setPromptBar] = createSignal<PromptBarState>({ status: "loading" });
 
   let loadOrdinal = 0;
   const lifecycle = createTuiRefreshLifecycle({
@@ -183,6 +189,7 @@ function createSessionQuotaResource(
     apply: (next) => {
       setSidebar(next.sidebar);
       setCompact(next.compact);
+      setPromptBar(next.promptBar ?? { status: "loading" });
     },
     intervalMs: REFRESH_INTERVAL_MS,
     eventRefreshDelaysMs: EVENT_REFRESH_DELAYS_MS,
@@ -220,6 +227,7 @@ function createSessionQuotaResource(
     sessionID,
     sidebar,
     compact,
+    promptBar,
     retain: () => {
       lifecycle.retain();
       return resource;
@@ -443,6 +451,166 @@ function SessionPromptWithCompactStatus(props: {
         ref={props.promptRef}
       />
       <CompactStatusLine api={props.api} panel={panel} justifyContent="flex-end" />
+    </box>
+  );
+}
+
+const PROMPT_BAR_WIDTH = 12;
+
+function shouldRenderPromptBar(
+  bar: PromptBarState,
+): bar is Extract<PromptBarState, { status: "ready" }> {
+  return bar.status === "ready" && Boolean(bar.entry);
+}
+
+function useSessionRunning(api: TuiPluginApi, sessionID: () => string): () => boolean {
+  const [running, setRunning] = createSignal(false);
+  createEffect(() => {
+    const id = sessionID();
+    if (!id) {
+      setRunning(false);
+      return;
+    }
+    const update = () => {
+      try {
+        const sessionState = api.state.session as {
+          status?: (sessionID: string) => { type?: string } | undefined;
+        };
+        const status = sessionState.status?.(id);
+        setRunning(!!status && status.type !== "idle");
+      } catch {
+        setRunning(false);
+      }
+    };
+    update();
+    const disposers = [
+      api.event.on("session.status", (event) => {
+        if (event.properties?.sessionID === id) {
+          update();
+        }
+      }),
+      api.event.on("session.updated", (event) => {
+        if (event.properties?.info?.id === id) {
+          update();
+        }
+      }),
+    ];
+    onCleanup(() => {
+      for (const dispose of disposers) {
+        if (typeof dispose === "function") {
+          dispose();
+        }
+      }
+    });
+  });
+  return running;
+}
+
+function buildPromptBarParts(params: {
+  bar: () => PromptBarState;
+  running: () => boolean;
+  phase: () => number;
+}): { label: string; barText: string; meta: string } | undefined {
+  const bar = params.bar();
+  if (!shouldRenderPromptBar(bar)) return undefined;
+  const entry = bar.entry;
+  const windowLabel =
+    extractSingleWindowWindowLabel(entry.label ?? "") ??
+    extractSingleWindowWindowLabel(entry.name ?? "") ??
+    "Quota";
+  const percent = formatDisplayedPercentLabel(
+    entry.percentRemaining ?? 0,
+    bar.percentDisplayMode ?? "remaining",
+  );
+  const reset = entry.resetTimeIso
+    ? formatResetCountdown(entry.resetTimeIso, {
+        compactRounded: true,
+        decimals: bar.resetTimeDecimals,
+      })
+    : "";
+  const p = Math.max(0, Math.min(100, Math.round(entry.percentRemaining ?? 0)));
+  const filled = Math.round((p / 100) * PROMPT_BAR_WIDTH);
+  const empty = PROMPT_BAR_WIDTH - filled;
+  let barText = "█".repeat(filled) + "░".repeat(empty);
+  if (params.running() && filled > 0) {
+    const cells = Array(filled).fill("▓");
+    const center = params.phase() % filled;
+    const gradient = ["▒", "▓", "█", "▓", "▒"];
+    for (let offset = -2; offset <= 2; offset++) {
+      const position = (center + offset + filled) % filled;
+      cells[position] = gradient[offset + 2];
+    }
+    barText = cells.join("") + "░".repeat(empty);
+  }
+  return {
+    label: windowLabel,
+    barText,
+    meta: [percent.replace(/\s+left$/u, ""), reset].filter(Boolean).join(" · "),
+  };
+}
+
+function PromptQuotaHint(props: {
+  api: TuiPluginApi;
+  bar: () => PromptBarState;
+  running: () => boolean;
+  phase: () => number;
+}) {
+  const parts = () => buildPromptBarParts(props);
+  const barColor = () => props.api.theme.current.textMuted;
+  const label = () => parts()?.label ?? "";
+  const bar = () => parts()?.barText ?? "";
+  const meta = () => parts()?.meta ?? "";
+  const barLeft = () => 26;
+
+  return (
+    <Show when={parts()}>
+      <box position="absolute" left={barLeft()} bottom={0} zIndex={100} flexDirection="row" gap={1}>
+        <text fg={props.api.theme.current.textMuted} wrapMode="none">
+          {label()}
+        </text>
+        <text fg={barColor()} wrapMode="none">
+          {bar()}
+        </text>
+        <text fg={props.api.theme.current.textMuted} wrapMode="none">
+          {meta()}
+        </text>
+      </box>
+    </Show>
+  );
+}
+
+function SessionQuotaPromptBar(props: {
+  api: TuiPluginApi;
+  sessionID: string;
+  initialLoads?: TuiInitialLoadCoordinator;
+  visible?: boolean;
+  disabled?: boolean;
+  onSubmit?: () => void;
+  promptRef?: TuiPromptRefCallback;
+}) {
+  const resource = useSessionQuotaResource(props.api, () => props.sessionID, props.initialLoads);
+  const promptBar = () => resource().promptBar();
+  const running = useSessionRunning(props.api, () => props.sessionID);
+  const [phase, setPhase] = createSignal(0);
+  createEffect(() => {
+    if (!running()) {
+      setPhase(0);
+      return;
+    }
+    const interval = setInterval(() => setPhase((p) => p + 1), 160);
+    onCleanup(() => clearInterval(interval));
+  });
+
+  return (
+    <box gap={0}>
+      <props.api.ui.Prompt
+        sessionID={props.sessionID}
+        visible={props.visible}
+        disabled={props.disabled}
+        onSubmit={props.onSubmit}
+        ref={props.promptRef}
+      />
+      <PromptQuotaHint api={props.api} bar={promptBar} running={running} phase={phase} />
     </box>
   );
 }
@@ -740,7 +908,21 @@ function registerStableTuiSlots(api: TuiPluginApi, current: () => TuiRegistratio
         },
       ) {
         const state = current();
-        if (state.status !== "active" || !state.registration.compact.sessionPrompt) return null;
+        if (state.status !== "active") return null;
+        if (state.registration.promptBar.enabled) {
+          return (
+            <SessionQuotaPromptBar
+              api={api}
+              sessionID={props.session_id}
+              initialLoads={state.initialLoads}
+              visible={props.visible}
+              disabled={props.disabled}
+              onSubmit={props.on_submit}
+              promptRef={props.ref}
+            />
+          );
+        }
+        if (!state.registration.compact.sessionPrompt) return null;
         return (
           <SessionPromptWithCompactStatus
             api={api}

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -477,7 +477,7 @@ function useSessionRunning(api: TuiPluginApi, sessionID: () => string): () => bo
           status?: (sessionID: string) => { type?: string } | undefined;
         };
         const status = sessionState.status?.(id);
-        setRunning(!!status && status.type !== "idle");
+        setRunning(status?.type === "busy" || status?.type === "retry");
       } catch {
         setRunning(false);
       }
@@ -514,6 +514,7 @@ function buildPromptBarParts(params: {
   const bar = params.bar();
   if (!shouldRenderPromptBar(bar)) return undefined;
   const entry = bar.entry;
+  if (!entry) return undefined;
   const windowLabel =
     extractSingleWindowWindowLabel(entry.label ?? "") ??
     extractSingleWindowWindowLabel(entry.name ?? "") ??
@@ -560,11 +561,10 @@ function PromptQuotaHint(props: {
   const label = () => parts()?.label ?? "";
   const bar = () => parts()?.barText ?? "";
   const meta = () => parts()?.meta ?? "";
-  const barLeft = () => 26;
 
   return (
     <Show when={parts()}>
-      <box position="absolute" left={barLeft()} bottom={0} zIndex={100} flexDirection="row" gap={1}>
+      <box flexDirection="row" justifyContent="flex-end" gap={1}>
         <text fg={props.api.theme.current.textMuted} wrapMode="none">
           {label()}
         </text>
@@ -593,7 +593,7 @@ function SessionQuotaPromptBar(props: {
   const running = useSessionRunning(props.api, () => props.sessionID);
   const [phase, setPhase] = createSignal(0);
   createEffect(() => {
-    if (!running()) {
+    if (!running() || !shouldRenderPromptBar(promptBar())) {
       setPhase(0);
       return;
     }

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -379,18 +379,46 @@ describe("loadConfig", () => {
     expect(withLegacyCompactToastStyle.meta.settingSources).toEqual({});
   });
 
+  it("defaults tuiPromptBar off and accepts validated opt-in overrides", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.tuiPromptBar).toEqual({ enabled: false });
+    expect(defaults.config.tuiPromptBar).not.toBe(DEFAULT_CONFIG.tuiPromptBar);
+
+    const enabled = await loadSdkConfig({ tuiPromptBar: { enabled: true } });
+    expect(enabled.config.tuiPromptBar).toEqual({ enabled: true });
+    expect(enabled.meta.settingSources).toEqual({
+      "tuiPromptBar.enabled": "client.config.get",
+    });
+
+    const disabled = await loadSdkConfig({ tuiPromptBar: { enabled: false } });
+    expect(disabled.config.tuiPromptBar).toEqual({ enabled: false });
+    expect(disabled.meta.settingSources).toEqual({
+      "tuiPromptBar.enabled": "client.config.get",
+    });
+
+    const invalidValue = await loadSdkConfig({ tuiPromptBar: { enabled: "yes" } });
+    expect(invalidValue.config.tuiPromptBar).toEqual({ enabled: false });
+    expect(invalidValue.meta.settingSources).toEqual({});
+
+    const invalidNested = await loadSdkConfig({ tuiPromptBar: true });
+    expect(invalidNested.config.tuiPromptBar).toEqual({ enabled: false });
+    expect(invalidNested.meta.settingSources).toEqual({});
+  });
+
   it("deep-clones default config when no config source exists", async () => {
     const meta = createLoadConfigMeta();
     const first = await loadConfig(undefined, meta, { cwd: isolatedCwd });
     first.tuiSidebarPanel.enabled = false;
     first.tuiCompactStatus.enabled = true;
     first.tuiCompactStatus.maxWidth = 1;
+    first.tuiPromptBar.enabled = true;
     first.maintainerAnnouncements.enabled = false;
     first.maintainerAnnouncements.home = false;
 
     const second = await loadConfig(undefined, undefined, { cwd: isolatedCwd });
     expect(second.tuiSidebarPanel).toEqual(DEFAULT_CONFIG.tuiSidebarPanel);
     expect(second.tuiCompactStatus).toEqual(DEFAULT_CONFIG.tuiCompactStatus);
+    expect(second.tuiPromptBar).toEqual(DEFAULT_CONFIG.tuiPromptBar);
     expect(DEFAULT_CONFIG.tuiSidebarPanel).toEqual({ enabled: true });
     expect(DEFAULT_CONFIG.tuiCompactStatus).toEqual({
       enabled: false,
@@ -399,6 +427,7 @@ describe("loadConfig", () => {
       suppressWhenNativeProviderQuota: true,
       maxWidth: 96,
     });
+    expect(DEFAULT_CONFIG.tuiPromptBar).toEqual({ enabled: false });
     expect(second.maintainerAnnouncements).toEqual(DEFAULT_CONFIG.maintainerAnnouncements);
     expect(DEFAULT_CONFIG.maintainerAnnouncements).toEqual({
       enabled: true,

--- a/tests/tui-runtime.test.ts
+++ b/tests/tui-runtime.test.ts
@@ -851,6 +851,7 @@ describe("tui runtime helpers", () => {
               sessionPrompt: true,
               suppressWhenNativeProviderQuota: true,
             },
+            tuiPromptBar: { enabled: true },
             maintainerAnnouncements: {
               home: false,
             },
@@ -948,6 +949,7 @@ describe("tui runtime helpers", () => {
               sessionPrompt: true,
               suppressWhenNativeProviderQuota: true,
             },
+            tuiPromptBar: { enabled: true },
           },
         },
       }),
@@ -1251,6 +1253,7 @@ describe("tui runtime helpers", () => {
               sessionPrompt: true,
               maxWidth: 42,
             },
+            tuiPromptBar: { enabled: true },
           },
         },
       }),
@@ -1357,6 +1360,119 @@ describe("tui runtime helpers", () => {
     expect(buildCompactQuotaStatusLine).not.toHaveBeenCalled();
   });
 
+  it("builds an opt-in prompt bar from the five-hour all-windows entry", async () => {
+    writeFileSync(
+      join(worktreeDir, "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: true,
+            percentDisplayMode: "used",
+            resetTimeDecimals: 2,
+            tuiSidebarPanel: { enabled: false },
+            tuiCompactStatus: { enabled: false },
+            tuiPromptBar: { enabled: true },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    collectQuotaRenderData.mockResolvedValue({
+      active: [],
+      data: {
+        entries: [{ name: "Copilot weekly", percentRemaining: 4 }],
+        errors: [],
+        sessionTokens: undefined,
+      },
+      allWindowsData: {
+        entries: [
+          { name: "Copilot weekly", percentRemaining: 4 },
+          { name: "Copilot 5h", percentRemaining: 72, resetTimeIso: "2026-08-09T12:00:00Z" },
+        ],
+        errors: [],
+        sessionTokens: undefined,
+      },
+    });
+
+    const surfaces = await loadTuiSessionQuotaSurfaces({
+      api: {
+        state: {
+          provider: [],
+          path: { worktree: worktreeDir, directory: nestedDir },
+          session: { messages: () => [] },
+        },
+        client: {},
+      } as any,
+      sessionID: "prompt-bar-five-hour",
+    });
+
+    expect(surfaces).toEqual({
+      sidebar: { status: "disabled", lines: [] },
+      compact: { status: "disabled" },
+      promptBar: {
+        status: "ready",
+        entry: {
+          name: "Copilot 5h",
+          percentRemaining: 72,
+          resetTimeIso: "2026-08-09T12:00:00Z",
+        },
+        percentDisplayMode: "used",
+        resetTimeDecimals: 2,
+      },
+    });
+    expect(collectQuotaRenderData).toHaveBeenCalledOnce();
+  });
+
+  it("falls back to the lowest finite prompt-bar percentage", async () => {
+    writeFileSync(
+      join(worktreeDir, "opencode.json"),
+      JSON.stringify({
+        experimental: {
+          quotaToast: {
+            enabled: true,
+            tuiSidebarPanel: { enabled: false },
+            tuiCompactStatus: { enabled: false },
+            tuiPromptBar: { enabled: true },
+          },
+        },
+      }),
+      "utf8",
+    );
+
+    collectQuotaRenderData.mockResolvedValue({
+      active: [],
+      data: {
+        entries: [
+          { name: "Balance", value: "$10" },
+          { name: "Copilot weekly", percentRemaining: 44 },
+          { name: "Copilot monthly", percentRemaining: 18 },
+        ],
+        errors: [],
+        sessionTokens: undefined,
+      },
+    });
+
+    const surfaces = await loadTuiSessionQuotaSurfaces({
+      api: {
+        state: {
+          provider: [],
+          path: { worktree: worktreeDir, directory: nestedDir },
+          session: { messages: () => [] },
+        },
+        client: {},
+      } as any,
+      sessionID: "prompt-bar-lowest",
+    });
+
+    expect(surfaces.promptBar).toEqual({
+      status: "ready",
+      entry: { name: "Copilot monthly", percentRemaining: 18 },
+      percentDisplayMode: "remaining",
+      resetTimeDecimals: undefined,
+    });
+  });
+
   it("loads sidebar and compact session surfaces from one collection", async () => {
     writeFileSync(
       join(worktreeDir, "opencode.json"),
@@ -1371,6 +1487,7 @@ describe("tui runtime helpers", () => {
               sessionPrompt: true,
               maxWidth: 42,
             },
+            tuiPromptBar: { enabled: true },
           },
         },
       }),
@@ -1467,6 +1584,7 @@ describe("tui runtime helpers", () => {
               enabled: true,
               sessionPrompt: true,
             },
+            tuiPromptBar: { enabled: true },
           },
         },
       }),
@@ -1495,7 +1613,11 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "ready", lines: [] },
       compact: { status: "ready", text: "Quota unavailable" },
-      promptBar: { status: "loading" },
+      promptBar: {
+        status: "ready",
+        percentDisplayMode: "remaining",
+        resetTimeDecimals: undefined,
+      },
     });
     expect(buildCompactQuotaStatusLine).not.toHaveBeenCalled();
   });
@@ -1512,6 +1634,7 @@ describe("tui runtime helpers", () => {
               enabled: true,
               sessionPrompt: true,
             },
+            tuiPromptBar: { enabled: true },
           },
         },
       }),

--- a/tests/tui-runtime.test.ts
+++ b/tests/tui-runtime.test.ts
@@ -871,6 +871,9 @@ describe("tui runtime helpers", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: {
+        enabled: true,
+      },
       announcements: {
         homeBottom: false,
       },
@@ -980,6 +983,9 @@ describe("tui runtime helpers", () => {
         sessionPrompt: false,
         hasNativeProviderQuota: true,
         suppressedByNativeProviderQuota: true,
+      },
+      promptBar: {
+        enabled: true,
       },
       announcements: {
         homeBottom: true,
@@ -1285,6 +1291,12 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "disabled", lines: [] },
       compact: { status: "ready", text: "Compact quota" },
+      promptBar: {
+        status: "ready",
+        entry: { name: "Copilot 5h", percentRemaining: 18 },
+        percentDisplayMode: "used",
+        resetTimeDecimals: undefined,
+      },
     });
     expect(collectQuotaRenderData).toHaveBeenCalledOnce();
     expect(buildSidebarQuotaPanelLines).not.toHaveBeenCalled();
@@ -1308,6 +1320,9 @@ describe("tui runtime helpers", () => {
             tuiCompactStatus: {
               enabled: true,
               sessionPrompt: false,
+            },
+            tuiPromptBar: {
+              enabled: false,
             },
           },
         },
@@ -1335,6 +1350,7 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "disabled", lines: [] },
       compact: { status: "disabled" },
+      promptBar: { status: "disabled" },
     });
     expect(collectQuotaRenderData).not.toHaveBeenCalled();
     expect(buildSidebarQuotaPanelLines).not.toHaveBeenCalled();
@@ -1403,6 +1419,12 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "ready", lines: ["Sidebar quota"] },
       compact: { status: "ready", text: "Compact quota" },
+      promptBar: {
+        status: "ready",
+        entry: { name: "Copilot 5h", percentRemaining: 18 },
+        percentDisplayMode: "used",
+        resetTimeDecimals: undefined,
+      },
     });
     expect(collectQuotaRenderData).toHaveBeenCalledOnce();
     expect(collectQuotaRenderData).toHaveBeenCalledWith(
@@ -1473,6 +1495,7 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "ready", lines: [] },
       compact: { status: "ready", text: "Quota unavailable" },
+      promptBar: { status: "loading" },
     });
     expect(buildCompactQuotaStatusLine).not.toHaveBeenCalled();
   });
@@ -1527,6 +1550,7 @@ describe("tui runtime helpers", () => {
     expect(surfaces).toEqual({
       sidebar: { status: "loading", lines: [] },
       compact: { status: "loading" },
+      promptBar: { status: "loading" },
     });
     expect(buildSidebarQuotaPanelLines).not.toHaveBeenCalled();
     expect(buildCompactQuotaStatusLine).not.toHaveBeenCalled();

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -1691,23 +1691,45 @@ describe("tui plugin smoke", () => {
       homeBottom: false,
     });
 
+    loadTuiSessionQuotaSurfaces.mockResolvedValueOnce({
+      sidebar: { status: "disabled", lines: [] },
+      compact: { status: "disabled" },
+      promptBar: {
+        status: "ready",
+        entry: { name: "Copilot 5h", percentRemaining: 50 },
+        percentDisplayMode: "remaining",
+      },
+    });
+
     await startTui(plugin, api);
 
     const compactRegistration = registered.find((registration) => registration.order === 90);
     expect(compactRegistration).toBeDefined();
 
-    compactRegistration!.slots.session_prompt(
-      {},
-      {
-        session_id: "session-1",
-        visible: false,
-        disabled: true,
-        on_submit: onSubmit,
-        ref,
-      },
-    );
+    const promptProps = {
+      session_id: "session-1",
+      visible: false,
+      disabled: true,
+      on_submit: onSubmit,
+      ref,
+    };
+    compactRegistration!.slots.session_prompt({}, promptProps);
+    await flushPromises();
+    const rendered = compactRegistration!.slots.session_prompt({}, promptProps) as any;
 
-    expect(api.ui.Prompt).toHaveBeenCalledTimes(1);
+    const hint = rendered.props.children[1];
+    expect(hint.type).toBe("box");
+    expect(hint.props).toMatchObject({
+      flexDirection: "row",
+      justifyContent: "flex-end",
+      gap: 1,
+    });
+    expect(hint.props).not.toHaveProperty("position");
+    expect(hint.props).not.toHaveProperty("left");
+    expect(hint.props).not.toHaveProperty("bottom");
+    expect(hint.props.children[1].props.children).toHaveLength(12);
+
+    expect(api.ui.Prompt).toHaveBeenCalledTimes(2);
     expect(api.ui.Prompt).toHaveBeenCalledWith({
       sessionID: "session-1",
       visible: false,

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -1696,7 +1696,11 @@ describe("tui plugin smoke", () => {
       compact: { status: "disabled" },
       promptBar: {
         status: "ready",
-        entry: { name: "Copilot 5h", percentRemaining: 50 },
+        entry: {
+          name: "Copilot 5h",
+          percentRemaining: 50,
+          resetTimeIso: "2099-01-01T00:00:00.000Z",
+        },
         percentDisplayMode: "remaining",
       },
     });
@@ -1728,6 +1732,8 @@ describe("tui plugin smoke", () => {
     expect(hint.props).not.toHaveProperty("left");
     expect(hint.props).not.toHaveProperty("bottom");
     expect(hint.props.children[1].props.children).toHaveLength(12);
+    expect(hint.props.children[2].props.children).toContain(" | ");
+    expect(hint.props.children[2].props.children).not.toContain("·");
 
     expect(api.ui.Prompt).toHaveBeenCalledTimes(2);
     expect(api.ui.Prompt).toHaveBeenCalledWith({

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -323,6 +323,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: true,
     });
@@ -363,6 +365,8 @@ describe("tui plugin smoke", () => {
             hasNativeProviderQuota: false,
             suppressedByNativeProviderQuota: false,
           },
+          promptBar: { enabled: true },
+
           announcements: { homeBottom: false },
           homeBottom: true,
         });
@@ -418,6 +422,8 @@ describe("tui plugin smoke", () => {
             hasNativeProviderQuota: false,
             suppressedByNativeProviderQuota: false,
           },
+          promptBar: { enabled: true },
+
           announcements: { homeBottom: false },
           homeBottom: false,
         });
@@ -462,6 +468,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -491,6 +499,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -541,6 +551,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -583,6 +595,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: true,
     });
@@ -637,6 +651,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -678,6 +694,8 @@ describe("tui plugin smoke", () => {
           hasNativeProviderQuota: false,
           suppressedByNativeProviderQuota: false,
         },
+        promptBar: { enabled: true },
+
         announcements: { homeBottom: false },
         homeBottom: false,
       });
@@ -750,6 +768,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -788,6 +808,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -827,6 +849,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -863,6 +887,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -947,6 +973,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -989,6 +1017,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: false },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1018,6 +1048,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1045,6 +1077,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1081,6 +1115,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1137,6 +1173,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1195,6 +1233,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1221,6 +1261,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1278,6 +1320,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1319,6 +1363,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });
@@ -1357,6 +1403,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: true,
     });
@@ -1400,6 +1448,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1423,6 +1473,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1450,6 +1502,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1535,6 +1589,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: true },
       homeBottom: true,
     });
@@ -1593,6 +1649,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: true,
     });
@@ -1627,6 +1685,8 @@ describe("tui plugin smoke", () => {
         hasNativeProviderQuota: false,
         suppressedByNativeProviderQuota: false,
       },
+      promptBar: { enabled: true },
+
       announcements: { homeBottom: false },
       homeBottom: false,
     });

--- a/tests/tui-startup-runtime-resolution.test.ts
+++ b/tests/tui-startup-runtime-resolution.test.ts
@@ -272,6 +272,7 @@ function writeGenerationConfig(worktreeDir: string, generation: number): void {
           export: { enabled: false },
           maintainerAnnouncements: { enabled: false, home: false },
           tuiSidebarPanel: { enabled: true },
+          tuiPromptBar: { enabled: false },
           tuiCompactStatus: {
             enabled: true,
             homeBottom: true,


### PR DESCRIPTION
## Summary

Renders a compact quota progress bar directly under the TUI prompt. The bar shows the single-window quota entry (preferring the 5h window), remaining percent, and a reset countdown, with a subtle animation while the session is running. It replaces the compact status line under the prompt and falls back to that line when disabled.

This was originally prototyped locally by hand-editing the installed plugin bundle; this PR ports the feature to the source tree and adds the missing \	uiPromptBar\ config plumbing.

## Linked Issue

No issue exists yet; this PR is opened alongside the feature (issue-first per CONTRIBUTING is fine to open in parallel). Scope: new opt-in TUI surface, default \	rue\, configurable via \quotaToast.tuiPromptBar.enabled\.

## What changed

- \src/lib/types.ts\ / \src/lib/config.ts\: new \	uiPromptBar\ config key (default \{ enabled: true }\) with patch extraction, apply, and setting-source tracking. Also deep-clones the new nested key in \cloneConfig\ to avoid mutating \DEFAULT_CONFIG\.
- \src/lib/tui-panel-state.ts\: \PromptBarState\ / \PromptBarEntry\ surface types.
- \src/lib/tui-runtime.ts\: \pickPromptBarEntry\ (prefers the 5h window entry, falls back to the lowest remaining percent), \uildPromptBarFromData\, and wiring through \loadTuiSessionQuotaSurfaces\ / \esolveTuiSurfaceRegistration\.
- \src/tui.tsx\: \PromptQuotaHint\ / \SessionQuotaPromptBar\ render the 12-cell bar (label + percent + reset countdown, animated while running). The \session_prompt\ slot prefers the bar when \promptBar.enabled\, otherwise keeps the existing compact status line behavior; the fallback registration stays conservative.
- Tests updated in \	ests/tui-runtime.test.ts\, \	ests/tui-smoke.test.ts\, \	ests/tui-startup-runtime-resolution.test.ts\.
- Docs: \docs/readme/configuration.md\, \docs/readme/manual-install.md\.

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.15 (TUI)
- Why this version is relevant to the fix: the feature targets the TUI plugin surface (\session_prompt\ slot, \pi.state.session.status\), which is stable across recent releases.

## Quality Checklist

- [x] I ran \pnpm run typecheck\
- [x] I ran \pnpm run build\
- [x] I ran \pnpm test\ (Windows: remaining failures are pre-existing environment issues, verified unchanged with and without this PR)
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] For provider changes, I followed Provider Changes, or this does not apply (no provider changes)