### PR TITLE
fix(opencode-go): accept rate-limited window status instead of discarding the response

### DIFF
--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -82,7 +82,7 @@ function normalizeWindow(
     return contractError(`${windowKey} window is missing or malformed`);
   }
 
-  if (window.status !== "ok") {
+  if (window.status !== "ok" && window.status !== "rate-limited") {
     return contractError(
       `${windowKey} status is not ok: ${sanitizeMessage(String(window.status), accessToken)}`,
     );
@@ -104,7 +104,7 @@ function normalizeWindow(
   }
 
   return {
-    status: "ok",
+    status: window.status as "ok" | "rate-limited",
     usagePercent: percent,
     percentRemaining: 100 - percent,
     resetTimeIso: new Date(resetTime).toISOString(),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -895,7 +895,7 @@ export type OllamaCloudResult =
 /** Single normalized usage window from the OpenCode Go API. */
 export interface OpenCodeGoWindow {
   /** Raw API status after exact validation. */
-  status: "ok";
+  status: "ok" | "rate-limited";
   /** Usage percentage [0..100]. */
   usagePercent: number;
   /** Remaining percentage [0..100]. */

--- a/tests/lib.opencode-go.test.ts
+++ b/tests/lib.opencode-go.test.ts
@@ -131,6 +131,20 @@ describe("queryOpenCodeGoQuota", () => {
     });
   });
 
+  it("accepts a rate-limited window as a valid exhausted state", async () => {
+    const payload = validPayload();
+    windowFrom(payload, "monthly").status = "rate-limited";
+    windowFrom(payload, "monthly").percent = 100;
+    mockSuccess(payload);
+
+    const result = await queryOpenCodeGoQuota("token");
+
+    expect(result).toMatchObject({
+      success: true,
+      monthly: { status: "rate-limited", usagePercent: 100, percentRemaining: 0 },
+    });
+  });
+
   it.each([null, [], "bad", 1])("rejects a non-object root: %j", async (payload) => {
     mockSuccess(payload);
     await expect(queryOpenCodeGoQuota("token")).resolves.toEqual({

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -221,6 +221,29 @@ describe("opencode-go provider", () => {
     });
   });
 
+  it("surfaces a rate-limited monthly window as a valid result", async () => {
+    const result = successfulResult();
+    result.monthly = {
+      status: "rate-limited" as const,
+      usagePercent: 100,
+      percentRemaining: 0,
+      resetTimeIso: "2026-09-01T04:00:00.000Z",
+    };
+    mocks.queryOpenCodeGoQuota.mockResolvedValueOnce(result);
+
+    const out = await runFetch();
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.statusDetails).toContainEqual({
+      key: "monthly_usage",
+      value:
+        "status=rate-limited percent_used=100 percent_remaining=0 reset_at=2026-09-01T04:00:00.000Z",
+    });
+    expect(
+      out.entries.find((entry) => entry.name === "OpenCode Go Monthly")?.percentRemaining,
+    ).toBe(0);
+  });
+
   it("does not copy the resolved token into provider output", async () => {
     const out = await runFetch();
     expect(JSON.stringify(out)).not.toContain("provider-test-token");


### PR DESCRIPTION
## Summary

Fixes #241 — the OpenCode Go provider reported **"Invalid OpenCode Go API"** whenever the monthly quota was exhausted, even though the API response was a valid HTTP 200.

Root cause: `normalizeWindow` in `src/lib/opencode-go.ts` required every window `status` to be exactly `"ok"`. When the monthly window is exhausted, the usage API returns `status: "rate-limited"`, so a single non-`ok` window failed the *entire* `normalizeResponse` and the whole payload was discarded.

## Changes

- `src/lib/opencode-go.ts`: accept `"rate-limited"` as a valid terminal window state alongside `"ok"`.
- `src/lib/types.ts`: widen `OpenCodeGoWindow.status` to `"ok" | "rate-limited"`.
- Preserve the raw status in the normalized window so consumers can surface the exhausted state (`percentRemaining: 0`).
- Added regression tests:
  - `tests/lib.opencode-go.test.ts` — rate-limited monthly window normalizes to success.
  - `tests/providers.opencode-go.test.ts` — provider surfaces `status=rate-limited` as a valid result.

## Verification

- `pnpm verify` passes locally (biome, typecheck, build, full suite: 182 files / 2176 tests, four-surface parity, package contents).
- Manual repro before fix: `queryOpenCodeGoQuota` returned `Invalid OpenCode Go API response: monthly status is not ok: rate-limited`. After fix: `success: true` with `monthly.status: "rate-limited"`, `percentRemaining: 0`.

## Tested against

- OpenCode production release: **1.18.23**
- Plugin: @slkiser/opencode-quota 4.8.2