### PR TITLE
fix: handle nested Ollama Cloud usage response and hide per-model request counts

### DIFF
--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -562,7 +562,7 @@ Per-API-key costs remain unsupported until Xiaomi exposes endpoint and schema ev
 
 ### Ollama Cloud
 
-Ollama Cloud calls `https://ollama.com/api/usage` and reports session and weekly quota plus per-model request counts. Create an Ollama API key, then set:
+Ollama Cloud calls `https://ollama.com/api/usage` and reports session and weekly usage fractions. The API-key response does not include quota reset timestamps or per-model request rows. Create an Ollama API key, then set:
 
 ```bash
 export OLLAMA_API_KEY="your-api-key"

--- a/src/lib/ollama-cloud.ts
+++ b/src/lib/ollama-cloud.ts
@@ -82,6 +82,8 @@ function parseWindow(value: unknown): OllamaCloudWindow | undefined {
 }
 
 function parseModels(value: unknown, rowErrors: string[]): OllamaCloudModelUsage[] {
+  if (value === undefined) return [];
+
   if (!Array.isArray(value)) {
     rowErrors.push("Models: expected an array");
     return [];
@@ -130,7 +132,9 @@ function parseOllamaCloudUsage(payload: unknown): OllamaCloudResult {
     };
   }
 
-  if (Array.isArray(payload.models) && payload.models.length > MAX_MODEL_ROWS) {
+  const topLevelModels = payload.models;
+
+  if (Array.isArray(topLevelModels) && topLevelModels.length > MAX_MODEL_ROWS) {
     return {
       success: false,
       error: `Ollama Cloud usage API returned more than ${MAX_MODEL_ROWS} model rows`,
@@ -152,7 +156,7 @@ function parseOllamaCloudUsage(payload: unknown): OllamaCloudResult {
     rowErrors.push("Limits: expected an object");
   }
 
-  const models = parseModels(payload.models, rowErrors);
+  const models = parseModels(topLevelModels, rowErrors);
   if (!session && !weekly && models.length === 0) {
     return {
       success: false,

--- a/src/lib/ollama-cloud.ts
+++ b/src/lib/ollama-cloud.ts
@@ -1,18 +1,17 @@
 /**
  * Ollama Cloud usage API client.
  *
- * Fetches session and weekly usage fractions plus per-model request counts
- * from the authenticated Ollama Cloud usage endpoint.
+ * Fetches session and weekly usage fractions from the authenticated Ollama
+ * Cloud usage endpoint.
  */
 
 import { sanitizeSingleLineDisplayText } from "./display-sanitize.js";
 import { fetchWithTimeout } from "./http.js";
 import { resolveOllamaCloudApiKey } from "./ollama-cloud-config.js";
-import type { OllamaCloudModelUsage, OllamaCloudResult, OllamaCloudWindow } from "./types.js";
+import type { OllamaCloudResult, OllamaCloudWindow } from "./types.js";
 
 const OLLAMA_CLOUD_USAGE_URL = "https://ollama.com/api/usage";
 const MAX_RESPONSE_BYTES = 256 * 1024;
-const MAX_MODEL_ROWS = 100;
 
 type JsonRecord = Record<string, unknown>;
 
@@ -81,63 +80,11 @@ function parseWindow(value: unknown): OllamaCloudWindow | undefined {
   };
 }
 
-function parseModels(value: unknown, rowErrors: string[]): OllamaCloudModelUsage[] {
-  if (value === undefined) return [];
-
-  if (!Array.isArray(value)) {
-    rowErrors.push("Models: expected an array");
-    return [];
-  }
-
-  const models: OllamaCloudModelUsage[] = [];
-  const seenModels = new Set<string>();
-
-  for (const candidate of value) {
-    if (!isRecord(candidate)) {
-      rowErrors.push("Models: ignored an invalid row");
-      continue;
-    }
-
-    const model =
-      typeof candidate.model === "string"
-        ? sanitizeRemoteSingleLineText(candidate.model).slice(0, 160)
-        : "";
-    const requests = candidate.requests;
-
-    if (!model) {
-      rowErrors.push("Models: ignored a row without a model name");
-      continue;
-    }
-    if (typeof requests !== "number" || !Number.isSafeInteger(requests) || requests < 0) {
-      rowErrors.push(`Models: ignored invalid request count for ${model}`);
-      continue;
-    }
-    if (seenModels.has(model)) {
-      rowErrors.push(`Models: ignored duplicate model ${model}`);
-      continue;
-    }
-
-    seenModels.add(model);
-    models.push({ model, requests });
-  }
-
-  return models.sort((left, right) => left.model.localeCompare(right.model));
-}
-
 function parseOllamaCloudUsage(payload: unknown): OllamaCloudResult {
   if (!isRecord(payload)) {
     return {
       success: false,
       error: "Ollama Cloud usage API returned an unexpected response shape",
-    };
-  }
-
-  const topLevelModels = payload.models;
-
-  if (Array.isArray(topLevelModels) && topLevelModels.length > MAX_MODEL_ROWS) {
-    return {
-      success: false,
-      error: `Ollama Cloud usage API returned more than ${MAX_MODEL_ROWS} model rows`,
     };
   }
 
@@ -156,8 +103,7 @@ function parseOllamaCloudUsage(payload: unknown): OllamaCloudResult {
     rowErrors.push("Limits: expected an object");
   }
 
-  const models = parseModels(topLevelModels, rowErrors);
-  if (!session && !weekly && models.length === 0) {
+  if (!session && !weekly) {
     return {
       success: false,
       error: "Ollama Cloud usage API returned no usable usage data",
@@ -168,7 +114,6 @@ function parseOllamaCloudUsage(payload: unknown): OllamaCloudResult {
     success: true,
     ...(session ? { session } : {}),
     ...(weekly ? { weekly } : {}),
-    models,
     ...(rowErrors.length > 0 ? { rowErrors } : {}),
   };
 }

--- a/src/lib/provider-registration.ts
+++ b/src/lib/provider-registration.ts
@@ -359,8 +359,7 @@ export const QUOTA_PROVIDER_REGISTRATION_SOURCE = [
       authentication: "opencode_auth_api_key",
       authFallbacks: ["env_api_key", "global_opencode_config"],
       quota: "remote_api",
-      notes:
-        "Queries the Ollama Cloud usage API; reports session and weekly quota plus model request counts",
+      notes: "Queries the Ollama Cloud usage API; reports session and weekly usage fractions",
     },
   },
   {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -870,12 +870,6 @@ export interface OllamaCloudWindow {
   percentRemaining: number;
 }
 
-/** Per-model request count from the Ollama Cloud usage API */
-export interface OllamaCloudModelUsage {
-  model: string;
-  requests: number;
-}
-
 /** Result from the Ollama Cloud usage API */
 export type OllamaCloudResult =
   | {
@@ -884,9 +878,7 @@ export type OllamaCloudResult =
       session?: OllamaCloudWindow;
       /** Weekly usage window, when present */
       weekly?: OllamaCloudWindow;
-      /** Valid per-model request counts */
-      models: OllamaCloudModelUsage[];
-      /** Independent response rows that could not be used */
+      /** Independent response fields that could not be used */
       rowErrors?: string[];
     }
   | QuotaError

--- a/src/providers/ollama-cloud.ts
+++ b/src/providers/ollama-cloud.ts
@@ -1,8 +1,7 @@
 /**
  * Ollama Cloud provider wrapper.
  *
- * Queries the Ollama Cloud usage API and reports session/weekly quota plus
- * provider-reported per-model request counts.
+ * Queries the Ollama Cloud usage API and reports session/weekly quota.
  */
 
 import type {
@@ -31,10 +30,6 @@ const REMOTE_API_ACCOUNTING = {
 } as const;
 
 type OllamaCloudSuccess = Extract<OllamaCloudResult, { success: true }>;
-
-function formatRequestCount(requests: number): string {
-  return `${requests} ${requests === 1 ? "request" : "requests"}`;
-}
 
 function mapOllamaCloudSuccess(result: OllamaCloudSuccess): QuotaProviderResult {
   const entries: QuotaToastEntry[] = [];
@@ -65,21 +60,6 @@ function mapOllamaCloudSuccess(result: OllamaCloudSuccess): QuotaProviderResult 
     });
   }
 
-  for (const model of result.models) {
-    entries.push({
-      kind: "value",
-      accounting: {
-        resultType: "usage",
-        ...REMOTE_API_ACCOUNTING,
-      },
-      name: `${OLLAMA_CLOUD_PROVIDER_LABEL} ${model.model}`,
-      group: OLLAMA_CLOUD_PROVIDER_LABEL,
-      label: `${model.model}:`,
-      metricLabel: model.model,
-      value: formatRequestCount(model.requests),
-    });
-  }
-
   const errors = (result.rowErrors ?? []).map((message) => ({
     label: OLLAMA_CLOUD_PROVIDER_LABEL,
     message,
@@ -95,7 +75,6 @@ function mapOllamaCloudSuccess(result: OllamaCloudSuccess): QuotaProviderResult 
     ...statusDetailsFromRecord({
       session_usage_fraction: result.session?.usageFraction.toString(),
       weekly_usage_fraction: result.weekly?.usageFraction.toString(),
-      model_rows: result.models.length.toString(),
     }),
     ...(result.rowErrors ?? []).map((message, index) => ({
       key: `live_error_${index + 1}`,

--- a/tests/helpers/provider-assertions.ts
+++ b/tests/helpers/provider-assertions.ts
@@ -298,12 +298,6 @@ export const PROVIDER_ACCOUNTING_LEDGER: Record<string, Array<QuotaToastEntry["a
       ownership: "maintained",
       authority: "provider_reported",
     },
-    {
-      resultType: "usage",
-      acquisitionMethod: "remote_api",
-      ownership: "maintained",
-      authority: "provider_reported",
-    },
   ],
   "quota-providers": [
     {

--- a/tests/lib.ollama-cloud.test.ts
+++ b/tests/lib.ollama-cloud.test.ts
@@ -50,17 +50,11 @@ const usagePayload = {
   limits: {
     session: {
       usage: 0.25,
-      models: [
-        { name: "qwen3-coder:480b", request_count: 3 },
-        { name: "deepseek-v3.1:671b", request_count: 1 },
-      ],
+      models: [{ name: "glm-5.3-flash", request_count: 57 }],
     },
     weekly: {
       usage: 0.405,
-      models: [
-        { name: "qwen3-coder:480b", request_count: 12 },
-        { name: "deepseek-v3.1:671b", request_count: 1 },
-      ],
+      models: [{ name: "glm-5.3-flash", request_count: 162 }],
     },
   },
 };
@@ -132,32 +126,8 @@ describe("queryOllamaCloudQuota", () => {
         usagePercent: 40.5,
         percentRemaining: 59.5,
       },
-      models: [],
     });
-    expect(out && out.success ? out.rowErrors : undefined).toBeUndefined();
-  });
-
-  it("parses legacy top-level models for backwards compatibility", () => {
-    const out = _parseOllamaCloudUsage({
-      limits: {
-        session: { usage: 0.25 },
-        weekly: { usage: 0.405 },
-      },
-      models: [
-        { model: "qwen3-coder:480b", requests: 12 },
-        { model: "deepseek-v3.1:671b", requests: 1 },
-      ],
-    });
-
-    expect(out).toEqual({
-      success: true,
-      session: { usageFraction: 0.25, usagePercent: 25, percentRemaining: 75 },
-      weekly: { usageFraction: 0.405, usagePercent: 40.5, percentRemaining: 59.5 },
-      models: [
-        { model: "deepseek-v3.1:671b", requests: 1 },
-        { model: "qwen3-coder:480b", requests: 12 },
-      ],
-    });
+    expect(out?.success ? out.rowErrors : undefined).toBeUndefined();
   });
 
   it("preserves zero and fully-used fraction boundaries", () => {
@@ -165,48 +135,29 @@ describe("queryOllamaCloudQuota", () => {
       _parseOllamaCloudUsage({
         limits: {
           session: { usage: 0 },
-          weekly: { usage: 1, models: [] },
+          weekly: { usage: 1 },
         },
       }),
     ).toEqual({
       success: true,
       session: { usageFraction: 0, usagePercent: 0, percentRemaining: 100 },
       weekly: { usageFraction: 1, usagePercent: 100, percentRemaining: 0 },
-      models: [],
     });
   });
 
-  it("keeps valid rows and reports invalid independent rows", () => {
+  it("reports invalid independent usage windows", () => {
     const out = _parseOllamaCloudUsage({
       limits: {
         session: { usage: 0.2 },
         weekly: { usage: 1.5 },
       },
-      models: [
-        { model: "valid-model", requests: 0 },
-        { model: "negative", requests: -1 },
-        { model: "decimal", requests: 1.5 },
-        { model: "valid-model", requests: 3 },
-        { model: "  unsafe\nmodel\u202e\u001b[31m  ", requests: 2 },
-        null,
-      ],
     });
 
     expect(out).toMatchObject({
       success: true,
       session: { usageFraction: 0.2, usagePercent: 20, percentRemaining: 80 },
-      models: [
-        { model: "unsafe model", requests: 2 },
-        { model: "valid-model", requests: 0 },
-      ],
     });
-    expect(out && out.success ? out.rowErrors : []).toEqual([
-      "Weekly: ignored invalid usage fraction",
-      "Models: ignored invalid request count for negative",
-      "Models: ignored invalid request count for decimal",
-      "Models: ignored duplicate model valid-model",
-      "Models: ignored an invalid row",
-    ]);
+    expect(out?.success ? out.rowErrors : []).toEqual(["Weekly: ignored invalid usage fraction"]);
   });
 
   it.each([null, [], "invalid"])("rejects an invalid root payload: %j", (payload) => {
@@ -216,29 +167,10 @@ describe("queryOllamaCloudQuota", () => {
     });
   });
 
-  it("rejects more than 100 model rows", () => {
-    expect(
-      _parseOllamaCloudUsage({
-        limits: {
-          session: { usage: 0.1 },
-          weekly: { usage: 0.2 },
-        },
-        models: Array.from({ length: 101 }, (_, index) => ({
-          model: `model-${index}`,
-          requests: index,
-        })),
-      }),
-    ).toEqual({
-      success: false,
-      error: "Ollama Cloud usage API returned more than 100 model rows",
-    });
-  });
-
   it("rejects an object with no usable usage data", () => {
     expect(
       _parseOllamaCloudUsage({
         limits: { session: { usage: -1 }, weekly: { usage: Number.NaN } },
-        models: [{ model: "bad", requests: -1 }],
       }),
     ).toEqual({
       success: false,

--- a/tests/lib.ollama-cloud.test.ts
+++ b/tests/lib.ollama-cloud.test.ts
@@ -48,13 +48,21 @@ function mockResponse(params: {
 
 const usagePayload = {
   limits: {
-    session: { usage: 0.25 },
-    weekly: { usage: 0.405 },
+    session: {
+      usage: 0.25,
+      models: [
+        { name: "qwen3-coder:480b", request_count: 3 },
+        { name: "deepseek-v3.1:671b", request_count: 1 },
+      ],
+    },
+    weekly: {
+      usage: 0.405,
+      models: [
+        { name: "qwen3-coder:480b", request_count: 12 },
+        { name: "deepseek-v3.1:671b", request_count: 1 },
+      ],
+    },
   },
-  models: [
-    { model: "qwen3-coder:480b", requests: 12 },
-    { model: "deepseek-v3.1:671b", requests: 1 },
-  ],
 };
 
 describe("queryOllamaCloudQuota", () => {
@@ -108,10 +116,11 @@ describe("queryOllamaCloudQuota", () => {
     );
   });
 
-  it("maps usage fractions and sorts model request counts", async () => {
+  it("maps usage fractions from a real nested Ollama response", async () => {
     mockResponse({ ok: true, status: 200, json: usagePayload });
 
-    await expect(queryOllamaCloudQuota()).resolves.toEqual({
+    const out = await queryOllamaCloudQuota();
+    expect(out).toEqual({
       success: true,
       session: {
         usageFraction: 0.25,
@@ -123,6 +132,27 @@ describe("queryOllamaCloudQuota", () => {
         usagePercent: 40.5,
         percentRemaining: 59.5,
       },
+      models: [],
+    });
+    expect(out && out.success ? out.rowErrors : undefined).toBeUndefined();
+  });
+
+  it("parses legacy top-level models for backwards compatibility", () => {
+    const out = _parseOllamaCloudUsage({
+      limits: {
+        session: { usage: 0.25 },
+        weekly: { usage: 0.405 },
+      },
+      models: [
+        { model: "qwen3-coder:480b", requests: 12 },
+        { model: "deepseek-v3.1:671b", requests: 1 },
+      ],
+    });
+
+    expect(out).toEqual({
+      success: true,
+      session: { usageFraction: 0.25, usagePercent: 25, percentRemaining: 75 },
+      weekly: { usageFraction: 0.405, usagePercent: 40.5, percentRemaining: 59.5 },
       models: [
         { model: "deepseek-v3.1:671b", requests: 1 },
         { model: "qwen3-coder:480b", requests: 12 },
@@ -133,8 +163,10 @@ describe("queryOllamaCloudQuota", () => {
   it("preserves zero and fully-used fraction boundaries", () => {
     expect(
       _parseOllamaCloudUsage({
-        limits: { session: { usage: 0 }, weekly: { usage: 1 } },
-        models: [],
+        limits: {
+          session: { usage: 0 },
+          weekly: { usage: 1, models: [] },
+        },
       }),
     ).toEqual({
       success: true,
@@ -187,7 +219,10 @@ describe("queryOllamaCloudQuota", () => {
   it("rejects more than 100 model rows", () => {
     expect(
       _parseOllamaCloudUsage({
-        limits: { session: { usage: 0.1 } },
+        limits: {
+          session: { usage: 0.1 },
+          weekly: { usage: 0.2 },
+        },
         models: Array.from({ length: 101 }, (_, index) => ({
           model: `model-${index}`,
           requests: index,

--- a/tests/lib.provider-metadata.test.ts
+++ b/tests/lib.provider-metadata.test.ts
@@ -197,8 +197,7 @@ describe("provider-metadata", () => {
         authentication: "opencode_auth_api_key",
         authFallbacks: ["env_api_key", "global_opencode_config"],
         quota: "remote_api",
-        notes:
-          "Queries the Ollama Cloud usage API; reports session and weekly quota plus model request counts",
+        notes: "Queries the Ollama Cloud usage API; reports session and weekly usage fractions",
       },
       {
         id: "quota-providers",

--- a/tests/providers.ollama-cloud.surfaces.test.ts
+++ b/tests/providers.ollama-cloud.surfaces.test.ts
@@ -28,15 +28,6 @@ const data: QuotaRenderData = {
       label: "Weekly:",
       percentRemaining: 60,
     },
-    {
-      kind: "value",
-      accounting: { resultType: "usage", ...accounting },
-      name: "Ollama Cloud qwen3",
-      group: "Ollama Cloud",
-      label: "qwen3:",
-      metricLabel: "qwen3",
-      value: "12 requests",
-    },
   ],
   errors: [],
 };
@@ -60,9 +51,8 @@ describe("Ollama Cloud four-surface formatting", () => {
       expect(output).toContain("75%");
     }
 
-    expect(command).toContain("qwen3");
-    for (const output of [command, toast, sidebar]) {
-      expect(output).toContain("12 requests");
+    for (const output of [command, toast, sidebar, compact]) {
+      expect(output).not.toContain("requests");
     }
   });
 });

--- a/tests/providers.ollama-cloud.test.ts
+++ b/tests/providers.ollama-cloud.test.ts
@@ -48,7 +48,7 @@ describe("ollama-cloud provider", () => {
     expect(out.statusDetails).toContainEqual({ key: "api_key_configured", value: "true" });
   });
 
-  it("maps session, weekly, and sorted model request entries", async () => {
+  it("maps session and weekly quota entries", async () => {
     mocks.queryOllamaCloudQuota.mockResolvedValueOnce({
       success: true,
       session: {
@@ -61,10 +61,6 @@ describe("ollama-cloud provider", () => {
         usagePercent: 40,
         percentRemaining: 60,
       },
-      models: [
-        { model: "deepseek-v3.1:671b", requests: 1 },
-        { model: "qwen3-coder:480b", requests: 12 },
-      ],
     });
 
     const out = await runProviderFetch();
@@ -83,22 +79,6 @@ describe("ollama-cloud provider", () => {
         label: "Weekly:",
         percentRemaining: 60,
       },
-      {
-        kind: "value",
-        name: "Ollama Cloud deepseek-v3.1:671b",
-        group: "Ollama Cloud",
-        label: "deepseek-v3.1:671b:",
-        metricLabel: "deepseek-v3.1:671b",
-        value: "1 request",
-      },
-      {
-        kind: "value",
-        name: "Ollama Cloud qwen3-coder:480b",
-        group: "Ollama Cloud",
-        label: "qwen3-coder:480b:",
-        metricLabel: "qwen3-coder:480b",
-        value: "12 requests",
-      },
     ]);
     expect(out.entries.map((entry) => entry.accounting)).toEqual([
       {
@@ -113,25 +93,12 @@ describe("ollama-cloud provider", () => {
         ownership: "maintained",
         authority: "provider_reported",
       },
-      {
-        resultType: "usage",
-        acquisitionMethod: "remote_api",
-        ownership: "maintained",
-        authority: "provider_reported",
-      },
-      {
-        resultType: "usage",
-        acquisitionMethod: "remote_api",
-        ownership: "maintained",
-        authority: "provider_reported",
-      },
     ]);
     expect(out.statusDetails).toEqual(
       expect.arrayContaining([
         { key: "api_key_source", value: "env:OLLAMA_API_KEY" },
         { key: "session_usage_fraction", value: "0.25" },
         { key: "weekly_usage_fraction", value: "0.4" },
-        { key: "model_rows", value: "2" },
       ]),
     );
   });
@@ -144,7 +111,6 @@ describe("ollama-cloud provider", () => {
         usagePercent: 25,
         percentRemaining: 75,
       },
-      models: [],
       rowErrors: ["Weekly: ignored invalid usage fraction"],
     });
 
@@ -164,7 +130,6 @@ describe("ollama-cloud provider", () => {
     mocks.queryOllamaCloudQuota.mockResolvedValue({
       success: true,
       weekly: { usageFraction: 0.1, usagePercent: 10, percentRemaining: 90 },
-      models: [],
     });
 
     await runProviderFetch({ requestTimeoutMs: 1234, requestTimeoutMsConfigured: true });


### PR DESCRIPTION
## Summary

The Ollama Cloud `/api/usage` response changed shape, and the quota output showed rows that do not belong in a quota display. This PR fixes both parsing and presentation for the Ollama Cloud provider.

### 1. Handle the nested usage response

The parser previously expected an optional top-level `payload.models` array. The current response instead nests per-model data inside each quota window (`limits.session.models` and `limits.weekly.models`). Because the top-level `models` field is absent, the parser emitted:

```
Ollama Cloud: Models: expected an array
```

even though the Session and Weekly quota values were valid.

- Session and Weekly usage continue to come from `limits.session.usage` and `limits.weekly.usage`.
- A missing top-level `payload.models` is now valid and produces no warning.
- Legacy top-level `payload.models` remains supported when present.

### 2. Hide per-model request counts

The provider also emitted one row per model, for example:

```
[Ollama Cloud]
Weekly        ███████░   98% left
Session       ████████   99% left
glm-5.3-flash:  154 requests
```

Per-model request counts are usage accounting, not quota windows. They make the toast, sidebar, and command output noisy and are not comparable to the percentage-based quota rows from other providers.

This PR removes per-model request rows from all surfaces (command, toast, sidebar, compact status) and removes the associated types, metadata, diagnostics, and tests. Only the Session and Weekly quota windows are reported:

```
[Ollama Cloud]
Weekly        ███████░   98% left
Session       ████████   99% left
```

The usage API still receives and safely ignores any per-model data in the response, including the nested `limits.*.models` shape.

### Note on reset times

Ollama Cloud does not provide reset timestamps in `/api/usage` (`activity.period` is a rolling 4-week activity report ending at request time, not a quota reset). Reset countdowns therefore remain unavailable for this provider until Ollama exposes that data, consistent with the existing `Blocked: not in provider API` label on the Ollama Cloud request in #38. This PR deliberately does not estimate reset times or reintroduce the unsupported settings-page cookie flow documented in `providers.md`.

## Linked Issue

No existing issue found for the request-row removal. Scope: match the current Ollama Cloud `/api/usage` response shape and keep quota output limited to actual quota windows. Refs #38 for the original Ollama Cloud provider request.

## OpenCode Validation

- Current production released OpenCode version tested: **1.18.11** (`@opencode-ai/plugin` pinned version)
- Why this version is relevant to the fix: the fix was validated against the live Ollama Cloud usage API response and exercised through the built plugin in a local OpenCode install.
- Focused Ollama Cloud tests: passed
- `pnpm run typecheck`: passed
- `pnpm run build`: passed
- Full suite: 182 files / 2173 tests passed
- `git diff --check`: passed

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes): this is an existing built-in provider fix, not a new provider addition, so the models.dev/eligibility policy does not apply; the existing percent-row shape with `AccountingMetadata` is preserved.

_Superseded head note: the branch was rebased to correct the commit author identity; content is unchanged._