### PR TITLE
fix(opencode-zen): parse new SolidJS SSR billing page format

### DIFF
--- a/src/lib/opencode-zen.ts
+++ b/src/lib/opencode-zen.ts
@@ -43,6 +43,84 @@ function parseSsrBillingData(html: string): OpenCodeZenBillingData | null {
   };
 }
 
+/**
+ * Extracts the object/array assigned to a SolidJS SSR `_$HY.r["key[\"id\"]"]`
+ * response via `$R[N]($R[promise],$R[value]={...})`, brace-matched so nested
+ * `new Date(...)` / object literals don't break the scan. `$R` indices are
+ * layout-dependent, so every anchor is a generic `$R[\d+]`.
+ */
+function extractSsrAssignment(html: string, key: string): string | null {
+  const keyMatch = new RegExp(
+    `${key}\\[\\\\?"[^"]+\\\\?"\\]"]=\\$R\\[\\d+\\]=\\$R\\[\\d+\\]\\(\\$R\\[(\\d+)\\]`,
+  ).exec(html);
+  if (!keyMatch) return null;
+
+  const resolveMatch = new RegExp(`\\$R\\[\\d+\\]\\(\\$R\\[${keyMatch[1]}\\],\\$R\\[\\d+\\]=`).exec(
+    html,
+  );
+  if (!resolveMatch) return null;
+
+  const start = resolveMatch.index + resolveMatch[0].length;
+  const open = html[start];
+  if (open !== "{" && open !== "[") return null;
+  const close = open === "{" ? "}" : "]";
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let i = start; i < html.length; i++) {
+    const ch = html[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === open) {
+      depth++;
+    } else if (ch === close) {
+      depth--;
+      if (depth === 0) return html.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+function parseNewSsrBillingData(html: string): OpenCodeZenBillingData | null {
+  const object = extractSsrAssignment(html, "billing\\.get");
+  if (!object) return null;
+
+  const balanceMatch = object.match(/\bbalance\s*:\s*(-?\d+)/);
+  const limitMatch = object.match(/\bmonthlyLimit\s*:\s*(\d+)/);
+  const usageMatch = object.match(/\bmonthlyUsage\s*:\s*(\d+)/);
+  if (!balanceMatch) return null;
+
+  return {
+    balance: Math.max(0, Number(balanceMatch[1])),
+    monthlyLimit: limitMatch ? Number(limitMatch[1]) : null,
+    monthlyUsage: usageMatch ? Number(usageMatch[1]) : null,
+    lastPayment: null,
+  };
+}
+
+function parseNewSsrPaymentData(html: string): number | null {
+  const array = extractSsrAssignment(html, "payment\\.list");
+  if (!array) return null;
+
+  let latest: number | null = null;
+  // Real SSR output pairs `amount` directly with `timeRefunded`; a non-null
+  // refund date means the payment was refunded and must be skipped.
+  for (const match of array.matchAll(
+    /\bamount\s*:\s*(\d+)\s*,\s*timeRefunded\s*:\s*(null|new Date\([^)]*\))/g,
+  )) {
+    const amount = Number(match[1]);
+    if (amount > 0 && match[2] === "null") latest = amount;
+  }
+  return latest === null ? null : latest / OPENCODE_ZEN_BILLING_UNITS_PER_DOLLAR;
+}
+
 function parseDataSlotBillingData(html: string): OpenCodeZenBillingData | null {
   let balance: number | null = null;
   let monthlyLimit: number | null = null;
@@ -150,7 +228,10 @@ export async function queryOpenCodeZenQuota(
         }
 
         const html = await response.text();
-        const data = parseSsrBillingData(html) ?? parseDataSlotBillingData(html);
+        const data =
+          parseNewSsrBillingData(html) ??
+          parseSsrBillingData(html) ??
+          parseDataSlotBillingData(html);
         if (!data) {
           return {
             success: false,
@@ -159,7 +240,10 @@ export async function queryOpenCodeZenQuota(
           };
         }
 
-        data.lastPayment = parseSsrPaymentData(html) ?? parseDataSlotPaymentData(html);
+        data.lastPayment =
+          parseNewSsrPaymentData(html) ??
+          parseSsrPaymentData(html) ??
+          parseDataSlotPaymentData(html);
         return { success: true, data };
       },
     });
