### PR TITLE
fix(provider): prefer explicit provider IDs for current-model filtering

### DIFF
--- a/src/lib/display-sanitize.ts
+++ b/src/lib/display-sanitize.ts
@@ -72,6 +72,7 @@ export function sanitizeQuotaToastError(error: QuotaToastError): QuotaToastError
   return {
     label: sanitizeDisplayText(error.label),
     message: sanitizeDisplayText(error.message),
+    ...(error.kind ? { kind: error.kind } : {}),
   };
 }
 

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -105,6 +105,8 @@ export interface QuotaToastError {
   /** Short label that will be rendered as "label: message". */
   label: string;
   message: string;
+  /** Intentional diagnostics remain verbose but do not count as compact-status issues. */
+  kind?: "intentional-filter";
 }
 
 /** Per-model token summary for current session (toast display). */

--- a/src/lib/provider-metadata.ts
+++ b/src/lib/provider-metadata.ts
@@ -484,6 +484,13 @@ export function getQuotaProviderRuntimeIds(id: string): readonly string[] {
   return [...new Set(QUOTA_PROVIDER_RUNTIME_IDS[shape.id])];
 }
 
+export function getQuotaProviderIdsForRuntimeId(id: string): readonly CanonicalQuotaProviderId[] {
+  const normalized = id.trim().toLowerCase();
+  return catalogKeys().filter((providerId) =>
+    QUOTA_PROVIDER_RUNTIME_IDS[providerId].includes(normalized),
+  );
+}
+
 export function isLiveLocalUsageProviderId(id: string): boolean {
   return LIVE_LOCAL_USAGE_PROVIDER_ID_SET.has(normalizeQuotaProviderId(id));
 }

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -1,7 +1,6 @@
 import { getAnthropicNoDataMessage } from "../providers/anthropic.js";
 import { getProviders } from "../providers/registry.js";
 import type { LoadConfigMeta } from "./config.js";
