### PR TITLE
fix: make verification portable to Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,30 @@ jobs:
           path: package-artifacts/*
           if-no-files-found: error
 
+  windows-verify:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - name: Activate pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.0.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run canonical verification
+        run: pnpm verify
+
   runtime-smoke:
     runs-on: ubuntu-latest
     needs: pnpm-quality

--- a/scripts/lib/upstream-plugin-fs.mjs
+++ b/scripts/lib/upstream-plugin-fs.mjs
@@ -3,7 +3,12 @@ import path from "node:path";
 
 export async function safeRm(targetPath) {
   try {
-    await rm(targetPath, { force: true, recursive: true });
+    await rm(targetPath, {
+      force: true,
+      recursive: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   } catch {
     // best-effort cleanup
   }

--- a/scripts/verify-package-contents.mjs
+++ b/scripts/verify-package-contents.mjs
@@ -30,9 +30,13 @@ let rawManifest;
 if (manifestPath) {
   rawManifest = await readFile(path.resolve(repoRoot, manifestPath), "utf8");
 } else {
+  const pnpmCliPath = process.env.npm_execpath;
+  if (!pnpmCliPath) {
+    throw new Error("pnpm CLI path is unavailable; run this script through pnpm.");
+  }
   const result = spawnSync(
-    "pnpm",
-    ["--config.ignore-scripts=true", "pack", "--json", "--dry-run"],
+    process.execPath,
+    [pnpmCliPath, "--config.ignore-scripts=true", "pack", "--json", "--dry-run"],
     {
       cwd: repoRoot,
       encoding: "utf8",

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -8,6 +8,7 @@ const authMocks = vi.hoisted(() => ({
   readAuthFileCached: vi.fn(),
 }));
 
+import { join } from "node:path";
 import { execFile } from "child_process";
 import { readFile } from "fs/promises";
 import {
@@ -897,7 +898,7 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.message).toContain(
       "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
     );
-    expect(diagnostics.message).toContain(".claude/.credentials.json");
+    expect(diagnostics.message).toContain(join(".claude", ".credentials.json"));
 
     const quota = await queryAnthropicQuota();
     expect(quota?.success).toBe(false);
@@ -905,7 +906,7 @@ describe("Claude CLI diagnostics", () => {
       expect(quota.error).toContain(
         "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
       );
-      expect(quota.error).toContain(".claude/.credentials.json");
+      expect(quota.error).toContain(join(".claude", ".credentials.json"));
     }
     expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
     expect(readFileMock).toHaveBeenCalledTimes(1);
@@ -934,13 +935,13 @@ describe("Claude CLI diagnostics", () => {
     const diagnostics = await getAnthropicDiagnostics();
     expect(diagnostics.quotaSupported).toBe(false);
     expect(diagnostics.message).toContain("Claude Code-credentials");
-    expect(diagnostics.message).toContain(".claude/.credentials.json");
+    expect(diagnostics.message).toContain(join(".claude", ".credentials.json"));
 
     const quota = await queryAnthropicQuota();
     expect(quota?.success).toBe(false);
     if (quota && !quota.success) {
       expect(quota.error).toContain("Claude Code-credentials");
-      expect(quota.error).toContain(".claude/.credentials.json");
+      expect(quota.error).toContain(join(".claude", ".credentials.json"));
     }
     expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
     expect(readFileMock).toHaveBeenCalledTimes(1);
@@ -1394,7 +1395,7 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.message).toContain(
       "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
     );
-    expect(diagnostics.message).toContain(".claude/.credentials.json");
+    expect(diagnostics.message).toContain(join(".claude", ".credentials.json"));
     await expect(hasAnthropicCredentialsConfigured()).resolves.toBe(true);
 
     const quota = await queryAnthropicQuota();
@@ -1403,7 +1404,7 @@ describe("Claude CLI diagnostics", () => {
       expect(quota.error).toContain(
         "Claude CLI auth detected, but quota was unavailable from the local CLI and OAuth credential sources.",
       );
-      expect(quota.error).toContain(".claude/.credentials.json");
+      expect(quota.error).toContain(join(".claude", ".credentials.json"));
     }
   });
 

--- a/tests/lib.config-file-utils.test.ts
+++ b/tests/lib.config-file-utils.test.ts
@@ -1,10 +1,14 @@
-import { join } from "node:path";
+import { resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
   getEffectiveConfigRoot,
   resolveRuntimeContextRoots,
 } from "../src/lib/config-file-utils.js";
+
+const PROJECT_ROOT = resolve("home", "user", "project");
+const WORKSPACE_ROOT = resolve("work", "repo");
+const FALLBACK_DIRECTORY = resolve(WORKSPACE_ROOT, "packages", "app");
 
 describe("getEffectiveConfigRoot", () => {
   const original = process.env.OPENCODE_CONFIG_DIR;
@@ -19,24 +23,23 @@ describe("getEffectiveConfigRoot", () => {
 
   it("returns fallback when OPENCODE_CONFIG_DIR is not set", () => {
     delete process.env.OPENCODE_CONFIG_DIR;
-    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/home/user/project");
+    expect(getEffectiveConfigRoot(PROJECT_ROOT)).toBe(PROJECT_ROOT);
   });
 
   it("returns OPENCODE_CONFIG_DIR when set", () => {
-    process.env.OPENCODE_CONFIG_DIR = "/custom/config";
-    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/custom/config");
+    const customConfig = resolve("custom", "config");
+    process.env.OPENCODE_CONFIG_DIR = customConfig;
+    expect(getEffectiveConfigRoot(PROJECT_ROOT)).toBe(customConfig);
   });
 
   it("resolves relative OPENCODE_CONFIG_DIR from fallback", () => {
     process.env.OPENCODE_CONFIG_DIR = ".opencode";
-    expect(getEffectiveConfigRoot("/home/user/project")).toBe(
-      join("/home/user/project", ".opencode"),
-    );
+    expect(getEffectiveConfigRoot(PROJECT_ROOT)).toBe(resolve(PROJECT_ROOT, ".opencode"));
   });
 
   it("ignores whitespace-only OPENCODE_CONFIG_DIR", () => {
     process.env.OPENCODE_CONFIG_DIR = "   ";
-    expect(getEffectiveConfigRoot("/home/user/project")).toBe("/home/user/project");
+    expect(getEffectiveConfigRoot(PROJECT_ROOT)).toBe(PROJECT_ROOT);
   });
 });
 
@@ -55,26 +58,27 @@ describe("resolveRuntimeContextRoots", () => {
     process.env.OPENCODE_CONFIG_DIR = ".opencode";
     expect(
       resolveRuntimeContextRoots({
-        workspaceRoot: "/work/repo",
-        fallbackDirectory: "/work/repo/packages/app",
+        workspaceRoot: WORKSPACE_ROOT,
+        fallbackDirectory: FALLBACK_DIRECTORY,
       }),
     ).toEqual({
-      workspaceRoot: "/work/repo",
-      configRoot: "/work/repo/.opencode",
+      workspaceRoot: WORKSPACE_ROOT,
+      configRoot: resolve(WORKSPACE_ROOT, ".opencode"),
     });
   });
 
   it("uses explicit configRoot as-is without re-applying OPENCODE_CONFIG_DIR", () => {
     process.env.OPENCODE_CONFIG_DIR = ".opencode";
+    const explicitConfigRoot = resolve(WORKSPACE_ROOT, ".explicit");
     expect(
       resolveRuntimeContextRoots({
-        workspaceRoot: "/work/repo",
-        configRoot: "/work/repo/.explicit",
-        fallbackDirectory: "/work/repo/packages/app",
+        workspaceRoot: WORKSPACE_ROOT,
+        configRoot: explicitConfigRoot,
+        fallbackDirectory: FALLBACK_DIRECTORY,
       }),
     ).toEqual({
-      workspaceRoot: "/work/repo",
-      configRoot: "/work/repo/.explicit",
+      workspaceRoot: WORKSPACE_ROOT,
+      configRoot: explicitConfigRoot,
     });
   });
 });

--- a/tests/lib.copilot.test.ts
+++ b/tests/lib.copilot.test.ts
@@ -1,4 +1,21 @@
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const testPaths = vi.hoisted(() => {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  const homeDir =
+    process.platform === "win32"
+      ? ["C:", "Users", "test"].join(separator)
+      : ["", "home", "test"].join(separator);
+  const withinHome = (...parts: string[]) => [homeDir, ...parts].join(separator);
+  return {
+    dataDir: withinHome(".local", "share", "opencode"),
+    configDir: withinHome(".config", "opencode"),
+    cacheDir: withinHome(".cache", "opencode"),
+    stateDir: withinHome(".local", "state", "opencode"),
+  };
+});
 
 const fsMocks = vi.hoisted(() => ({
   existsSync: vi.fn(() => false),
@@ -20,10 +37,10 @@ vi.mock("fs", async (importOriginal) => {
 
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirCandidates: () => ({
-    dataDirs: ["/home/test/.local/share/opencode"],
-    configDirs: ["/home/test/.config/opencode"],
-    cacheDirs: ["/home/test/.cache/opencode"],
-    stateDirs: ["/home/test/.local/state/opencode"],
+    dataDirs: [testPaths.dataDir],
+    configDirs: [testPaths.configDir],
+    cacheDirs: [testPaths.cacheDir],
+    stateDirs: [testPaths.stateDir],
   }),
 }));
 
@@ -31,7 +48,7 @@ vi.mock("../src/lib/opencode-auth.js", () => ({
   readAuthFile: authMocks.readAuthFile,
 }));
 
-const patPath = "/home/test/.config/opencode/copilot-quota-token.json";
+const patPath = join(testPaths.configDir, "copilot-quota-token.json");
 
 function configure(value: Record<string, unknown>): void {
   fsMocks.existsSync.mockImplementation((path) => path === patPath);

--- a/tests/lib.cursor-detection.test.ts
+++ b/tests/lib.cursor-detection.test.ts
@@ -1,6 +1,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockFiles = vi.hoisted(() => new Map<string, string>());
+const { mockFiles, testPaths } = vi.hoisted(() => {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  const join = (...parts: string[]) => parts.join(separator);
+  const root = join(process.cwd(), ".cursor-detection-test");
+  const home = join(root, "home");
+  const config = join(root, "config");
+  return {
+    mockFiles: new Map<string, string>(),
+    testPaths: {
+      home,
+      auth: join(root, "auth.json"),
+      cursorAuth: join(home, ".config", "cursor", "auth.json"),
+      config,
+      opencodeConfig: join(config, "opencode.json"),
+      data: join(root, "data"),
+      cache: join(root, "cache"),
+      state: join(root, "state"),
+    },
+  };
+});
 
 vi.mock("fs", () => ({
   existsSync: vi.fn((path: string) => mockFiles.has(path)),
@@ -19,21 +38,21 @@ vi.mock("os", async () => {
   const actual = await vi.importActual<typeof import("os")>("os");
   return {
     ...actual,
-    homedir: () => "/tmp/home",
+    homedir: () => testPaths.home,
     platform: () => "linux",
   };
 });
 
 vi.mock("../src/lib/opencode-auth.js", () => ({
-  getAuthPaths: () => ["/tmp/auth.json"],
+  getAuthPaths: () => [testPaths.auth],
 }));
 
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirCandidates: () => ({
-    dataDirs: ["/tmp/data"],
-    configDirs: ["/tmp/config"],
-    cacheDirs: ["/tmp/cache"],
-    stateDirs: ["/tmp/state"],
+    dataDirs: [testPaths.data],
+    configDirs: [testPaths.config],
+    cacheDirs: [testPaths.cache],
+    stateDirs: [testPaths.state],
   }),
 }));
 
@@ -46,7 +65,7 @@ describe("cursor detection", () => {
 
   it("prefers Cursor OAuth auth in OpenCode auth.json", async () => {
     mockFiles.set(
-      "/tmp/auth.json",
+      testPaths.auth,
       JSON.stringify({
         cursor: {
           type: "oauth",
@@ -54,23 +73,20 @@ describe("cursor detection", () => {
         },
       }),
     );
-    mockFiles.set(
-      "/tmp/home/.config/cursor/auth.json",
-      JSON.stringify({ accessToken: "legacy-token" }),
-    );
+    mockFiles.set(testPaths.cursorAuth, JSON.stringify({ accessToken: "legacy-token" }));
 
     const { inspectCursorAuthPresence } = await import("../src/lib/cursor-detection.js");
     const result = await inspectCursorAuthPresence();
 
     expect(result.state).toBe("present");
-    expect(result.selectedPath).toBe("/tmp/auth.json");
-    expect(result.presentPaths).toContain("/tmp/auth.json");
-    expect(result.presentPaths).toContain("/tmp/home/.config/cursor/auth.json");
+    expect(result.selectedPath).toBe(testPaths.auth);
+    expect(result.presentPaths).toContain(testPaths.auth);
+    expect(result.presentPaths).toContain(testPaths.cursorAuth);
   });
 
   it("detects the canonical Cursor companion package and provider.cursor config", async () => {
     mockFiles.set(
-      "/tmp/config/opencode.json",
+      testPaths.opencodeConfig,
       JSON.stringify({
         plugin: ["@playwo/opencode-cursor-oauth"],
         provider: {
@@ -89,7 +105,7 @@ describe("cursor detection", () => {
     expect(CURSOR_CANONICAL_PLUGIN_PACKAGE).toBe("@playwo/opencode-cursor-oauth");
     expect(result.pluginEnabled).toBe(true);
     expect(result.providerConfigured).toBe(true);
-    expect(result.matchedPaths).toEqual(["/tmp/config/opencode.json"]);
+    expect(result.matchedPaths).toEqual([testPaths.opencodeConfig]);
   });
 
   it("keeps legacy Cursor plugin names as compatibility aliases", async () => {
@@ -107,7 +123,7 @@ describe("cursor detection", () => {
     for (const alias of aliases) {
       mockFiles.clear();
       mockFiles.set(
-        "/tmp/config/opencode.json",
+        testPaths.opencodeConfig,
         JSON.stringify({
           plugin: [alias],
         }),
@@ -117,13 +133,13 @@ describe("cursor detection", () => {
 
       expect(result.pluginEnabled, alias).toBe(true);
       expect(result.providerConfigured, alias).toBe(false);
-      expect(result.matchedPaths, alias).toEqual(["/tmp/config/opencode.json"]);
+      expect(result.matchedPaths, alias).toEqual([testPaths.opencodeConfig]);
     }
   });
 
   it("detects legacy cursor runtime ids in provider config without treating them as plugins", async () => {
     mockFiles.set(
-      "/tmp/config/opencode.json",
+      testPaths.opencodeConfig,
       JSON.stringify({
         plugin: ["some-other-plugin"],
         provider: {
@@ -139,6 +155,6 @@ describe("cursor detection", () => {
 
     expect(result.pluginEnabled).toBe(false);
     expect(result.providerConfigured).toBe(true);
-    expect(result.matchedPaths).toEqual(["/tmp/config/opencode.json"]);
+    expect(result.matchedPaths).toEqual([testPaths.opencodeConfig]);
   });
 });

--- a/tests/lib.google-token-cache.test.ts
+++ b/tests/lib.google-token-cache.test.ts
@@ -1,4 +1,19 @@
+import { dirname } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const testPaths = vi.hoisted(() => {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  const join = (...parts: string[]) => parts.join(separator);
+  const root = join(process.cwd(), ".google-token-cache-test");
+  const cacheDir = join(root, "cache", "opencode");
+  return {
+    dataDir: join(root, "data", "opencode"),
+    configDir: join(root, "config", "opencode"),
+    cacheDir,
+    stateDir: join(root, "state", "opencode"),
+    cachePath: join(cacheDir, "opencode-quota", "google-access-tokens.json"),
+  };
+});
 
 vi.mock("fs/promises", () => ({
   mkdir: vi.fn(async () => undefined),
@@ -12,14 +27,14 @@ vi.mock("fs/promises", () => ({
 
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirs: () => ({
-    dataDir: "/tmp/data/opencode",
-    configDir: "/tmp/config/opencode",
-    cacheDir: "/tmp/cache/opencode",
-    stateDir: "/tmp/state/opencode",
+    dataDir: testPaths.dataDir,
+    configDir: testPaths.configDir,
+    cacheDir: testPaths.cacheDir,
+    stateDir: testPaths.stateDir,
   }),
 }));
 
-const CACHE_PATH = "/tmp/cache/opencode/opencode-quota/google-access-tokens.json";
+const CACHE_PATH = testPaths.cachePath;
 
 function entry(accessToken: string) {
   return {
@@ -42,7 +57,7 @@ describe("google-token-cache", () => {
 
     await setCachedAccessToken({ key: "account-key", entry: entry("access-token") });
 
-    expect(mkdir).toHaveBeenCalledWith("/tmp/cache/opencode/opencode-quota", {
+    expect(mkdir).toHaveBeenCalledWith(dirname(CACHE_PATH), {
       recursive: true,
       mode: 0o700,
     });

--- a/tests/lib.google.auth-presence.test.ts
+++ b/tests/lib.google.auth-presence.test.ts
@@ -8,6 +8,22 @@ const fsMocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
 }));
 
+const testPaths = vi.hoisted(() => {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  const join = (...parts: string[]) => parts.join(separator);
+  const root = join(process.cwd(), ".google-auth-presence-test");
+  const configDir = join(root, "config", "opencode");
+  const dataDir = join(root, "data", "opencode");
+  return {
+    configDir,
+    dataDir,
+    cacheDir: join(root, "cache", "opencode"),
+    stateDir: join(root, "state", "opencode"),
+    configPath: join(configDir, "antigravity-accounts.json"),
+    dataPath: join(dataDir, "antigravity-accounts.json"),
+  };
+});
+
 vi.mock("fs/promises", () => ({
   readFile: promiseMocks.readFile,
 }));
@@ -18,10 +34,10 @@ vi.mock("fs", () => ({
 
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirCandidates: () => ({
-    dataDirs: ["/home/test/.local/share/opencode"],
-    configDirs: ["/home/test/.config/opencode"],
-    cacheDirs: ["/home/test/.cache/opencode"],
-    stateDirs: ["/home/test/.local/state/opencode"],
+    dataDirs: [testPaths.dataDir],
+    configDirs: [testPaths.configDir],
+    cacheDirs: [testPaths.cacheDir],
+    stateDirs: [testPaths.stateDir],
   }),
 }));
 
@@ -31,8 +47,8 @@ import {
   readAntigravityAccounts,
 } from "../src/lib/google.js";
 
-const CONFIG_PATH = "/home/test/.config/opencode/antigravity-accounts.json";
-const DATA_PATH = "/home/test/.local/share/opencode/antigravity-accounts.json";
+const CONFIG_PATH = testPaths.configPath;
+const DATA_PATH = testPaths.dataPath;
 
 describe("google antigravity auth presence", () => {
   beforeEach(() => {

--- a/tests/lib.mimo.security.test.ts
+++ b/tests/lib.mimo.security.test.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +16,8 @@ vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
 }));
 
 const originalEnv = process.env;
+const primaryConfigDir = join(tmpdir(), "trusted", "primary");
+const fallbackConfigDir = join(tmpdir(), "trusted", "fallback");
 
 describe("MiMo credential security boundary", () => {
   beforeEach(() => {
@@ -22,7 +26,7 @@ describe("MiMo credential security boundary", () => {
     process.env = { ...originalEnv };
     delete process.env.MIMO_USAGE_COOKIE;
     mocks.getOpencodeRuntimeDirCandidates.mockReturnValue({
-      configDirs: ["/trusted/primary", "/trusted/fallback"],
+      configDirs: [primaryConfigDir, fallbackConfigDir],
     });
     mocks.readFile.mockImplementation(async () => {
       const error = new Error("missing") as NodeJS.ErrnoException;
@@ -40,8 +44,8 @@ describe("MiMo credential security boundary", () => {
 
     await expect(resolveMimoConfig()).resolves.toEqual({ state: "none" });
     expect(mocks.readFile.mock.calls.map((call) => call[0])).toEqual([
-      "/trusted/primary/opencode-quota/mimo.json",
-      "/trusted/fallback/opencode-quota/mimo.json",
+      join(primaryConfigDir, "opencode-quota", "mimo.json"),
+      join(fallbackConfigDir, "opencode-quota", "mimo.json"),
     ]);
 
     const checked = JSON.stringify(mocks.readFile.mock.calls);

--- a/tests/lib.opencode-config-read.test.ts
+++ b/tests/lib.opencode-config-read.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -23,16 +23,18 @@ function tempDir(): string {
 
 describe("read-only OpenCode config mechanics", () => {
   it("builds candidates in caller-supplied directory and format order", () => {
+    const globalDir = join("root", "global");
+    const workspaceDir = join("root", "workspace");
     expect(
       buildOpenCodeConfigCandidates({
-        directories: ["/global", "/workspace"],
+        directories: [globalDir, workspaceDir],
         formatOrder: ["jsonc", "json"],
       }),
     ).toEqual([
-      { path: "/global/opencode.jsonc", format: "jsonc" },
-      { path: "/global/opencode.json", format: "json" },
-      { path: "/workspace/opencode.jsonc", format: "jsonc" },
-      { path: "/workspace/opencode.json", format: "json" },
+      { path: join(globalDir, "opencode.jsonc"), format: "jsonc" },
+      { path: join(globalDir, "opencode.json"), format: "json" },
+      { path: join(workspaceDir, "opencode.jsonc"), format: "jsonc" },
+      { path: join(workspaceDir, "opencode.json"), format: "json" },
     ]);
   });
 

--- a/tests/lib.opencode-runtime-paths.test.ts
+++ b/tests/lib.opencode-runtime-paths.test.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -17,10 +18,10 @@ describe("opencode-runtime-paths", () => {
 
     const dirs = getOpencodeRuntimeDirs({ env, homeDir: "/home/test" });
     expect(dirs).toEqual({
-      dataDir: "/x/data/opencode",
-      configDir: "/x/config/opencode",
-      cacheDir: "/x/cache/opencode",
-      stateDir: "/x/state/opencode",
+      dataDir: join(env.XDG_DATA_HOME!, "opencode"),
+      configDir: join(env.XDG_CONFIG_HOME!, "opencode"),
+      cacheDir: join(env.XDG_CACHE_HOME!, "opencode"),
+      stateDir: join(env.XDG_STATE_HOME!, "opencode"),
     });
   });
 
@@ -32,7 +33,7 @@ describe("opencode-runtime-paths", () => {
       },
       homeDir: "/home/test",
     });
-    expect(absolute.configDir).toBe("/custom/opencode");
+    expect(absolute.configDir).toBe(join("/custom", "opencode"));
 
     const relative = getOpencodeRuntimeDirs({
       env: {
@@ -41,7 +42,7 @@ describe("opencode-runtime-paths", () => {
       },
       homeDir: "/home/test",
     });
-    expect(relative.configDir).toBe("/x/config/opencode/work-profile");
+    expect(relative.configDir).toBe(join("/x/config", "opencode", "work-profile"));
 
     const candidates = getOpencodeRuntimeDirCandidates({
       platform: "linux",
@@ -51,7 +52,7 @@ describe("opencode-runtime-paths", () => {
       },
       homeDir: "/home/test",
     });
-    expect(candidates.configDirs[0]).toBe("/custom/opencode");
+    expect(candidates.configDirs[0]).toBe(join("/custom", "opencode"));
   });
 
   it("includes Windows APPDATA/LOCALAPPDATA fallbacks after primary", () => {
@@ -77,11 +78,11 @@ describe("opencode-runtime-paths", () => {
     expect(c.cacheDirs[0]).toBe(primary.cacheDir);
     expect(c.stateDirs[0]).toBe(primary.stateDir);
 
-    expect(c.dataDirs).toContain("C:/Users/u/AppData/Roaming/opencode");
-    expect(c.dataDirs).toContain("C:/Users/u/AppData/Local/opencode");
+    expect(c.dataDirs).toContain(join(env.APPDATA!, "opencode"));
+    expect(c.dataDirs).toContain(join(env.LOCALAPPDATA!, "opencode"));
 
-    expect(c.configDirs).toContain("C:/Users/u/AppData/Roaming/opencode");
-    expect(c.configDirs).toContain("C:/Users/u/AppData/Local/opencode");
+    expect(c.configDirs).toContain(join(env.APPDATA!, "opencode"));
+    expect(c.configDirs).toContain(join(env.LOCALAPPDATA!, "opencode"));
   });
 
   it("derives opencode.db candidates from runtime data dirs", () => {
@@ -113,7 +114,7 @@ describe("opencode-runtime-paths", () => {
       const candidates = getOpenCodeDbPathCandidates();
 
       // Ensure the primary candidate matches runtime primary (order matters).
-      expect(candidates[0]).toBe(dirs.dataDirs[0] + "/opencode.db");
+      expect(candidates[0]).toBe(join(dirs.dataDirs[0]!, "opencode.db"));
     } finally {
       process.env.XDG_DATA_HOME = prev.XDG_DATA_HOME;
       process.env.XDG_CONFIG_HOME = prev.XDG_CONFIG_HOME;

--- a/tests/lib.opencode-runtime-paths.test.ts
+++ b/tests/lib.opencode-runtime-paths.test.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -26,14 +26,15 @@ describe("opencode-runtime-paths", () => {
   });
 
   it("uses OPENCODE_CONFIG_DIR as the primary global config directory", () => {
+    const absoluteConfigDir = resolve("custom", "opencode");
     const absolute = getOpencodeRuntimeDirs({
       env: {
         XDG_CONFIG_HOME: "/x/config",
-        OPENCODE_CONFIG_DIR: "/custom/opencode",
+        OPENCODE_CONFIG_DIR: absoluteConfigDir,
       },
       homeDir: "/home/test",
     });
-    expect(absolute.configDir).toBe(join("/custom", "opencode"));
+    expect(absolute.configDir).toBe(absoluteConfigDir);
 
     const relative = getOpencodeRuntimeDirs({
       env: {
@@ -48,11 +49,11 @@ describe("opencode-runtime-paths", () => {
       platform: "linux",
       env: {
         XDG_CONFIG_HOME: "/x/config",
-        OPENCODE_CONFIG_DIR: "/custom/opencode",
+        OPENCODE_CONFIG_DIR: absoluteConfigDir,
       },
       homeDir: "/home/test",
     });
-    expect(candidates.configDirs[0]).toBe(join("/custom", "opencode"));
+    expect(candidates.configDirs[0]).toBe(absoluteConfigDir);
   });
 
   it("includes Windows APPDATA/LOCALAPPDATA fallbacks after primary", () => {

--- a/tests/lib.opencode-runtime-paths.test.ts
+++ b/tests/lib.opencode-runtime-paths.test.ts
@@ -43,7 +43,7 @@ describe("opencode-runtime-paths", () => {
       },
       homeDir: "/home/test",
     });
-    expect(relative.configDir).toBe(join("/x/config", "opencode", "work-profile"));
+    expect(relative.configDir).toBe(resolve(join("/x/config", "opencode"), "work-profile"));
 
     const candidates = getOpencodeRuntimeDirCandidates({
       platform: "linux",

--- a/tests/lib.quota-export.test.ts
+++ b/tests/lib.quota-export.test.ts
@@ -1,16 +1,31 @@
-import { readFileSync } from "fs";
-import { homedir } from "os";
-import { join } from "path";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // --------------- mock modules ---------------
 
+const testPaths = vi.hoisted(() => {
+  const separator = process.platform === "win32" ? "\\" : "/";
+  const join = (...parts: string[]) => parts.join(separator);
+  const root = join(process.cwd(), ".quota-export-test");
+  const cacheDir = join(root, "cache");
+  return {
+    dataDir: join(root, "data"),
+    configDir: join(root, "config"),
+    cacheDir,
+    stateDir: join(root, "state"),
+    defaultExport: join(cacheDir, "quota-export.json"),
+    explicitExport: join(root, "export.json"),
+  };
+});
+
 vi.mock("../src/lib/opencode-runtime-paths.js", () => ({
   getOpencodeRuntimeDirs: () => ({
-    dataDir: "/tmp/test-opencode-quota-export/data",
-    configDir: "/tmp/test-opencode-quota-export/config",
-    cacheDir: "/tmp/test-opencode-quota-export/cache",
-    stateDir: "/tmp/test-opencode-quota-export/state",
+    dataDir: testPaths.dataDir,
+    configDir: testPaths.configDir,
+    cacheDir: testPaths.cacheDir,
+    stateDir: testPaths.stateDir,
   }),
 }));
 
@@ -82,7 +97,7 @@ const QUOTA_ACCOUNTING = {
 
 describe("resolveExportPath", () => {
   it("handles empty, tilde, absolute, and relative paths", () => {
-    expect(resolveExportPath("")).toBe("/tmp/test-opencode-quota-export/cache/quota-export.json");
+    expect(resolveExportPath("")).toBe(testPaths.defaultExport);
     expect(resolveExportPath("~/my-exports/quota.json")).toBe(
       join(homedir(), "my-exports/quota.json"),
     );
@@ -699,9 +714,9 @@ describe("writeQuotaExport", () => {
 
   it("calls writeJsonAtomic with the resolved path and trailing newline", async () => {
     const exportData: any = { version: 2, providers: {} };
-    await writeQuotaExport(exportData, "/tmp/export.json");
+    await writeQuotaExport(exportData, testPaths.explicitExport);
 
-    expect(writeJsonAtomic).toHaveBeenCalledWith("/tmp/export.json", exportData, {
+    expect(writeJsonAtomic).toHaveBeenCalledWith(testPaths.explicitExport, exportData, {
       trailingNewline: true,
     });
   });

--- a/tests/lib.scoped-update-migration.test.ts
+++ b/tests/lib.scoped-update-migration.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -406,11 +407,15 @@ describe("migration candidate discovery", () => {
       selectedPackagePaths: [symlinkPath],
     });
 
+    const [realPath, realRoot] = await Promise.all([
+      realpath(workspaceFile),
+      realpath(workspaceRoot),
+    ]);
     expect(result.candidates).toHaveLength(1);
     expect(result.candidates[0]).toMatchObject({
       path: workspaceFile,
-      realPath: realpathSync(workspaceFile),
-      realRoot: realpathSync(workspaceRoot),
+      realPath,
+      realRoot,
     });
     expect(result.manualFindings).toEqual([
       {

--- a/tests/lib.scoped-update.test.ts
+++ b/tests/lib.scoped-update.test.ts
@@ -1008,9 +1008,10 @@ describe("scoped update application safety", () => {
     expect(readFileSync(config, "utf8")).toContain("provider-secret-canary");
   });
 
-  it("sanitizes display paths without creating invalid filesystem names", async () => {
+  it("sanitizes preview, failure, and final-result paths without Windows-invalid names", async () => {
     const root = tempDir();
-    const project = join(root, "project");
+    // Windows permits C1 controls in filenames; the display sanitizer still removes them.
+    const project = join(root, "project \u0085unsafe");
     mkdirSync(join(project, ".git"), { recursive: true });
     const config = join(project, "opencode.json");
     write(config, `{"plugin":["@slkiser/opencode-quota@3.11.1"]}`);
@@ -1032,6 +1033,7 @@ describe("scoped update application safety", () => {
     for (const message of log.mock.calls.flat()) {
       expect(hasControlCharacter(message)).toBe(false);
     }
+    expect(log.mock.calls.flat().join("\n")).toContain("project unsafe");
 
     write(config, `{"plugin":["@slkiser/opencode-quota@3.11.1"]}`);
     const plan = await planScopedUpdate(params);

--- a/tests/lib.scoped-update.test.ts
+++ b/tests/lib.scoped-update.test.ts
@@ -1008,9 +1008,9 @@ describe("scoped update application safety", () => {
     expect(readFileSync(config, "utf8")).toContain("provider-secret-canary");
   });
 
-  it("sanitizes preview, failure, and final-result paths to one line", async () => {
+  it("sanitizes display paths without creating invalid filesystem names", async () => {
     const root = tempDir();
-    const project = join(root, "project\n\u001b[31munsafe");
+    const project = join(root, "project");
     mkdirSync(join(project, ".git"), { recursive: true });
     const config = join(project, "opencode.json");
     write(config, `{"plugin":["@slkiser/opencode-quota@3.11.1"]}`);
@@ -1032,14 +1032,37 @@ describe("scoped update application safety", () => {
     for (const message of log.mock.calls.flat()) {
       expect(hasControlCharacter(message)).toBe(false);
     }
-    expect(log.mock.calls.flat().join("\n")).toContain("project unsafe");
 
     write(config, `{"plugin":["@slkiser/opencode-quota@3.11.1"]}`);
     const plan = await planScopedUpdate(params);
-    write(config, `{"plugin":["other-plugin"]}`);
-    const error = await applyScopedUpdatePlan(plan).catch((caught: unknown) => caught);
+    const unsafePath = `${config}\n\u001b[31munsafe`;
+    const unsafePlan = {
+      ...plan,
+      configPaths: plan.configPaths.map((path) => (path === config ? unsafePath : path)),
+      configEdits: plan.configEdits.map((edit) =>
+        edit.path === config ? { ...edit, path: unsafePath } : edit,
+      ),
+      configSnapshots: plan.configSnapshots.map((snapshot) =>
+        snapshot.path === config ? { ...snapshot, path: unsafePath } : snapshot,
+      ),
+      safeActions: plan.safeActions.map((action) =>
+        action.path === config ? { ...action, path: unsafePath } : action,
+      ),
+    };
+
+    const previewLines = formatScopedUpdatePreview(unsafePlan);
+    for (const line of previewLines) {
+      expect(hasControlCharacter(line)).toBe(false);
+    }
+    expect(previewLines.join("\n")).toContain("opencode.json unsafe");
+
+    const error = await applyScopedUpdatePlan(unsafePlan, {
+      readBytes: async () => {
+        throw new Error("simulated read failure");
+      },
+    }).catch((caught: unknown) => caught);
     expect(hasControlCharacter(String(error))).toBe(false);
-    expect(String(error)).toContain("project unsafe");
+    expect(String(error)).toContain("opencode.json unsafe");
   });
 
   it("keeps accepted update flags and two-code exits unchanged", async () => {

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -11,6 +11,7 @@ interface WorkflowStep {
 }
 
 interface WorkflowJob {
+  "runs-on"?: string;
   needs?: string | string[];
   permissions?: Record<string, string>;
   steps?: WorkflowStep[];
@@ -321,8 +322,12 @@ describe("package manifest compatibility", () => {
     );
   });
 
-  it("structures CI as one Node 24 pack followed by exact-artifact Node 22/24 smoke", () => {
-    expect(Object.keys(ciWorkflow.jobs).sort()).toEqual(["pnpm-quality", "runtime-smoke"]);
+  it("runs canonical verification on Ubuntu and Windows before exact-artifact smoke", () => {
+    expect(Object.keys(ciWorkflow.jobs).sort()).toEqual([
+      "pnpm-quality",
+      "runtime-smoke",
+      "windows-verify",
+    ]);
 
     const quality = ciWorkflow.jobs["pnpm-quality"];
     const checkout = quality.steps?.find((step) => step.uses === "actions/checkout@v6");
@@ -349,6 +354,18 @@ describe("package manifest compatibility", () => {
     expect(
       quality.steps?.filter((step) => step.run?.includes("pnpm run pack:release-package")),
     ).toHaveLength(1);
+
+    const windows = ciWorkflow.jobs["windows-verify"];
+    expect(windows["runs-on"]).toBe("windows-latest");
+    expect(
+      windows.steps?.find((step) => step.uses === "actions/checkout@v6")?.with?.["fetch-depth"],
+    ).toBe(0);
+    expect(
+      windows.steps?.find((step) => step.uses === "actions/setup-node@v6")?.with?.["node-version"],
+    ).toBe("24.x");
+    expect(namedStep(windows, "Install dependencies").run).toBe("pnpm install --frozen-lockfile");
+    expect(namedStep(windows, "Run canonical verification").run).toBe("pnpm verify");
+    expectCanonicalVerificationOnly(windows);
 
     expect(namedStep(quality, "Upload exact npm artifact")).toEqual(
       expect.objectContaining({

--- a/tests/plugin.qwen-hook.test.ts
+++ b/tests/plugin.qwen-hook.test.ts
@@ -40,6 +40,8 @@ vi.mock("../src/lib/alibaba-auth.js", () =>
 );
 vi.mock("../src/lib/modelsdev-pricing.js", () => createPricingModuleMock(mocks));
 
+const { QuotaToastPlugin } = await import("../src/plugin.js");
+
 describe("plugin question hook accounting boundary", () => {
   beforeEach(() => {
     seedDefaultPluginBootstrapMocks(mocks, {
@@ -48,7 +50,6 @@ describe("plugin question hook accounting boundary", () => {
   });
 
   it("does not treat a successful question-tool execution as a completed model request", async () => {
-    const { QuotaToastPlugin } = await import("../src/plugin.js");
     const client = createClient({ modelID: "qwen3-coder-plus", providerID: "qwen-code" });
     const hooks = await QuotaToastPlugin({ client } as any);
 
@@ -63,7 +64,6 @@ describe("plugin question hook accounting boundary", () => {
   });
 
   it("does not use question-tool failure metadata as accounting authority", async () => {
-    const { QuotaToastPlugin } = await import("../src/plugin.js");
     const client = createClient({ modelID: "qwen3-coder-plus", providerID: "qwen-code" });
     const hooks = await QuotaToastPlugin({ client } as any);
 

--- a/tests/release-gates.test.ts
+++ b/tests/release-gates.test.ts
@@ -111,17 +111,22 @@ describe("v4 release gates", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  it("verifies TypeScript 7 and keeps the v4 history free of local-only files", () => {
+  it("verifies TypeScript 7 and accepts clean v4 history", async () => {
     const typescript = run(typescriptScript);
     expect(typescript.status).toBe(0);
     expect(typescript.stdout).toContain(
       "TypeScript 7.0.2 and @opencode-ai/plugin 1.18.11 lock entries verified",
     );
 
-    const history = run(historyScript);
+    const historyRepo = path.join(tempDir, "clean-history");
+    const base = await createHistoryRepo(historyRepo);
+    const history = run(historyScript, [], {
+      V4_HISTORY_BASE: base,
+      V4_HISTORY_REPO: historyRepo,
+    });
     expect(history.status).toBe(0);
     expect(history.stdout).toContain("V4 history privacy verified");
-  }, 10_000);
+  });
 
   it("rejects every forced-added private path from temporary commit history", async () => {
     const historyRepo = path.join(tempDir, "history");

--- a/tests/tui-dist-packaging.test.ts
+++ b/tests/tui-dist-packaging.test.ts
@@ -29,6 +29,8 @@ async function exists(url: URL): Promise<boolean> {
   }
 }
 
+const packagedTui = await import("../dist/tui.js");
+
 describe("tui dist packaging", () => {
   it("ships the precompiled TUI entry and removes stale jsx artifacts", async () => {
     const distTui = new URL("../dist/tui.js", import.meta.url);
@@ -52,12 +54,10 @@ describe("tui dist packaging", () => {
     expect(source).not.toContain("jsx-dev-runtime");
   });
 
-  it("can load the packaged TUI module", async () => {
-    const mod = await import("../dist/tui.js");
-
-    expect(mod.default).toMatchObject({
+  it("can load the packaged TUI module", () => {
+    expect(packagedTui.default).toMatchObject({
       id: "@slkiser/opencode-quota",
     });
-    expect(typeof mod.default.tui).toBe("function");
+    expect(typeof packagedTui.default.tui).toBe("function");
   });
 });

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -223,9 +223,10 @@ function createApi() {
   };
 }
 
+const tuiPlugin = (await import("../src/tui.tsx")).default;
+
 async function loadTuiModule() {
-  const mod = await import("../src/tui.tsx");
-  return mod.default;
+  return tuiPlugin;
 }
 
 function deferred<T>() {

--- a/tests/tui-startup-runtime-resolution.test.ts
+++ b/tests/tui-startup-runtime-resolution.test.ts
@@ -247,7 +247,7 @@ import {
 const originalCwd = process.cwd();
 const originalEnv = { ...process.env };
 const reportResults: StartupRuntimeResult[] = [];
-let plugin: typeof import("../src/tui.tsx")["default"];
+const plugin = (await import("../src/tui.tsx")).default;
 
 function createElement(
   type: unknown,
@@ -528,10 +528,9 @@ async function runInitialSample(
   }
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   vi.useFakeTimers();
   (globalThis as { React?: unknown }).React = { createElement };
-  plugin = (await import("../src/tui.tsx")).default;
 });
 
 beforeEach(() => {

--- a/tests/upstream-plugin-fs.test.ts
+++ b/tests/upstream-plugin-fs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+const fsMocks = vi.hoisted(() => ({
+  rm: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs/promises")>()),
+  rm: fsMocks.rm,
+}));
+
+import { safeRm } from "../scripts/lib/upstream-plugin-fs.mjs";
+
+describe("upstream-plugin-fs", () => {
+  it("requests native retries for transient Windows cleanup failures", async () => {
+    fsMocks.rm.mockResolvedValue(undefined);
+
+    await safeRm("temporary-reference-tree");
+
+    expect(fsMocks.rm).toHaveBeenCalledOnce();
+    expect(fsMocks.rm).toHaveBeenCalledWith("temporary-reference-tree", {
+      force: true,
+      recursive: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
+  });
+});

--- a/tests/upstream-plugin-sync.test.ts
+++ b/tests/upstream-plugin-sync.test.ts
@@ -226,7 +226,12 @@ describe("upstream-plugin-sync", () => {
   });
 
   afterEach(async () => {
-    await rm(testState.repoRoot, { force: true, recursive: true });
+    await rm(testState.repoRoot, {
+      force: true,
+      recursive: true,
+      maxRetries: 5,
+      retryDelay: 100,
+    });
   });
 
   it("stages the full reference tree before swapping it into place", async () => {


### PR DESCRIPTION
## Summary

- Keep the full pre-push check unchanged: contributors still run `pnpm verify`.
- Make test paths work correctly on Windows.
- Avoid creating filenames that Windows rejects.
- Handle temporary cleanup failures without skipping tests or increasing timeouts.
- Add Windows CI running the same `pnpm verify` command as Ubuntu.

## Local validation

- `pnpm verify`: 2,174 main tests and 2 display-surface tests passed.
- `git diff --check`: passed.
- The worktree remained clean.

The local validation ran on macOS. Do not merge this PR until the unchanged `pnpm verify` passes on both Ubuntu and Windows GitHub Actions.

Closes #234