### PR TITLE
fix(anthropic): read quota OAuth token from OpenCode auth.json first

### DIFF
--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -370,7 +370,7 @@ Official references: [AI Credit billing reports](https://docs.github.com/en/rest
 
 ### Anthropic (Claude)
 
-Install Claude Code, authenticate it, and make sure `claude` is on your `PATH`:
+OpenCode's existing Anthropic OAuth credential is sufficient; a separate Claude Code installation is not required. To use Claude Code as the local quota source and credential fallback, install it, authenticate it, and make sure `claude` is on your `PATH`:
 
 ```bash
 claude auth login

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -379,6 +379,8 @@ claude auth status
 
 If Claude lives at a custom path, set `anthropicBinaryPath` in `opencode-quota/quota-toast.json`.
 
+When Claude Code does not expose quota windows itself, quota is read from Anthropic's OAuth usage endpoint using the first usable access token: OpenCode's own `anthropic` OAuth credential from `auth.json`, then Claude Code's credentials. `/quota_status` reports which store answered as `oauth_credential_source`.
+
 <a id="cursor"></a>
 
 ### Cursor

--- a/src/lib/anthropic-auth.ts
+++ b/src/lib/anthropic-auth.ts
@@ -1,0 +1,50 @@
+/**
+ * OpenCode-managed Anthropic OAuth credentials.
+ *
+ * Reads the `anthropic` OAuth entry from OpenCode's own auth.json. This is the
+ * credential OpenCode refreshes for Anthropic subscription models, so it stays
+ * usable even when a separately installed Claude Code has stale credentials.
+ */
+
+import { readAuthFileCached } from "./opencode-auth.js";
+import type { AuthData } from "./types.js";
+
+export const DEFAULT_ANTHROPIC_AUTH_CACHE_MAX_AGE_MS = 5_000;
+
+export type ResolvedAnthropicOAuth =
+  | { state: "none" }
+  | { state: "expired"; expiresAt: number }
+  | { state: "configured"; accessToken: string; expiresAt?: number };
+
+export function resolveAnthropicOAuth(
+  auth: AuthData | null | undefined,
+  options: { nowMs?: number } = {},
+): ResolvedAnthropicOAuth {
+  const entry = auth?.anthropic;
+  if (!entry || entry.type !== "oauth") {
+    return { state: "none" };
+  }
+
+  const accessToken = typeof entry.access === "string" ? entry.access.trim() : "";
+  if (!accessToken) {
+    return { state: "none" };
+  }
+
+  const expiresAt = typeof entry.expires === "number" ? entry.expires : undefined;
+  if (expiresAt !== undefined && expiresAt <= (options.nowMs ?? Date.now())) {
+    return { state: "expired", expiresAt };
+  }
+
+  return expiresAt === undefined
+    ? { state: "configured", accessToken }
+    : { state: "configured", accessToken, expiresAt };
+}
+
+export async function resolveAnthropicOAuthCached(params?: {
+  maxAgeMs?: number;
+}): Promise<ResolvedAnthropicOAuth> {
+  const auth = await readAuthFileCached({
+    maxAgeMs: Math.max(0, params?.maxAgeMs ?? DEFAULT_ANTHROPIC_AUTH_CACHE_MAX_AGE_MS),
+  });
+  return resolveAnthropicOAuth(auth);
+}

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -566,7 +566,9 @@ async function readClaudeCredentialsAccessTokenFromFile(): Promise<ClaudeCredent
   }
 }
 
-async function readAnthropicOAuthAccessToken(): Promise<AnthropicCredentialsAccess> {
+async function readAnthropicOAuthAccessToken(options: {
+  includeClaudeCredentials: boolean;
+}): Promise<AnthropicCredentialsAccess> {
   const locationsChecked: string[] = [];
   const unavailableDetails: string[] = [];
 
@@ -577,6 +579,10 @@ async function readAnthropicOAuthAccessToken(): Promise<AnthropicCredentialsAcce
       accessToken: opencodeCredentials.accessToken,
       source: "opencode-auth",
     };
+  }
+
+  if (!options.includeClaudeCredentials) {
+    return { state: "unavailable" };
   }
 
   const keychainCredentials = await readClaudeCredentialsAccessTokenFromMacOSKeychain();
@@ -1192,12 +1198,18 @@ export async function getAnthropicDiagnostics(
 
   const inFlight = (async () => {
     const localDiagnostics = await getCachedAnthropicLocalDiagnostics({ binaryPath });
-    if (localDiagnostics.authStatus !== "authenticated" || localDiagnostics.localQuota) {
+    if (localDiagnostics.localQuota) {
       return mapLocalDiagnosticsToAnthropicDiagnostics(localDiagnostics);
     }
 
-    const credentials = await readAnthropicOAuthAccessToken();
+    const credentials = await readAnthropicOAuthAccessToken({
+      includeClaudeCredentials: localDiagnostics.authStatus === "authenticated",
+    });
     if (credentials.state !== "configured") {
+      if (localDiagnostics.authStatus !== "authenticated") {
+        return mapLocalDiagnosticsToAnthropicDiagnostics(localDiagnostics);
+      }
+
       const diagnostics: AnthropicDiagnostics = {
         installed: localDiagnostics.installed,
         version: localDiagnostics.version,
@@ -1272,6 +1284,15 @@ export async function getAnthropicDiagnostics(
 export async function hasAnthropicCredentialsConfigured(
   options: AnthropicProbeOptions = {},
 ): Promise<boolean> {
+  try {
+    const opencodeCredentials = await resolveAnthropicOAuthCached();
+    if (opencodeCredentials.state === "configured") {
+      return true;
+    }
+  } catch {
+    // Fall back to the existing local Claude CLI probe.
+  }
+
   try {
     const diagnostics = await getCachedAnthropicLocalDiagnostics(options);
     return diagnostics.installed && diagnostics.authStatus === "authenticated";

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -3,8 +3,9 @@
  *
  * Uses the local Claude CLI/runtime to detect install/auth state first. When
  * Claude auth is confirmed but local quota windows are missing, it falls back
- * to Claude OAuth credentials (macOS Keychain first, then the local credentials
- * file) and Anthropic's OAuth usage endpoint.
+ * to Anthropic's OAuth usage endpoint using the first usable OAuth access
+ * token: OpenCode's own auth.json, then Claude OAuth credentials (macOS
+ * Keychain first, then the local credentials file).
  */
 
 import { execFile } from "child_process";
@@ -13,6 +14,7 @@ import { readFile } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 
+import { resolveAnthropicOAuthCached } from "./anthropic-auth.js";
 import { sanitizeDisplaySnippet, sanitizeDisplayText } from "./display-sanitize.js";
 import { fetchWithTimeout } from "./http.js";
 
@@ -27,7 +29,7 @@ const CLAUDE_CODE_CREDENTIALS_SERVICE = "Claude Code-credentials";
 const CLAUDE_NO_LOCAL_QUOTA_MESSAGE =
   "Claude CLI auth detected, but local quota windows were not exposed.";
 const ANTHROPIC_NO_QUOTA_MESSAGE =
-  "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback.";
+  "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.";
 
 export interface AnthropicQuotaWindow {
   utilization?: number;
@@ -64,6 +66,7 @@ export type AnthropicAuthStatus = "authenticated" | "unauthenticated" | "unknown
 export type AnthropicQuotaSource =
   | "claude-auth-status-json"
   | "claude-credentials-oauth-api"
+  | "opencode-auth-oauth-api"
   | "none";
 
 export interface AnthropicDiagnostics {
@@ -72,6 +75,8 @@ export interface AnthropicDiagnostics {
   authStatus: AnthropicAuthStatus;
   quotaSupported: boolean;
   quotaSource: AnthropicQuotaSource;
+  /** Credential store that supplied the OAuth token for the usage probe. */
+  oauthCredentialSource?: AnthropicCredentialSource;
   checkedCommands: string[];
   message?: string;
   quota?: AnthropicQuotaResult;
@@ -123,10 +128,14 @@ type AnthropicOAuthCooldown = {
   blockedUntilMs: number;
 };
 
-type ClaudeCredentialsAccess =
+/** Which credential store provided the OAuth access token used for the usage probe. */
+export type AnthropicCredentialSource = "opencode-auth" | "claude-credentials";
+
+type AnthropicCredentialsAccess =
   | {
       state: "configured";
       accessToken: string;
+      source: AnthropicCredentialSource;
     }
   | {
       state: "unavailable";
@@ -557,13 +566,22 @@ async function readClaudeCredentialsAccessTokenFromFile(): Promise<ClaudeCredent
   }
 }
 
-async function readClaudeCredentialsAccessToken(): Promise<ClaudeCredentialsAccess> {
+async function readAnthropicOAuthAccessToken(): Promise<AnthropicCredentialsAccess> {
   const locationsChecked: string[] = [];
   const unavailableDetails: string[] = [];
 
+  const opencodeCredentials = await resolveAnthropicOAuthCached();
+  if (opencodeCredentials.state === "configured") {
+    return {
+      state: "configured",
+      accessToken: opencodeCredentials.accessToken,
+      source: "opencode-auth",
+    };
+  }
+
   const keychainCredentials = await readClaudeCredentialsAccessTokenFromMacOSKeychain();
   if (keychainCredentials?.state === "configured") {
-    return keychainCredentials;
+    return { ...keychainCredentials, source: "claude-credentials" };
   }
   if (keychainCredentials?.state === "unavailable") {
     unavailableDetails.push(keychainCredentials.detail);
@@ -574,7 +592,7 @@ async function readClaudeCredentialsAccessToken(): Promise<ClaudeCredentialsAcce
 
   const fileCredentials = await readClaudeCredentialsAccessTokenFromFile();
   if (fileCredentials.state === "configured") {
-    return fileCredentials;
+    return { ...fileCredentials, source: "claude-credentials" };
   }
   if (fileCredentials.state === "unavailable") {
     unavailableDetails.push(fileCredentials.detail);
@@ -1178,7 +1196,7 @@ export async function getAnthropicDiagnostics(
       return mapLocalDiagnosticsToAnthropicDiagnostics(localDiagnostics);
     }
 
-    const credentials = await readClaudeCredentialsAccessToken();
+    const credentials = await readAnthropicOAuthAccessToken();
     if (credentials.state !== "configured") {
       const diagnostics: AnthropicDiagnostics = {
         installed: localDiagnostics.installed,
@@ -1203,6 +1221,7 @@ export async function getAnthropicDiagnostics(
         authStatus: localDiagnostics.authStatus,
         quotaSupported: false,
         quotaSource: "none",
+        oauthCredentialSource: credentials.source,
         checkedCommands: localDiagnostics.checkedCommands,
         message: buildAnthropicNoQuotaDiagnosticsMessage(fallbackQuota.detail),
       };
@@ -1214,7 +1233,11 @@ export async function getAnthropicDiagnostics(
       version: localDiagnostics.version,
       authStatus: localDiagnostics.authStatus,
       quotaSupported: true,
-      quotaSource: "claude-credentials-oauth-api",
+      quotaSource:
+        credentials.source === "opencode-auth"
+          ? "opencode-auth-oauth-api"
+          : "claude-credentials-oauth-api",
+      oauthCredentialSource: credentials.source,
       checkedCommands: localDiagnostics.checkedCommands,
       quota: fallbackQuota.quota,
     };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -316,6 +316,14 @@ export interface CursorOAuthAuthData {
   [key: string]: unknown;
 }
 
+export interface AnthropicOAuthAuthData {
+  type: string;
+  access?: string;
+  refresh?: string;
+  expires?: number;
+  [key: string]: unknown;
+}
+
 export interface OpenAIOAuthData {
   type: string;
   access?: string;
@@ -430,6 +438,7 @@ export interface CopilotQuotaConfig {
 
 /** Full auth.json structure (partial - only what we need) */
 export interface AuthData {
+  anthropic?: AnthropicOAuthAuthData;
   "github-copilot"?: CopilotAuthData;
   copilot?: CopilotAuthData;
   "copilot-chat"?: CopilotAuthData;

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -26,7 +26,7 @@ import {
 } from "./result-helpers.js";
 
 export function getAnthropicNoDataMessage(): string {
-  return "Quota unavailable via local Claude CLI or Claude OAuth fallback";
+  return "Quota unavailable via local Claude CLI or OAuth credentials";
 }
 
 export const anthropicProvider: QuotaProvider = {
@@ -66,6 +66,7 @@ export const anthropicProvider: QuotaProvider = {
         auth_status: diagnostics.authStatus,
         quota_supported: diagnostics.quotaSupported ? "true" : "false",
         quota_source: diagnostics.quotaSource === "none" ? "(none)" : diagnostics.quotaSource,
+        oauth_credential_source: diagnostics.oauthCredentialSource ?? "(none)",
         checked_commands: diagnostics.checkedCommands.join(" | ") || "(none)",
         message: diagnostics.message,
         five_hour_remaining: quota

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -57,9 +57,13 @@ export const anthropicProvider: QuotaProvider = {
       requestTimeoutMs: ctx.config?.requestTimeoutMs,
     };
     let statusDetails;
+    let acquisitionMethod: QuotaToastEntry["accounting"]["acquisitionMethod"] = "local_cli";
     try {
       const diagnostics = await getAnthropicDiagnostics(options);
       const quota = diagnostics.quotaSupported ? diagnostics.quota : undefined;
+      if (diagnostics.quotaSupported && diagnostics.quotaSource !== "claude-auth-status-json") {
+        acquisitionMethod = "remote_api";
+      }
       statusDetails = statusDetailsFromRecord({
         cli_installed: diagnostics.installed ? "true" : "false",
         cli_version: diagnostics.version ?? "(none)",
@@ -96,7 +100,7 @@ export const anthropicProvider: QuotaProvider = {
       {
         accounting: {
           resultType: "quota",
-          acquisitionMethod: "local_cli",
+          acquisitionMethod,
           ownership: "maintained",
           authority: "provider_reported",
         },
@@ -109,7 +113,7 @@ export const anthropicProvider: QuotaProvider = {
       {
         accounting: {
           resultType: "quota",
-          acquisitionMethod: "local_cli",
+          acquisitionMethod,
           ownership: "maintained",
           authority: "provider_reported",
         },

--- a/tests/helpers/provider-assertions.ts
+++ b/tests/helpers/provider-assertions.ts
@@ -16,6 +16,12 @@ export const PROVIDER_ACCOUNTING_LEDGER: Record<string, Array<QuotaToastEntry["a
       ownership: "maintained",
       authority: "provider_reported",
     },
+    {
+      resultType: "quota",
+      acquisitionMethod: "remote_api",
+      ownership: "maintained",
+      authority: "provider_reported",
+    },
   ],
   copilot: [
     {

--- a/tests/lib.anthropic-auth.test.ts
+++ b/tests/lib.anthropic-auth.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  readAuthFileCached: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: mocks.readAuthFileCached,
+}));
+
+import {
+  DEFAULT_ANTHROPIC_AUTH_CACHE_MAX_AGE_MS,
+  resolveAnthropicOAuth,
+  resolveAnthropicOAuthCached,
+} from "../src/lib/anthropic-auth.js";
+
+describe("anthropic auth resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves the OpenCode anthropic OAuth entry", () => {
+    expect(
+      resolveAnthropicOAuth(
+        { anthropic: { type: "oauth", access: "opencode-token", expires: 4_000 } },
+        { nowMs: 2_000 },
+      ),
+    ).toEqual({
+      state: "configured",
+      accessToken: "opencode-token",
+      expiresAt: 4_000,
+    });
+  });
+
+  it("resolves entries without an expiry", () => {
+    expect(
+      resolveAnthropicOAuth({ anthropic: { type: "oauth", access: "opencode-token" } }),
+    ).toEqual({
+      state: "configured",
+      accessToken: "opencode-token",
+    });
+  });
+
+  it("ignores API key auth entries because the usage endpoint requires OAuth", () => {
+    expect(resolveAnthropicOAuth({ anthropic: { type: "api", access: "opencode-token" } })).toEqual(
+      {
+        state: "none",
+      },
+    );
+  });
+
+  it("ignores blank access tokens", () => {
+    expect(resolveAnthropicOAuth({ anthropic: { type: "oauth", access: "   " } })).toEqual({
+      state: "none",
+    });
+  });
+
+  it("reports expired entries as expired instead of configured", () => {
+    expect(
+      resolveAnthropicOAuth(
+        { anthropic: { type: "oauth", access: "opencode-token", expires: 1_000 } },
+        { nowMs: 2_000 },
+      ),
+    ).toEqual({
+      state: "expired",
+      expiresAt: 1_000,
+    });
+  });
+
+  it("returns none when auth data is missing", () => {
+    expect(resolveAnthropicOAuth(null)).toEqual({ state: "none" });
+    expect(resolveAnthropicOAuth({})).toEqual({ state: "none" });
+  });
+
+  it("uses cached auth reads for resolveAnthropicOAuthCached", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce({
+      anthropic: { type: "oauth", access: "cached-token" },
+    });
+
+    await expect(resolveAnthropicOAuthCached()).resolves.toEqual({
+      state: "configured",
+      accessToken: "cached-token",
+    });
+    expect(mocks.readAuthFileCached).toHaveBeenCalledWith({
+      maxAgeMs: DEFAULT_ANTHROPIC_AUTH_CACHE_MAX_AGE_MS,
+    });
+  });
+
+  it("clamps negative cache ages", async () => {
+    mocks.readAuthFileCached.mockResolvedValueOnce(null);
+
+    await expect(resolveAnthropicOAuthCached({ maxAgeMs: -1 })).resolves.toEqual({ state: "none" });
+    expect(mocks.readAuthFileCached).toHaveBeenCalledWith({ maxAgeMs: 0 });
+  });
+});

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -1,7 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const httpMocks = vi.hoisted(() => ({
   fetchResponse: vi.fn(),
+}));
+
+const authMocks = vi.hoisted(() => ({
+  readAuthFileCached: vi.fn(),
 }));
 
 import { execFile } from "child_process";
@@ -22,6 +26,10 @@ vi.mock("child_process", () => ({
 
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
+}));
+
+vi.mock("../src/lib/opencode-auth.js", () => ({
+  readAuthFileCached: authMocks.readAuthFileCached,
 }));
 
 vi.mock("../src/lib/http.js", () => ({
@@ -50,6 +58,7 @@ const ANTHROPIC_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 
 const execFileMock = vi.mocked(execFile);
 const readFileMock = vi.mocked(readFile);
+const readAuthFileCachedMock = authMocks.readAuthFileCached;
 const fetchWithTimeoutMock = vi.mocked(fetchWithTimeout);
 const fetchResponseMock = httpMocks.fetchResponse;
 const originalProcessPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
@@ -116,10 +125,15 @@ function authenticatedWithoutQuotaSteps(count: number): ExecSequenceStep[] {
   ]).flat();
 }
 
+beforeEach(() => {
+  readAuthFileCachedMock.mockResolvedValue(null);
+});
+
 afterEach(() => {
   vi.useRealTimers();
   execFileMock.mockReset();
   readFileMock.mockReset();
+  readAuthFileCachedMock.mockReset();
   fetchWithTimeoutMock.mockClear();
   fetchResponseMock.mockReset();
   clearAnthropicDiagnosticsCacheForTests();
@@ -458,6 +472,171 @@ describe("Claude CLI diagnostics", () => {
     expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
   });
 
+  it("prefers OpenCode's own Anthropic OAuth credentials over Claude Code credentials", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "oauth", access: "opencode-access-token", expires: Date.now() + 60_000 },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockJsonResponse({
+        five_hour: { utilization: 20, resets_at: "2026-03-25T18:00:00.000Z" },
+        seven_day: { utilization: 30, resets_at: "2026-04-01T00:00:00.000Z" },
+      }),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.quotaSupported).toBe(true);
+    expect(diagnostics.quotaSource).toBe("opencode-auth-oauth-api");
+    expect(diagnostics.quota?.five_hour.percentRemaining).toBe(80);
+    expect(diagnostics.quota?.seven_day.percentRemaining).toBe(70);
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(ANTHROPIC_USAGE_URL, {
+      request: {
+        headers: {
+          Authorization: "Bearer opencode-access-token",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      },
+      timeoutMs: undefined,
+      consume: expect.any(Function),
+    });
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to Claude Code credentials when OpenCode's Anthropic OAuth token is expired", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+      {
+        stdout: JSON.stringify({
+          claudeAiOauth: { accessToken: "oauth-access-token-from-keychain" },
+        }),
+      },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "oauth", access: "expired-opencode-token", expires: Date.now() - 60_000 },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockJsonResponse({
+        five_hour: { utilization: 10 },
+        seven_day: { utilization: 20 },
+      }),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.quotaSupported).toBe(true);
+    expect(diagnostics.quotaSource).toBe("claude-credentials-oauth-api");
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(ANTHROPIC_USAGE_URL, {
+      request: {
+        headers: {
+          Authorization: "Bearer oauth-access-token-from-keychain",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      },
+      timeoutMs: undefined,
+      consume: expect.any(Function),
+    });
+  });
+
+  it("ignores non-OAuth OpenCode Anthropic auth entries", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+      {
+        stdout: JSON.stringify({
+          claudeAiOauth: { accessToken: "oauth-access-token-from-keychain" },
+        }),
+      },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "api", key: "sk-ant-api-key" },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockJsonResponse({
+        five_hour: { utilization: 10 },
+        seven_day: { utilization: 20 },
+      }),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.quotaSource).toBe("claude-credentials-oauth-api");
+    expect(fetchWithTimeoutMock).toHaveBeenCalledWith(ANTHROPIC_USAGE_URL, {
+      request: {
+        headers: {
+          Authorization: "Bearer oauth-access-token-from-keychain",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      },
+      timeoutMs: undefined,
+      consume: expect.any(Function),
+    });
+  });
+
+  it("keeps the first usable credential when the usage endpoint rate limits it", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "oauth", access: "opencode-access-token" },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockOAuthResponse(429, JSON.stringify({ error: { type: "rate_limit_error" } })),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.quotaSupported).toBe(false);
+    expect(diagnostics.quotaSource).toBe("none");
+    expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports which credential store answered the usage probe even when it fails", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "oauth", access: "opencode-access-token" },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockOAuthResponse(429, JSON.stringify({ error: { type: "rate_limit_error" } })),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.oauthCredentialSource).toBe("opencode-auth");
+  });
+
+  it("reports the Claude credential store when OpenCode has no Anthropic OAuth entry", async () => {
+    setProcessPlatform("darwin");
+    mockExecSequence([
+      { stdout: "claude 1.2.3\n" },
+      { stdout: JSON.stringify({ authenticated: true }) },
+      {
+        stdout: JSON.stringify({
+          claudeAiOauth: { accessToken: "oauth-access-token-from-keychain" },
+        }),
+      },
+    ]);
+    fetchResponseMock.mockResolvedValue(
+      mockJsonResponse({
+        five_hour: { utilization: 10 },
+        seven_day: { utilization: 20 },
+      }),
+    );
+
+    const diagnostics = await getAnthropicDiagnostics();
+    expect(diagnostics.oauthCredentialSource).toBe("claude-credentials");
+  });
+
   it("falls back to macOS Keychain Claude OAuth credentials when local Claude auth omits quota windows", async () => {
     setProcessPlatform("darwin");
     mockExecSequence([
@@ -581,7 +760,7 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.quotaSupported).toBe(false);
     expect(diagnostics.quotaSource).toBe("none");
     expect(diagnostics.message).toContain(
-      "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback.",
+      "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
     );
     expect(diagnostics.message).toContain(".claude/.credentials.json");
 
@@ -589,7 +768,7 @@ describe("Claude CLI diagnostics", () => {
     expect(quota?.success).toBe(false);
     if (quota && !quota.success) {
       expect(quota.error).toContain(
-        "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback.",
+        "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
       );
       expect(quota.error).toContain(".claude/.credentials.json");
     }
@@ -1078,7 +1257,7 @@ describe("Claude CLI diagnostics", () => {
       "claude auth status",
     ]);
     expect(diagnostics.message).toContain(
-      "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback.",
+      "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
     );
     expect(diagnostics.message).toContain(".claude/.credentials.json");
     await expect(hasAnthropicCredentialsConfigured()).resolves.toBe(true);
@@ -1087,7 +1266,7 @@ describe("Claude CLI diagnostics", () => {
     expect(quota?.success).toBe(false);
     if (quota && !quota.success) {
       expect(quota.error).toContain(
-        "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback.",
+        "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
       );
       expect(quota.error).toContain(".claude/.credentials.json");
     }

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -318,6 +318,43 @@ describe("Claude CLI diagnostics", () => {
     await expect(queryAnthropicQuota()).resolves.toBeNull();
   });
 
+  it("uses OpenCode Anthropic OAuth when Claude CLI is unavailable", async () => {
+    mockExecSequence([
+      {
+        code: "ENOENT",
+        errorMessage: "spawn claude ENOENT",
+      },
+    ]);
+    readAuthFileCachedMock.mockResolvedValue({
+      anthropic: { type: "oauth", access: "opencode-access-token", expires: Date.now() + 60_000 },
+    });
+    fetchResponseMock.mockResolvedValue(
+      mockJsonResponse({
+        five_hour: { utilization: 20 },
+        seven_day: { utilization: 30 },
+      }),
+    );
+
+    await expect(hasAnthropicCredentialsConfigured()).resolves.toBe(true);
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+
+    const diagnostics = await getAnthropicDiagnostics();
+
+    expect(diagnostics.installed).toBe(false);
+    expect(diagnostics.authStatus).toBe("unknown");
+    expect(diagnostics.quotaSupported).toBe(true);
+    expect(diagnostics.quotaSource).toBe("opencode-auth-oauth-api");
+    expect(diagnostics.oauthCredentialSource).toBe("opencode-auth");
+    expect(diagnostics.quota?.five_hour.percentRemaining).toBe(80);
+    expect(diagnostics.quota?.seven_day.percentRemaining).toBe(70);
+    await expect(queryAnthropicQuota()).resolves.toMatchObject({ success: true });
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).toHaveBeenCalledTimes(1);
+  });
+
   it("uses a configured Claude binary path for probe commands", async () => {
     mockExecSequence([
       {
@@ -354,6 +391,8 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.message).toContain("claude auth login");
     await expect(hasAnthropicCredentialsConfigured()).resolves.toBe(false);
     await expect(queryAnthropicQuota()).resolves.toBeNull();
+    expect(readFileMock).not.toHaveBeenCalled();
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
   });
 
   it("returns quota data when Claude auth status JSON includes quota windows", async () => {

--- a/tests/lib.quota-status.test.ts
+++ b/tests/lib.quota-status.test.ts
@@ -1330,7 +1330,7 @@ describe("buildQuotaStatusReport", () => {
           quota_source: "(none)",
           checked_commands: "claude --version | claude auth status --json",
           message:
-            "Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback. Claude credentials file not found at /Users/test/.claude/.credentials.json.",
+            "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources. Claude credentials file not found at /Users/test/.claude/.credentials.json.",
         }),
         makeProviderSuccessProbe("cursor", {
           plan: "none",
@@ -1390,7 +1390,7 @@ describe("buildQuotaStatusReport", () => {
       - quota_supported: false
       - quota_source: (none)
       - checked_commands: claude --version | claude auth status --json
-      - message: Claude CLI auth detected, but quota was unavailable from both the local CLI and Claude OAuth fallback. Claude credentials file not found at /Users/test/.claude/.credentials.json.
+      - message: Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources. Claude credentials file not found at /Users/test/.claude/.credentials.json.
 
       cursor:
       - plan: none

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -887,7 +887,7 @@ describe("/quota command behavior", () => {
 
     const injected = await buildDialogOutput({ client, sessionID: "session-anthropic-empty" });
     expect(injected).toContain(
-      "Anthropic: Quota unavailable via local Claude CLI or Claude OAuth fallback",
+      "Anthropic: Quota unavailable via local Claude CLI or OAuth credentials",
     );
     expect(injected).not.toContain("Anthropic: Not configured");
   });
@@ -922,7 +922,7 @@ describe("/quota command behavior", () => {
 
     const injected = await buildDialogOutput({ client, sessionID: "session-anthropic-auto-empty" });
     expect(injected).toContain(
-      "Anthropic: Quota unavailable via local Claude CLI or Claude OAuth fallback",
+      "Anthropic: Quota unavailable via local Claude CLI or OAuth credentials",
     );
     expect(injected).not.toContain("Providers detected");
   });

--- a/tests/providers.anthropic.test.ts
+++ b/tests/providers.anthropic.test.ts
@@ -9,11 +9,68 @@ import {
 import { createProviderAvailabilityContext } from "./helpers/provider-test-harness.js";
 
 vi.mock("../src/lib/anthropic.js", () => ({
+  getAnthropicDiagnostics: vi.fn(),
   hasAnthropicCredentialsConfigured: vi.fn(),
   queryAnthropicQuota: vi.fn(),
 }));
 
 describe("anthropic provider", () => {
+  it("reports the credential store that answered the usage probe", async () => {
+    const { getAnthropicDiagnostics, queryAnthropicQuota } = await import(
+      "../src/lib/anthropic.js"
+    );
+    (getAnthropicDiagnostics as any).mockResolvedValueOnce({
+      installed: true,
+      version: "1.2.3",
+      authStatus: "authenticated",
+      quotaSupported: true,
+      quotaSource: "opencode-auth-oauth-api",
+      oauthCredentialSource: "opencode-auth",
+      checkedCommands: ["claude --version"],
+      quota: {
+        success: true,
+        five_hour: { percentRemaining: 80 },
+        seven_day: { percentRemaining: 70 },
+      },
+    });
+    (queryAnthropicQuota as any).mockResolvedValueOnce({
+      success: true,
+      five_hour: { percentRemaining: 80 },
+      seven_day: { percentRemaining: 70 },
+    });
+
+    const out = await anthropicProvider.fetch({} as any);
+    expect(out.statusDetails).toContainEqual({
+      key: "oauth_credential_source",
+      value: "opencode-auth",
+    });
+    expect(out.statusDetails).toContainEqual({
+      key: "quota_source",
+      value: "opencode-auth-oauth-api",
+    });
+  });
+
+  it("reports no credential store when the OAuth probe was never reached", async () => {
+    const { getAnthropicDiagnostics, queryAnthropicQuota } = await import(
+      "../src/lib/anthropic.js"
+    );
+    (getAnthropicDiagnostics as any).mockResolvedValueOnce({
+      installed: true,
+      version: "1.2.3",
+      authStatus: "authenticated",
+      quotaSupported: false,
+      quotaSource: "none",
+      checkedCommands: ["claude --version"],
+    });
+    (queryAnthropicQuota as any).mockResolvedValueOnce(null);
+
+    const out = await anthropicProvider.fetch({} as any);
+    expect(out.statusDetails).toContainEqual({
+      key: "oauth_credential_source",
+      value: "(none)",
+    });
+  });
+
   it("returns attempted:false when Anthropic quota is unavailable locally", async () => {
     const { queryAnthropicQuota } = await import("../src/lib/anthropic.js");
     (queryAnthropicQuota as any).mockResolvedValueOnce(null);

--- a/tests/providers.anthropic.test.ts
+++ b/tests/providers.anthropic.test.ts
@@ -48,6 +48,10 @@ describe("anthropic provider", () => {
       key: "quota_source",
       value: "opencode-auth-oauth-api",
     });
+    expect(out.entries).toHaveLength(2);
+    expect(out.entries.every((entry) => entry.accounting.acquisitionMethod === "remote_api")).toBe(
+      true,
+    );
   });
 
   it("reports no credential store when the OAuth probe was never reached", async () => {
@@ -79,8 +83,23 @@ describe("anthropic provider", () => {
     expectNotAttempted(out);
   });
 
-  it("maps quota windows into canonical grouped-capable rows", async () => {
-    const { queryAnthropicQuota } = await import("../src/lib/anthropic.js");
+  it("maps local CLI quota windows into canonical grouped-capable rows", async () => {
+    const { getAnthropicDiagnostics, queryAnthropicQuota } = await import(
+      "../src/lib/anthropic.js"
+    );
+    (getAnthropicDiagnostics as any).mockResolvedValueOnce({
+      installed: true,
+      version: "1.2.3",
+      authStatus: "authenticated",
+      quotaSupported: true,
+      quotaSource: "claude-auth-status-json",
+      checkedCommands: ["claude --version"],
+      quota: {
+        success: true,
+        five_hour: { percentRemaining: 43 },
+        seven_day: { percentRemaining: 88 },
+      },
+    });
     (queryAnthropicQuota as any).mockResolvedValueOnce({
       success: true,
       five_hour: { percentRemaining: 43, resetTimeIso: "2026-03-25T18:00:00.000Z" },
@@ -105,6 +124,9 @@ describe("anthropic provider", () => {
         resetTimeIso: "2026-04-01T00:00:00.000Z",
       },
     ]);
+    expect(out.entries.every((entry) => entry.accounting.acquisitionMethod === "local_cli")).toBe(
+      true,
+    );
     expect(out.presentation).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

The Anthropic OAuth usage fallback resolves its access token **only** from Claude Code's credential stores (`src/lib/anthropic.ts:560` — macOS Keychain, then `~/.claude/.credentials.json`). It never reads OpenCode's own `auth.json`, even though `src/lib/opencode-auth.ts` exists for exactly that and every other OAuth provider (openai, cursor, qwen, zai, deepseek, alibaba, minimax, the Google providers) already goes through it. Anthropic is the only OAuth provider that does not.

That matters because **Anthropic answers a dead OAuth token on `/api/oauth/usage` with HTTP 429, not 401.** Measured on the machine from #157 — same second, same IP, same endpoint:

| token source | result |
| --- | --- |
| `~/.local/share/opencode/auth.json` → `anthropic.access` | **200**, full usage payload |
| macOS Keychain `Claude Code-credentials` | **429** `rate_limit_error`, `Retry-After: 2974` |
| deliberately malformed token (control) | 401 |

Since OpenCode's token succeeds from the same IP at the same moment, the 429 is bound to the token, not to the account or the network.

That Claude Code token is permanently dead, not throttled:

- `expiresAt` is ~6 weeks in the past and `refreshToken` is the empty string, so Claude Code cannot renew it.
- `~/.claude.json` records `bridgeOauthDeadExpiresAt` (identical timestamp) and `bridgeOauthDeadFailCount: 1` — Claude Code has itself marked these credentials dead.
- The same token returns a clean **401** against `/api/oauth/profile`, confirming it is invalid rather than rate limited.
- `claude auth status` still reports `loggedIn: true`, so the CLI probe cannot detect this.

The bounded cooldown added in v3.11.2 (`src/lib/anthropic.ts:611`) therefore classifies a permanently broken credential as a transient rate limit. No amount of backoff can recover from that, which is why #157 persisted after v3.11.2 — the reporter's `/quota_status` still showed the 429 plus `retry in 900s`.

## What changed

`readClaudeCredentialsAccessToken` becomes `readAnthropicOAuthAccessToken` and resolves the first usable OAuth token from an ordered candidate list: OpenCode `auth.json` → macOS Keychain → `~/.claude/.credentials.json`. OpenCode refreshes its own Anthropic credential, so it stays usable independently of Claude Code's state.

Deliberately kept out of scope:

- **No credential refresh or mutation.** Only reads, matching the guarantee given in #157. Expired `auth.json` entries are skipped so the next candidate gets a turn — they are not renewed.
- **No cascading on HTTP failure.** The first usable credential wins, so a probe still issues exactly one request. Retrying the next store on a 429 would double requests during a genuine rate limit.
- **No availability change.** `isAvailable()` still requires Claude Code, so `authentication: "local_cli_auth"` in `provider-metadata.ts` and the `Needs setup` README label remain accurate.
- **Cooldown and in-flight dedupe untouched.** Both are keyed by token fingerprint (`anthropic.ts:764`), so they work unchanged regardless of which store the token came from.

New `src/lib/anthropic-auth.ts` follows the `qwen-auth.ts` shape rather than growing `anthropic.ts` (already 1287 lines). `AuthData` gains the `anthropic` key, which was simply missing from `src/lib/types.ts`.

Diagnostics gain `oauthCredentialSource` (`opencode-auth` / `claude-credentials`), surfaced in `/quota_status` as `oauth_credential_source`, plus the `opencode-auth-oauth-api` quota source. Without this a 429 is indistinguishable from a dead credential in a bug report — the exact ambiguity that made this issue hard to diagnose.

The no-quota message said "from **both** the local CLI and Claude OAuth fallback", which is no longer accurate with three sources; it now reads "from the local CLI and OAuth credential sources".

## Linked Issue

Fixes #157

## OpenCode Validation

- Current production released OpenCode version tested: `1.18.16`.
- Why this version is relevant to the fix: the fix reads OpenCode's runtime `auth.json`, so it depends on how the current OpenCode release stores and refreshes the `anthropic` OAuth entry (`type: "oauth"` with `access` / `refresh` / `expires`). Verified against a live Anthropic Max subscription on that version.

## Verification

Against the real installation from #157 (Claude Code 2.1.206, Anthropic Max), `getAnthropicDiagnostics()` on the built output:

```
# this branch
quotaSupported: true
quotaSource: opencode-auth-oauth-api
oauthCredentialSource: opencode-auth
5h remaining: 61%   7d remaining: 89%

# control: same tree, src/ stashed back to main
quotaSupported: false
quotaSource: none
message: Claude CLI auth detected, but quota was unavailable from both the local CLI
         and Claude OAuth fallback. Anthropic API error 429: {"error":{"type":
         "rate_limit_error","message":"Rate limited. Please try again later."}}
         Anthropic OAuth usage probe paused after HTTP 429; retry in 900s.
```

The control run reproduces the issue text verbatim, so the branch is what changes the outcome.

Also verified through the packed npm artifact (`pnpm pack` → install into a clean consumer project → import from `dist/`): `quotaSource: opencode-auth-oauth-api`, 5h 61% / 7d 89%.

Test gates:

- `pnpm verify` — clean (Biome, TypeScript version check, v4 history, typecheck, build, tests, four-surface parity, package contents).
- `pnpm test` — **1881 pass / 171 files**. Baseline on `main` at `75a7ee9` was 1865 / 170 after a build (`tests/tui-dist-packaging.test.ts` needs `dist/`, so it fails on a fresh clone until `pnpm run build` runs — unrelated to this change). Delta is exactly the 16 tests added here.
- Control: `src/` stashed, new tests kept → **10 fail** across `lib.anthropic`, `providers.anthropic`, `lib.quota-status`. Every new assertion fails without the implementation.

## Tests added

`tests/lib.anthropic-auth.test.ts` — 8 cases: resolves the OAuth entry (with and without expiry), ignores `type: "api"` (the usage endpoint requires OAuth), ignores a blank `access`, reports expired entries as `expired`, handles missing auth data, and covers the cached wrapper including negative-`maxAgeMs` clamping.

`tests/lib.anthropic.test.ts` — 6 cases: `auth.json` beats the Keychain; an expired `auth.json` token falls through to the Keychain; a non-OAuth entry is ignored; a 429 does not trigger a second request against another store; `oauthCredentialSource` is reported for both stores including on failure.

`tests/providers.anthropic.test.ts` — 2 cases: `oauth_credential_source` reaches `/quota_status` status details, and reads `(none)` when the OAuth probe was never attempted.

The ~40 pre-existing `lib.anthropic` cases stay untouched: `opencode-auth.js` is mocked to return `null` by default, so the new source is simply absent and every old path behaves exactly as before.

## Follow-up (not in this PR)

With the credential resolution in place, the Anthropic provider could report quota from `opencode auth login --provider anthropic` alone, without Claude Code installed. That means touching `isAvailable()`, `provider-metadata.ts`, the README ledger and the docs parity tests — beyond "the smallest safe fix that addresses the root cause". Happy to open it separately if you want it.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed — `docs/readme/providers.md` documents the credential order and the new `oauth_credential_source` field; the README ledger is unchanged because the setup workflow and `Needs setup` label are unchanged
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply — not a new provider; `contributing/provider-template/` covers additions, and this fixes credential resolution in an existing built-in provider