-import { isCursorProviderId } from "./cursor-pricing.js";
 import type {
   QuotaProvider,
   QuotaProviderContext,
@@ -14,7 +13,11 @@ import type {
 
 import { isPercentEntry } from "./entries.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
-import { getQuotaProviderDisplayLabel, normalizeQuotaProviderId } from "./provider-metadata.js";
+import {
+  getQuotaProviderDisplayLabel,
+  getQuotaProviderIdsForRuntimeId,
+  getQuotaProviderShape,
+} from "./provider-metadata.js";
 import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
 import type { QuotaFormatStyle } from "./quota-format-style.js";
 import { getQuotaFormatStyleDefinition } from "./quota-format-style.js";
@@ -124,19 +127,19 @@ export function matchesQuotaProviderCurrentSelection(params: {
   enabledProviders?: string[] | "auto";
   quotaProviders?: QuotaToastConfig["quotaProviders"];
 }): boolean {
-  if (params.currentModel) {
-    return params.provider.matchesCurrentModel
-      ? params.provider.matchesCurrentModel(params.currentModel, {
+  const matchesCurrentModel = (model: string): boolean =>
+    params.provider.matchesCurrentModel
+      ? params.provider.matchesCurrentModel(model, {
           enabledProviders: params.enabledProviders ?? "auto",
           ...(params.quotaProviders ? { quotaProviders: params.quotaProviders } : {}),
           ...(params.currentProviderID ? { currentProviderID: params.currentProviderID } : {}),
         })
       : true;
-  }
-
-  if (!params.currentProviderID) return false;
 
   if (params.provider.id === "quota-providers") {
+    if (params.currentModel) return matchesCurrentModel(params.currentModel);
+    if (!params.currentProviderID) return false;
+
     return Boolean(
       params.quotaProviders?.some(
         (source) => source.providerId === params.currentProviderID && source.modelIds === undefined,
@@ -144,11 +147,29 @@ export function matchesQuotaProviderCurrentSelection(params: {
     );
   }
 
-  const normalizedCurrentProviderID = normalizeQuotaProviderId(params.currentProviderID);
-  if (params.provider.id === normalizedCurrentProviderID) {
-    return true;
+  if (params.currentProviderID) {
+    const explicitId = params.currentProviderID.trim().toLowerCase();
+    const catalogShape = getQuotaProviderShape(explicitId);
+    if (catalogShape?.id === explicitId) return params.provider.id === catalogShape.id;
+
+    const runtimeCandidates = getQuotaProviderIdsForRuntimeId(explicitId);
+    if (runtimeCandidates.length === 1) return params.provider.id === runtimeCandidates[0];
+    if (runtimeCandidates.length > 1) {
+      if (!runtimeCandidates.some((candidate) => candidate === params.provider.id)) {
+        return false;
+      }
+      if (!params.currentModel || !params.provider.matchesCurrentModel) return false;
+
+      const qualifiedModel = params.currentModel.toLowerCase().startsWith(`${explicitId}/`)
+        ? params.currentModel
+        : `${explicitId}/${params.currentModel}`;
+      return matchesCurrentModel(qualifiedModel);
+    }
+
+    return catalogShape ? params.provider.id === catalogShape.id : false;
   }
-  return params.provider.id === "cursor" && isCursorProviderId(params.currentProviderID);
+
+  return params.currentModel ? matchesCurrentModel(params.currentModel) : false;
 }
 
 function hasCurrentQuotaSelection(params: {
@@ -583,6 +604,7 @@ function buildExplicitProviderIssues(params: {
           ? `current model: ${params.selection.currentModel}`
           : "filtered";
       errors.push({
+        kind: "intentional-filter",
         label: getQuotaProviderDisplayLabel(provider.id),
         message: `Skipped (${detail})`,
       });

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -166,7 +166,7 @@ export function matchesQuotaProviderCurrentSelection(params: {
       return matchesCurrentModel(qualifiedModel);
     }
 
-    return catalogShape ? params.provider.id === catalogShape.id : false;
+    return false;
   }
 
   return params.currentModel ? matchesCurrentModel(params.currentModel) : false;

--- a/src/lib/quota-state.ts
+++ b/src/lib/quota-state.ts
@@ -196,9 +196,10 @@ function isQuotaToastError(value: unknown): boolean {
 
   const error = value as Record<string, unknown>;
   return (
-    hasOnlyKeys(error, ["label", "message"]) &&
+    hasOnlyKeys(error, ["label", "message", "kind"]) &&
     typeof error.label === "string" &&
-    typeof error.message === "string"
+    typeof error.message === "string" &&
+    (error.kind === undefined || error.kind === "intentional-filter")
   );
 }
 

--- a/src/lib/tui-compact-format.ts
+++ b/src/lib/tui-compact-format.ts
@@ -221,18 +221,19 @@ export function buildCompactQuotaStatusLine(params: {
   const data = sanitizeQuotaRenderData(params.data);
   const percentDisplayMode = params.percentDisplayMode ?? "remaining";
   const segments = formatCompactEntrySegments({ entries: data.entries, percentDisplayMode });
+  const issues = data.errors.filter((error) => error.kind !== "intentional-filter");
 
   const sessionTokensSegment = formatCompactSessionTokensSegment(data);
   if (sessionTokensSegment) {
     segments.push(sessionTokensSegment);
   }
 
-  if (data.errors.length > 0) {
+  if (issues.length > 0) {
     if (segments.length === 0) {
-      const errorSegment = formatFirstErrorSegment(data.errors);
+      const errorSegment = formatFirstErrorSegment(issues);
       if (errorSegment) segments.push(errorSegment);
     } else {
-      const issueSegment = formatIssueCount(data.errors.length);
+      const issueSegment = formatIssueCount(issues.length);
       const candidate = [...segments, issueSegment].join(COMPACT_SEGMENT_SEPARATOR);
       if (compactText(candidate).length <= maxWidth) {
         segments.push(issueSegment);

--- a/src/providers/google-gemini-cli.ts
+++ b/src/providers/google-gemini-cli.ts
@@ -30,7 +30,9 @@ function isGeminiCliModel(model: string): boolean {
   if (["google-gemini-cli", "gemini-cli", "gemini", "opencode-gemini-auth"].includes(providerId)) {
     return true;
   }
-  return providerId === "google" && modelId.includes("gemini");
+  return (
+    providerId === "google" && !modelId.startsWith("antigravity-") && modelId.includes("gemini")
+  );
 }
 
 async function isGeminiCliConfigured(ctx: QuotaProviderContext): Promise<boolean> {

--- a/tests/plugin.quota-command.test.ts
+++ b/tests/plugin.quota-command.test.ts
@@ -1,6 +1,7 @@
 import { rm } from "fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { QuotaProviderContext } from "../src/lib/entries.js";
 import { DEFAULT_CONFIG } from "../src/lib/types.js";
 import {
   createAlibabaAuthModuleMock,
@@ -958,32 +959,60 @@ describe("/quota command behavior", () => {
     expect(injected).not.toContain("Providers detected");
   });
 
-  it("does not reuse shared /quota output after the current model changes in the same session", async () => {
+  it("invalidates model-scoped custom provider output when only the current model changes", async () => {
+    const quotaProviders = [
+      {
+        id: "shared-model-a",
+        providerId: "shared-provider",
+        label: "Shared Model A",
+        mode: "remote-api" as const,
+        url: "https://model-a.example/accounting",
+        format: "quota-v1" as const,
+        modelIds: ["model-a"],
+      },
+      {
+        id: "shared-model-b",
+        providerId: "shared-provider",
+        label: "Shared Model B",
+        mode: "remote-api" as const,
+        url: "https://model-b.example/accounting",
+        format: "quota-v1" as const,
+        modelIds: ["model-b"],
+      },
+    ];
     mocks.loadConfig.mockResolvedValue({
       ...DEFAULT_CONFIG,
       enabled: true,
+      enabledProviders: ["quota-providers"],
+      quotaProviders,
       onlyCurrentModel: true,
       showOnQuestion: false,
       showSessionTokens: false,
       minIntervalMs: 60_000,
     });
 
+    const { quotaProvidersProvider } = await import("../src/providers/quota-providers.js");
     const provider = {
-      id: "openai",
-      matchesCurrentModel: vi.fn((model?: string) => model === "openai/gpt-5"),
+      ...quotaProvidersProvider,
       isAvailable: vi.fn().mockResolvedValue(true),
-      fetch: vi.fn().mockResolvedValue({
+      fetch: vi.fn().mockImplementation(async (ctx: QuotaProviderContext) => ({
         attempted: true,
-        entries: [{ accounting: TEST_ACCOUNTING, name: "OpenAI Pro", percentRemaining: 95 }],
+        entries: [
+          {
+            accounting: TEST_ACCOUNTING,
+            name: ctx.config.currentModel === "model-a" ? "Shared Model A" : "Shared Model B",
+            percentRemaining: ctx.config.currentModel === "model-a" ? 95 : 60,
+          },
+        ],
         errors: [],
-      }),
+      })),
     };
     mocks.getProviders.mockReturnValue([provider]);
 
     const { QuotaToastPlugin } = await import("../src/plugin.js");
-    const client = createClient({ modelID: "openai/gpt-5", providerID: "openai" });
+    const client = createClient({ modelID: "model-a", providerID: "shared-provider" });
     let currentSession = {
-      data: { model: { id: "openai/gpt-5", providerID: "openai" } },
+      data: { model: { id: "model-a", providerID: "shared-provider" } },
     };
     client.session.get = vi.fn().mockImplementation(async () => currentSession);
 
@@ -995,7 +1024,7 @@ describe("/quota command behavior", () => {
     });
 
     currentSession = {
-      data: { model: { id: "openai/gpt-4.1", providerID: "openai" } },
+      data: { model: { id: "model-b", providerID: "shared-provider" } },
     };
 
     const secondInjected = await buildDialogOutput({
@@ -1004,10 +1033,9 @@ describe("/quota command behavior", () => {
     });
 
     expect(firstInjected).toContain("95% left");
-    expect(secondInjected).toContain(
-      "No enabled quota providers matched the current model: openai/gpt-4.1.",
-    );
+    expect(secondInjected).toContain("60% left");
     expect(secondInjected).not.toContain("95% left");
+    expect(provider.fetch).toHaveBeenCalledTimes(2);
   });
 
   it("reuses shared quota-state across /quota sessions when render context matches", async () => {

--- a/tests/quota-render-data.test.ts
+++ b/tests/quota-render-data.test.ts
@@ -34,6 +34,8 @@ import {
 } from "../src/lib/quota-render-data.js";
 import { __resetQuotaStateForTests } from "../src/lib/quota-state.js";
 import { DEFAULT_CONFIG, type QuotaToastConfig } from "../src/lib/types.js";
+import { googleAntigravityProvider } from "../src/providers/google-antigravity.js";
+import { googleGeminiCliProvider } from "../src/providers/google-gemini-cli.js";
 
 function renderConfig(overrides: Partial<QuotaToastConfig> = {}): QuotaToastConfig {
   return { ...DEFAULT_CONFIG, showSessionTokens: false, ...overrides };
@@ -406,6 +408,21 @@ describe("collectQuotaRenderData shared quota state", () => {
   });
 
   it.each([
+    ["claude", "anthropic"],
+    ["open-cursor", "cursor"],
+    ["qwen", "qwen-code"],
+    ["alibaba", "alibaba-coding-plan"],
+  ])("fails closed for normalization-only provider synonym %s", (currentProviderID, providerId) => {
+    expect(
+      matchesQuotaProviderCurrentSelection({
+        provider: testProvider(providerId),
+        currentProviderID,
+        currentModel: "unprefixed-model-id",
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
     ["gemini-2.5-pro", "google-gemini-cli"],
     ["antigravity-claude-sonnet", "google-antigravity"],
   ])("uses model matching to disambiguate the shared google runtime ID for %s", (currentModel, selectedProviderId) => {
@@ -431,6 +448,20 @@ describe("collectQuotaRenderData shared quota state", () => {
         currentProviderID: "google",
       });
     }
+  });
+
+  it("does not let Gemini CLI claim an Antigravity model containing gemini", () => {
+    const selection = {
+      currentProviderID: "google",
+      currentModel: "antigravity-gemini-3-pro",
+    };
+
+    expect(
+      matchesQuotaProviderCurrentSelection({ provider: googleAntigravityProvider, ...selection }),
+    ).toBe(true);
+    expect(
+      matchesQuotaProviderCurrentSelection({ provider: googleGeminiCliProvider, ...selection }),
+    ).toBe(false);
   });
 
   it("fails closed for an unknown explicit provider ID instead of broad model matching", () => {

--- a/tests/quota-render-data.test.ts
+++ b/tests/quota-render-data.test.ts
@@ -318,6 +318,48 @@ describe("collectQuotaRenderData shared quota state", () => {
     ]);
   });
 
+  it("marks providers excluded by current-model filtering as intentional diagnostics", async () => {
+    const openaiProvider = testProvider("openai", {
+      entries: [{ accounting: TEST_ACCOUNTING, name: "OpenAI", percentRemaining: 75 }],
+    });
+    const xaiProvider = testProvider("xai");
+    const ollamaProvider = testProvider("ollama-cloud");
+    const openrouterProvider = testProvider("openrouter");
+
+    const result = await collectQuotaRenderData({
+      client: TEST_CLIENT,
+      config: renderConfig({
+        enabledProviders: ["openai", "xai", "ollama-cloud", "openrouter"],
+        onlyCurrentModel: true,
+      }),
+      request: {
+        sessionID: "explicit-openai-session",
+        sessionMeta: { providerID: "openai", modelID: "gpt-5.6-sol" },
+      },
+      surfaceExplicitProviderIssues: true,
+      formatStyle: "allWindows",
+      providers: [openaiProvider, xaiProvider, ollamaProvider, openrouterProvider],
+    });
+
+    expect(result.data?.errors).toEqual([
+      {
+        kind: "intentional-filter",
+        label: "xAI",
+        message: "Skipped (current model: gpt-5.6-sol)",
+      },
+      {
+        kind: "intentional-filter",
+        label: "Ollama Cloud",
+        message: "Skipped (current model: gpt-5.6-sol)",
+      },
+      {
+        kind: "intentional-filter",
+        label: "OpenRouter",
+        message: "Skipped (current model: gpt-5.6-sol)",
+      },
+    ]);
+  });
+
   it("normalizes provider-only session metadata before matching providers", () => {
     expect(
       matchesQuotaProviderCurrentSelection({
@@ -327,23 +369,100 @@ describe("collectQuotaRenderData shared quota state", () => {
     ).toBe(true);
   });
 
-  it("uses currentModel matching when currentProviderID is also present", () => {
-    const provider = {
-      id: "openai",
+  it("selects an explicit OpenAI provider for an unprefixed OpenAI model", () => {
+    const openaiProvider = {
+      ...testProvider("openai"),
       matchesCurrentModel: vi.fn().mockReturnValue(false),
     };
 
     expect(
       matchesQuotaProviderCurrentSelection({
-        provider: provider as any,
+        provider: openaiProvider,
         currentProviderID: "openai",
-        currentModel: "anthropic/claude-sonnet-4",
+        currentModel: "gpt-5.6-sol",
+      }),
+    ).toBe(true);
+    expect(openaiProvider.matchesCurrentModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["chatgpt", "openai"],
+    ["codex", "openai"],
+    ["chutes-ai", "chutes"],
+  ])("selects the catalog provider for runtime alias %s", (currentProviderID, providerId) => {
+    const provider = {
+      ...testProvider(providerId),
+      matchesCurrentModel: vi.fn().mockReturnValue(false),
+    };
+
+    expect(
+      matchesQuotaProviderCurrentSelection({
+        provider,
+        currentProviderID,
+        currentModel: "unprefixed-model-id",
+      }),
+    ).toBe(true);
+    expect(provider.matchesCurrentModel).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["gemini-2.5-pro", "google-gemini-cli"],
+    ["antigravity-claude-sonnet", "google-antigravity"],
+  ])("uses model matching to disambiguate the shared google runtime ID for %s", (currentModel, selectedProviderId) => {
+    const antigravityProvider = {
+      ...testProvider("google-antigravity"),
+      matchesCurrentModel: vi.fn((model: string) => model === "google/antigravity-claude-sonnet"),
+    };
+    const geminiProvider = {
+      ...testProvider("google-gemini-cli"),
+      matchesCurrentModel: vi.fn((model: string) => model === "google/gemini-2.5-pro"),
+    };
+
+    for (const provider of [antigravityProvider, geminiProvider]) {
+      expect(
+        matchesQuotaProviderCurrentSelection({
+          provider,
+          currentProviderID: "google",
+          currentModel,
+        }),
+      ).toBe(provider.id === selectedProviderId);
+      expect(provider.matchesCurrentModel).toHaveBeenCalledWith(`google/${currentModel}`, {
+        enabledProviders: "auto",
+        currentProviderID: "google",
+      });
+    }
+  });
+
+  it("fails closed for an unknown explicit provider ID instead of broad model matching", () => {
+    const openaiProvider = {
+      ...testProvider("openai"),
+      matchesCurrentModel: vi.fn().mockReturnValue(true),
+    };
+
+    expect(
+      matchesQuotaProviderCurrentSelection({
+        provider: openaiProvider,
+        currentProviderID: "private-openai-compatible-gateway",
+        currentModel: "openai/gpt-5.6-sol",
       }),
     ).toBe(false);
-    expect(provider.matchesCurrentModel).toHaveBeenCalledWith("anthropic/claude-sonnet-4", {
-      enabledProviders: "auto",
-      currentProviderID: "openai",
-    });
+    expect(openaiProvider.matchesCurrentModel).not.toHaveBeenCalled();
+  });
+
+  it("does not select OpenAI for an explicit OpenRouter provider with an OpenAI-looking model", () => {
+    const openaiProvider = {
+      ...testProvider("openai"),
+      matchesCurrentModel: vi.fn().mockReturnValue(true),
+    };
+
+    expect(
+      matchesQuotaProviderCurrentSelection({
+        provider: openaiProvider,
+        currentProviderID: "openrouter",
+        currentModel: "openai/gpt-5.6-sol",
+      }),
+    ).toBe(false);
+    expect(openaiProvider.matchesCurrentModel).not.toHaveBeenCalled();
   });
 
   it("passes explicit enabledProviders context into current-model matching", () => {
@@ -364,7 +483,7 @@ describe("collectQuotaRenderData shared quota state", () => {
     });
   });
 
-  it("selects quota providers by exact model and permits provider-only identity only for provider-wide sources", () => {
+  it("keeps model-level matching for quota providers that share a provider ID", () => {
     const quotaProviders = [
       {
         id: "wide",
@@ -381,7 +500,7 @@ describe("collectQuotaRenderData shared quota state", () => {
         mode: "remote-api",
         url: "https://model.example/accounting",
         format: "quota-v1" as const,
-        modelIds: ["company/model-a"],
+        modelIds: ["model-a"],
       },
     ];
     const provider = {
@@ -402,11 +521,16 @@ describe("collectQuotaRenderData shared quota state", () => {
     expect(
       matchesQuotaProviderCurrentSelection({
         provider: provider as any,
-        currentModel: "company/model-a",
+        currentModel: "model-a",
         currentProviderID: "company",
         quotaProviders,
       }),
     ).toBe(true);
+    expect(provider.matchesCurrentModel).toHaveBeenCalledWith("model-a", {
+      enabledProviders: "auto",
+      currentProviderID: "company",
+      quotaProviders,
+    });
     expect(
       matchesQuotaProviderCurrentSelection({
         provider: provider as any,

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -625,7 +625,13 @@ describe("quota-state shared cache", () => {
       fetch: vi.fn().mockResolvedValue({
         attempted: true,
         entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 55 }],
-        errors: [],
+        errors: [
+          {
+            kind: "intentional-filter",
+            label: "OpenRouter",
+            message: "Skipped (current model: synthetic/default)",
+          },
+        ],
       }),
     } as any;
 
@@ -647,7 +653,13 @@ describe("quota-state shared cache", () => {
     expect(second).toEqual({
       attempted: true,
       entries: [{ accounting: TEST_ACCOUNTING, name: "Synthetic", percentRemaining: 55 }],
-      errors: [],
+      errors: [
+        {
+          kind: "intentional-filter",
+          label: "OpenRouter",
+          message: "Skipped (current model: synthetic/default)",
+        },
+      ],
     });
     expect(provider.fetch).toHaveBeenCalledTimes(1);
   });

--- a/tests/tui-compact-format.test.ts
+++ b/tests/tui-compact-format.test.ts
@@ -255,6 +255,53 @@ describe("buildCompactQuotaStatusLine", () => {
     expect(line).toBe("Copilot 75% | +2 issues");
   });
 
+  it("does not count providers intentionally excluded by current-model filtering", () => {
+    const line = buildCompactQuotaStatusLine({
+      maxWidth: 96,
+      data: {
+        entries: [{ name: "OpenAI", percentRemaining: 75 }],
+        errors: [
+          {
+            kind: "intentional-filter",
+            label: "xAI",
+            message: "Skipped (current model: gpt-5.6-sol)",
+          },
+          {
+            kind: "intentional-filter",
+            label: "Ollama Cloud",
+            message: "Skipped (current model: gpt-5.6-sol)",
+          },
+          {
+            kind: "intentional-filter",
+            label: "OpenRouter",
+            message: "Skipped (current model: gpt-5.6-sol)",
+          },
+        ],
+      },
+    });
+
+    expect(line).toBe("OpenAI 75%");
+  });
+
+  it("still counts genuine errors alongside intentional current-model filtering", () => {
+    const line = buildCompactQuotaStatusLine({
+      maxWidth: 96,
+      data: {
+        entries: [{ name: "OpenAI", percentRemaining: 75 }],
+        errors: [
+          {
+            kind: "intentional-filter",
+            label: "OpenRouter",
+            message: "Skipped (current model: gpt-5.6-sol)",
+          },
+          { label: "OpenAI", message: "Failed to parse quota response" },
+        ],
+      },
+    });
+
+    expect(line).toBe("OpenAI 75% | +1 issue");
+  });
+
   it("renders the first error with a remaining count when no quota segments exist", () => {
     const line = buildCompactQuotaStatusLine({
       percentDisplayMode: "remaining",


### PR DESCRIPTION
## Summary

- prefer canonical explicit provider IDs and unique runtime aliases before model-name matching
- use model matching only to disambiguate shared runtime IDs such as `google`, while unknown explicit IDs fail closed
- preserve exact model-level matching for custom `quota-providers`
- keep intentional current-model filtering visible in verbose diagnostics without counting it as compact-status issues
- preserve the diagnostic discriminator through sanitization and persisted cache validation, with regression coverage for selection, compact output, and model-sensitive cache invalidation

This PR is intentionally limited to issue #223. It does not include the unreleased OpenCode live-model accessor or the additional formatting/reactivity changes from the local integration.

## Linked Issue

Fixes #223

## OpenCode Validation

- Current production released OpenCode version tested: `1.18.18`
- Why this version is relevant to the fix: it supplies `providerID` separately from an unprefixed `modelID`, reproducing the identity mismatch described in the issue.

## Environment

- macOS `26.5.1` on Apple Silicon (`arm64`)
- OpenCode `1.18.18`
- `opencode-quota` base version `4.8.1`
- Node.js `24.16.0`; pnpm `11.0.0`
- TUI compact status with `onlyCurrentModel: true` and multiple explicit providers
- Reproduction selection: `{ "providerID": "openai", "modelID": "gpt-5.6-sol" }`

This PR is tested against the released host contract and does not depend on the proposed OpenCode live-model accessor.

## Verification Performed

`pnpm verify` passed twice: once immediately before commit and again in the repository's pre-push hook. The gate completed Biome checks, the pinned TypeScript check, history/privacy verification, typecheck, build, the full test suite, four-surface parity, and package-content verification.

Results:

- 173 test files and 1,943 tests passed
- four-surface parity: 2 tests passed
- npm package contents: 616 files verified

Focused regression coverage verifies:

- canonical `openai` selects OpenAI for unprefixed `gpt-5.6-sol`
- unique runtime aliases such as `chatgpt`, `codex`, and `chutes-ai` select their catalog provider
- shared `google` identity is disambiguated by Gemini versus Antigravity model metadata
- unknown explicit providers and OpenRouter do not fall through to OpenAI-looking model names
- custom `quota-providers` retain exact provider/model matching
- intentional current-model exclusions stay in verbose diagnostics but do not become compact `+N issues`
- genuine provider errors still count in compact output
- the diagnostic kind survives persisted-cache validation
- changing only the selected model invalidates model-scoped custom-provider output

Manual reproduction used the OpenCode `1.18.18` TUI compact status with the environment and selection above.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed (not required: none changed)
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply (no provider is added)