@@ -177,6 +261,8 @@ export async function queryOpenCodeZenQuota(
 export {
   parseDataSlotBillingData as _parseDataSlotBillingData,
   parseDataSlotPaymentData as _parseDataSlotPaymentData,
+  parseNewSsrBillingData as _parseNewSsrBillingData,
+  parseNewSsrPaymentData as _parseNewSsrPaymentData,
   parseSsrBillingData as _parseSsrBillingData,
   parseSsrPaymentData as _parseSsrPaymentData,
 };

--- a/src/lib/opencode-zen.ts
+++ b/src/lib/opencode-zen.ts
@@ -43,12 +43,42 @@ function parseSsrBillingData(html: string): OpenCodeZenBillingData | null {
   };
 }
 
-/**
- * Extracts the object/array assigned to a SolidJS SSR `_$HY.r["key[\"id\"]"]`
- * response via `$R[N]($R[promise],$R[value]={...})`, brace-matched so nested
- * `new Date(...)` / object literals don't break the scan. `$R` indices are
- * layout-dependent, so every anchor is a generic `$R[\d+]`.
- */
+/** Extracts one balanced object/array while ignoring delimiters inside quoted strings. */
+function extractBalancedValue(
+  source: string,
+  start: number,
+): { value: string; end: number } | null {
+  const open = source[start];
+  if (open !== "{" && open !== "[") return null;
+  const close = open === "{" ? "}" : "]";
+
+  let depth = 0;
+  let quote: '"' | "'" | "`" | null = null;
+  let escaped = false;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (quote !== null) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+    } else if (ch === open) {
+      depth++;
+    } else if (ch === close && --depth === 0) {
+      return { value: source.slice(start, i + 1), end: i };
+    }
+  }
+  return null;
+}
+
 function extractSsrAssignment(html: string, key: string): string | null {
   const match = new RegExp(
     `${key}\\[\\\\?"[^"]+\\\\?"\\]"]=\\$R\\[\\d+\\]=\\$R\\[\\d+\\]\\(\\$R\\[(\\d+)\\]` +
@@ -57,20 +87,7 @@ function extractSsrAssignment(html: string, key: string): string | null {
   if (!match) return null;
 
   const start = match.index + match[0].length;
-  const open = html[start];
-  if (open !== "{" && open !== "[") return null;
-  const close = open === "{" ? "}" : "]";
-
-  let depth = 0;
-  for (let i = start; i < html.length; i++) {
-    const ch = html[i];
-    if (ch === open) {
-      depth++;
-    } else if (ch === close && --depth === 0) {
-      return html.slice(start, i + 1);
-    }
-  }
-  return null;
+  return extractBalancedValue(html, start)?.value ?? null;
 }
 
 function parseNewSsrBillingData(html: string): OpenCodeZenBillingData | null {
@@ -94,16 +111,26 @@ function parseNewSsrPaymentData(html: string): number | null {
   const array = extractSsrAssignment(html, "payment\\.list");
   if (!array) return null;
 
-  let latest: number | null = null;
-  // Real SSR output pairs `amount` directly with `timeRefunded`; a non-null
-  // refund date means the payment was refunded and must be skipped.
-  for (const match of array.matchAll(
-    /\bamount\s*:\s*(\d+)\s*,\s*timeRefunded\s*:\s*(null|new Date\([^)]*\))/g,
-  )) {
-    const amount = Number(match[1]);
-    if (amount > 0 && match[2] === "null") latest = amount;
+  for (let i = 1; i < array.length - 1; i++) {
+    if (array[i] !== "{") continue;
+
+    const extracted = extractBalancedValue(array, i);
+    if (!extracted) return null;
+    i = extracted.end;
+
+    const amountMatch = extracted.value.match(/\bamount\s*:\s*(-?\d+(?:\.\d+)?)/);
+    const amount = amountMatch ? Number(amountMatch[1]) : Number.NaN;
+    if (!Number.isFinite(amount) || amount <= 0) continue;
+
+    const timeRefunded = extracted.value.match(/\btimeRefunded\s*:\s*([^,}]+)/)?.[1].trim();
+    const explicitlyRefunded =
+      /\brefunded\s*:\s*true\b/.test(extracted.value) ||
+      (timeRefunded !== undefined && timeRefunded !== "null");
+    if (!explicitlyRefunded) {
+      return amount / OPENCODE_ZEN_BILLING_UNITS_PER_DOLLAR;
+    }
   }
-  return latest === null ? null : latest / OPENCODE_ZEN_BILLING_UNITS_PER_DOLLAR;
+  return null;
 }
 
 function parseDataSlotBillingData(html: string): OpenCodeZenBillingData | null {

--- a/src/lib/opencode-zen.ts
+++ b/src/lib/opencode-zen.ts
@@ -50,39 +50,24 @@ function parseSsrBillingData(html: string): OpenCodeZenBillingData | null {
  * layout-dependent, so every anchor is a generic `$R[\d+]`.
  */
 function extractSsrAssignment(html: string, key: string): string | null {
-  const keyMatch = new RegExp(
-    `${key}\\[\\\\?"[^"]+\\\\?"\\]"]=\\$R\\[\\d+\\]=\\$R\\[\\d+\\]\\(\\$R\\[(\\d+)\\]`,
+  const match = new RegExp(
+    `${key}\\[\\\\?"[^"]+\\\\?"\\]"]=\\$R\\[\\d+\\]=\\$R\\[\\d+\\]\\(\\$R\\[(\\d+)\\]` +
+      `[\\s\\S]*?\\$R\\[\\d+\\]\\(\\$R\\[\\1\\],\\$R\\[\\d+\\]=`,
   ).exec(html);
-  if (!keyMatch) return null;
+  if (!match) return null;
 
-  const resolveMatch = new RegExp(`\\$R\\[\\d+\\]\\(\\$R\\[${keyMatch[1]}\\],\\$R\\[\\d+\\]=`).exec(
-    html,
-  );
-  if (!resolveMatch) return null;
-
-  const start = resolveMatch.index + resolveMatch[0].length;
+  const start = match.index + match[0].length;
   const open = html[start];
   if (open !== "{" && open !== "[") return null;
   const close = open === "{" ? "}" : "]";
 
   let depth = 0;
-  let inString = false;
-  let escaped = false;
   for (let i = start; i < html.length; i++) {
     const ch = html[i];
-    if (inString) {
-      if (escaped) escaped = false;
-      else if (ch === "\\") escaped = true;
-      else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-    } else if (ch === open) {
+    if (ch === open) {
       depth++;
-    } else if (ch === close) {
-      depth--;
-      if (depth === 0) return html.slice(start, i + 1);
+    } else if (ch === close && --depth === 0) {
+      return html.slice(start, i + 1);
     }
   }
   return null;

--- a/tests/lib.opencode-zen.test.ts
+++ b/tests/lib.opencode-zen.test.ts
@@ -179,10 +179,6 @@ describe("OpenCode Zen billing parser", () => {
     expect(_parseNewSsrPaymentData(newSsrPaymentHtml([0, 0]))).toBeNull();
   });
 
-  it("returns null for an empty new payment.list array", () => {
-    expect(_parseNewSsrPaymentData(newSsrPaymentHtml([]))).toBeNull();
-  });
-
   it("returns null when the new SSR keys are absent", () => {
     expect(_parseNewSsrBillingData("<html><body>Nothing here</body></html>")).toBeNull();
     expect(_parseNewSsrPaymentData("<html><body>Nothing here</body></html>")).toBeNull();

--- a/tests/lib.opencode-zen.test.ts
+++ b/tests/lib.opencode-zen.test.ts
@@ -161,10 +161,10 @@ describe("OpenCode Zen billing parser", () => {
     });
   });
 
-  it("returns the latest positive payment from the new payment.list array", () => {
+  it("returns the first positive payment in provider order", () => {
     expect(
       _parseNewSsrPaymentData(newSsrPaymentHtml([500_000_000, 2_000_000_000, 1_000_000_000])),
-    ).toBe(10);
+    ).toBe(5);
   });
 
   it("skips refunded payments in the new payment.list array", () => {
@@ -173,6 +173,20 @@ describe("OpenCode Zen billing parser", () => {
         newSsrPaymentHtml([{ amount: 2_000_000_000, refunded: true }, { amount: 1_000_000_000 }]),
       ),
     ).toBe(10);
+  });
+
+  it("parses reordered payment fields and skips malformed or explicitly refunded entries", () => {
+    const html =
+      `<html><script>_$HY.r["payment.list[\\"wrk_X\\"]"]=$R[34]=$R[2]($R[35]={p:0,s:0,f:0});` +
+      `$R[16]($R[35],$R[38]=[` +
+      `$R[39]={timeRefunded:null,amount:"invalid"},` +
+      `$R[41]={timeRefunded:new Date("2026-08-01T00:00:00.000Z"),id:"refunded",amount:2000000000},` +
+      `$R[43]={refunded:true,note:"skip",amount:1500000000},` +
+      `$R[45]={timeRefunded:null,note:"brace } and escaped \\" quote {",id:"valid",amount:1000000000},` +
+      `$R[47]={amount:3000000000}` +
+      `]);</script></html>`;
+
+    expect(_parseNewSsrPaymentData(html)).toBe(10);
   });
 
   it("returns null when the new payment.list has no positive amount", () => {
@@ -197,6 +211,21 @@ describe("OpenCode Zen billing parser", () => {
     });
   });
 
+  it("scopes billing fields and ignores escaped quotes or braces inside strings", () => {
+    const html =
+      `<script>const unrelated={balance:999,monthlyLimit:999};</script>` +
+      `<script>_$HY.r["billing.get[\\"wrk_X\\"]"]=$R[21]=$R[2]($R[22]={p:0,s:0,f:0});` +
+      `$R[16]($R[22],$R[25]={note:"brace } and escaped \\" quote {",` +
+      `balance:425000000,monthlyLimit:20,monthlyUsage:12500000});</script>`;
+
+    expect(_parseNewSsrBillingData(html)).toEqual({
+      balance: 425_000_000,
+      monthlyLimit: 20,
+      monthlyUsage: 12_500_000,
+      lastPayment: null,
+    });
+  });
+
   it("returns null for missing optional fields in the new billing object", () => {
     expect(_parseNewSsrBillingData(newSsrBillingHtml(425_000_000))).toEqual({
       balance: 425_000_000,
@@ -204,6 +233,18 @@ describe("OpenCode Zen billing parser", () => {
       monthlyUsage: null,
       lastPayment: null,
     });
+  });
+
+  it("returns null for unbalanced or unterminated new SSR assignments", () => {
+    const unbalancedBilling =
+      `<script>_$HY.r["billing.get[\\"wrk_X\\"]"]=$R[21]=$R[2]($R[22]={p:0,s:0,f:0});` +
+      `$R[16]($R[22],$R[25]={note:"unterminated },balance:425000000});</script>`;
+    const unbalancedPayments =
+      `<script>_$HY.r["payment.list[\\"wrk_X\\"]"]=$R[34]=$R[2]($R[35]={p:0,s:0,f:0});` +
+      `$R[16]($R[35],$R[38]=[$R[39]={amount:100000000,timeRefunded:null});</script>`;
+
+    expect(_parseNewSsrBillingData(unbalancedBilling)).toBeNull();
+    expect(_parseNewSsrPaymentData(unbalancedPayments)).toBeNull();
   });
 });
 
@@ -272,7 +313,7 @@ describe("queryOpenCodeZenQuota", () => {
         balance: 0,
         monthlyLimit: 50,
         monthlyUsage: 17_321_332,
-        lastPayment: 10,
+        lastPayment: 5,
       },
     });
   });

--- a/tests/lib.opencode-zen.test.ts
+++ b/tests/lib.opencode-zen.test.ts
@@ -25,6 +25,8 @@ vi.mock("../src/lib/http.js", () => ({
 import {
   _parseDataSlotBillingData,
   _parseDataSlotPaymentData,
+  _parseNewSsrBillingData,
+  _parseNewSsrPaymentData,
   _parseSsrBillingData,
   _parseSsrPaymentData,
   OPENCODE_ZEN_BILLING_UNITS_PER_DOLLAR,
@@ -57,6 +59,38 @@ function dataSlotHtml(): string {
     <span data-slot="billing-label">Monthly Usage</span>
     <span data-slot="billing-value">$12.50</span>
   </div>`;
+}
+
+function newSsrBillingHtml(balance: number, monthlyLimit?: number, monthlyUsage?: number): string {
+  const fields = [
+    'customerID:"cus_1"',
+    `balance:${balance}`,
+    ...(monthlyLimit === undefined ? [] : [`monthlyLimit:${monthlyLimit}`]),
+    ...(monthlyUsage === undefined ? [] : [`monthlyUsage:${monthlyUsage}`]),
+    `timeMonthlyUsageUpdated:$R[26]=new Date("2026-08-11T07:05:05.000Z")`,
+    "lite:$R[27]={useBalance:!0}",
+  ].join(",");
+  return (
+    `<html><script>_$HY.r["billing.get[\\"wrk_X\\"]"]=$R[21]=$R[2]($R[22]={p:0,s:0,f:0});` +
+    `$R[16]($R[22],$R[25]={${fields}});</script></html>`
+  );
+}
+
+function newSsrPaymentHtml(
+  amounts: Array<number | { amount: number; refunded?: boolean }>,
+): string {
+  const entries = amounts
+    .map((entry, index) => {
+      const amount = typeof entry === "number" ? entry : entry.amount;
+      const refunded = typeof entry === "number" ? false : Boolean(entry.refunded);
+      const timeRefunded = refunded ? `new Date("2026-08-01T00:00:00.000Z")` : "null";
+      return `$R[${39 + index * 2}]={id:"pay_${index}",amount:${amount},timeRefunded:${timeRefunded}}`;
+    })
+    .join(",");
+  return (
+    `<html><script>_$HY.r["payment.list[\\"wrk_X\\"]"]=$R[34]=$R[2]($R[35]={p:0,s:0,f:0});` +
+    `$R[16]($R[35],$R[38]=[${entries}]);</script></html>`
+  );
 }
 
 describe("OpenCode Zen billing parser", () => {
@@ -108,6 +142,73 @@ describe("OpenCode Zen billing parser", () => {
     </table>`;
     expect(_parseDataSlotPaymentData(html)).toBe(20);
   });
+
+  it("clamps a negative new-SSR balance to zero and keeps dollars as-is", () => {
+    expect(_parseNewSsrBillingData(newSsrBillingHtml(-14_496, 50, 17_321_332))).toEqual({
+      balance: 0,
+      monthlyLimit: 50,
+      monthlyUsage: 17_321_332,
+      lastPayment: null,
+    });
+  });
+
+  it("keeps a positive new-SSR balance in billing units", () => {
+    expect(_parseNewSsrBillingData(newSsrBillingHtml(425_000_000, 20, 12_500_000))).toEqual({
+      balance: 425_000_000,
+      monthlyLimit: 20,
+      monthlyUsage: 12_500_000,
+      lastPayment: null,
+    });
+  });
+
+  it("returns the latest positive payment from the new payment.list array", () => {
+    expect(
+      _parseNewSsrPaymentData(newSsrPaymentHtml([500_000_000, 2_000_000_000, 1_000_000_000])),
+    ).toBe(10);
+  });
+
+  it("skips refunded payments in the new payment.list array", () => {
+    expect(
+      _parseNewSsrPaymentData(
+        newSsrPaymentHtml([{ amount: 2_000_000_000, refunded: true }, { amount: 1_000_000_000 }]),
+      ),
+    ).toBe(10);
+  });
+
+  it("returns null when the new payment.list has no positive amount", () => {
+    expect(_parseNewSsrPaymentData(newSsrPaymentHtml([0, 0]))).toBeNull();
+  });
+
+  it("returns null for an empty new payment.list array", () => {
+    expect(_parseNewSsrPaymentData(newSsrPaymentHtml([]))).toBeNull();
+  });
+
+  it("returns null when the new SSR keys are absent", () => {
+    expect(_parseNewSsrBillingData("<html><body>Nothing here</body></html>")).toBeNull();
+    expect(_parseNewSsrPaymentData("<html><body>Nothing here</body></html>")).toBeNull();
+  });
+
+  it("parses a nested object literal inside the new billing object", () => {
+    const html =
+      `<html><script>_$HY.r["billing.get[\\"wrk_X\\"]"]=$R[21]=$R[2]($R[22]={p:0,s:0,f:0});` +
+      `$R[16]($R[22],$R[25]={customerID:"cus_1",balance:425000000,` +
+      `lite:$R[27]={useBalance:!0},monthlyLimit:20,monthlyUsage:12500000});</script></html>`;
+    expect(_parseNewSsrBillingData(html)).toEqual({
+      balance: 425_000_000,
+      monthlyLimit: 20,
+      monthlyUsage: 12_500_000,
+      lastPayment: null,
+    });
+  });
+
+  it("returns null for missing optional fields in the new billing object", () => {
+    expect(_parseNewSsrBillingData(newSsrBillingHtml(425_000_000))).toEqual({
+      balance: 425_000_000,
+      monthlyLimit: null,
+      monthlyUsage: null,
+      lastPayment: null,
+    });
+  });
 });
 
 describe("queryOpenCodeZenQuota", () => {
@@ -157,6 +258,25 @@ describe("queryOpenCodeZenQuota", () => {
         monthlyLimit: 100,
         monthlyUsage: 575_000_000,
         lastPayment: 21,
+      },
+    });
+  });
+
+  it("parses the new SolidJS SSR format end to end", async () => {
+    mocks.fetchResponse.mockResolvedValueOnce(
+      response(
+        newSsrBillingHtml(-14_496, 50, 17_321_332) +
+          newSsrPaymentHtml([500_000_000, 2_000_000_000, 1_000_000_000]),
+      ),
+    );
+
+    await expect(queryOpenCodeZenQuota("wrk_abc", "cookie")).resolves.toEqual({
+      success: true,
+      data: {
+        balance: 0,
+        monthlyLimit: 50,
+        monthlyUsage: 17_321_332,
+        lastPayment: 10,
       },
     });
   });


### PR DESCRIPTION
Closes #213

## Summary
The OpenCode Zen billing page changed to a new SolidJS SSR format. The billing data now lives in `billing.get["wrk_..."]` and `payment.list["wrk_..."]` `$R`-array assignments instead of the old flat fields / `data-slot` markup.

The old parsers failed because:
1. `SSR_FIELD_RE` uses `\d+` and rejects the now-possible **negative** `balance`.
2. Units are **mixed**: `monthlyLimit` is in USD dollars while `balance`/`monthlyUsage` are in billing units (100M = $1).
3. The payment-list key format changed (`payment.list["wrk_..."]` vs `payment.list`), so payments were never found.

## Changes
- `src/lib/opencode-zen.ts`:
  - `extractSsrAssignment` — brace-matching extractor for SolidJS `$R` SSR assignments (tolerates nested objects, strings, `new Date(...)`, layout-dependent indices).
  - `parseNewSsrBillingData` — parses `balance` (negative clamped to 0), `monthlyLimit` (dollars, as-is), `monthlyUsage` (billing units).
  - `parseNewSsrPaymentData` — latest positive non-refunded payment, in dollars.
  - New parsers wired as first choice, existing SSR/data-slot parsers kept as fallbacks.
- `tests/lib.opencode-zen.test.ts` — fixtures matching the real SSR shape + 8 new unit tests and an end-to-end query test (25 total in file).

## Verification
- `pnpm run build` clean.
- `pnpm test`: 1874 passed / 1 failed — the single failure (`tests/package-manifest.test.ts` "uses Lefthook…") is pre-existing and environment-specific (`.husky` dir present locally); fails identically with these changes stashed.
- Live probe against real billing page: `live_probe: success`, `balance_usd $0.00`, `monthly_limit_usd $50.00`, `last_payment_usd $5.00`.