### PR TITLE
fix(opencode-go): treat 403 EntitlementError as not-subscribed and skip silently

### DIFF
--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -367,6 +367,7 @@ Existing `experimental.quotaToast` settings remain supported. Quota settings do 
 | `showOnQuestion`  | `true`  | Show a toast after a question/assistant response.                                                                                                           |
 | `showOnCompact`   | `true`  | Show a toast after session compaction.                                                                                                                      |
 | `showOnBothFail`  | `true`  | Show a fallback toast when providers attempted quota reads and all failed.                                                                                  |
+| `showNotApplicableProviders` | `false` | Surface one soft line per deliberately no-data provider (e.g. an OpenCode Go source without a subscription) instead of hiding it entirely.                   |
 | `layout.maxWidth` | `50`    | Toast formatting width target.                                                                                                                              |
 | `layout.narrowAt` | `42`    | Toast compact-layout breakpoint.                                                                                                                            |
 | `layout.tinyAt`   | `32`    | Toast tiny-layout breakpoint.                                                                                                                               |

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -65,6 +65,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "showOnQuestion",
   "showOnCompact",
   "showOnBothFail",
+  "showNotApplicableProviders",
   "toastDurationMs",
   "onlyCurrentModel",
   "showSessionTokens",
@@ -138,6 +139,7 @@ const NETWORK_SETTING_SOURCE_KEYS = [
   "showOnQuestion",
   "showOnCompact",
   "showOnBothFail",
+  "showNotApplicableProviders",
 ] as const satisfies readonly QuotaToastSettingSourceKey[];
 
 type PricingSnapshotPatch = Partial<QuotaToastConfig["pricingSnapshot"]>;
@@ -176,6 +178,7 @@ type ValidatedQuotaToastPatch = {
   showOnQuestion?: boolean;
   showOnCompact?: boolean;
   showOnBothFail?: boolean;
+  showNotApplicableProviders?: boolean;
   toastDurationMs?: number;
   onlyCurrentModel?: boolean;
   showSessionTokens?: boolean;
@@ -815,6 +818,13 @@ function extractValidatedQuotaToastPatch(
   }
 
   if (
+    hasOwnKey(quotaToastConfig, "showNotApplicableProviders") &&
+    typeof quotaToastConfig.showNotApplicableProviders === "boolean"
+  ) {
+    patch.showNotApplicableProviders = quotaToastConfig.showNotApplicableProviders;
+  }
+
+  if (
     hasOwnKey(quotaToastConfig, "toastDurationMs") &&
     isPositiveNumber(quotaToastConfig.toastDurationMs)
   ) {
@@ -1045,6 +1055,11 @@ function applyValidatedQuotaToastPatch(
   if (hasOwnKey(patch, "showOnBothFail")) {
     config.showOnBothFail = patch.showOnBothFail!;
     applySettingSource(settingSources, "showOnBothFail", sourcePath);
+  }
+
+  if (hasOwnKey(patch, "showNotApplicableProviders")) {
+    config.showNotApplicableProviders = patch.showNotApplicableProviders!;
+    applySettingSource(settingSources, "showNotApplicableProviders", sourcePath);
   }
 
   if (hasOwnKey(patch, "toastDurationMs")) {

--- a/src/lib/display-sanitize.ts
+++ b/src/lib/display-sanitize.ts
@@ -124,6 +124,7 @@ export function sanitizeQuotaProviderResult(result: QuotaProviderResult): QuotaP
     attempted: result.attempted,
     entries: result.entries.map(sanitizeQuotaToastEntry),
     errors: result.errors.map(sanitizeQuotaToastError),
+    ...(result.notApplicable ? { notApplicable: true } : {}),
     ...(result.diagnostics
       ? {
           diagnostics: result.diagnostics.map((diagnostic) => ({

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -318,6 +318,12 @@ export interface QuotaProviderResult {
   attempted: boolean;
   entries: QuotaToastEntry[];
   errors: QuotaToastError[];
+  /**
+   * True when the provider deliberately has no data for this account (e.g. a
+   * subscription-gated source without the subscription). Not an error and not
+   * "not configured": renderers must not surface a no-data fallback for it.
+   */
+  notApplicable?: true;
   /** Internal provider diagnostics; not projected into normal presentation/export surfaces. */
   diagnostics?: QuotaProviderDiagnostic[];
   /**

--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -133,6 +133,11 @@ function normalizeResponse(payload: unknown, accessToken: string): OpenCodeGoRes
   };
 }
 
+function isNotSubscribedResponse(status: number, text: string): boolean {
+  if (status !== 403) return false;
+  return /EntitlementError|subscription required/i.test(text);
+}
+
 export async function queryOpenCodeGoQuota(
   accessToken: string,
   options: { requestTimeoutMs?: number } = {},
@@ -157,6 +162,14 @@ export async function queryOpenCodeGoQuota(
               success: false,
               error: `OpenCode Go API error ${response.status}: ${errorMessage(error, accessToken)}`,
               retryable: isRetryableHttpStatus(response.status),
+            };
+          }
+          if (isNotSubscribedResponse(response.status, text)) {
+            return {
+              success: false,
+              error: "OpenCode Go not subscribed (403 EntitlementError)",
+              notSubscribed: true,
+              retryable: false,
             };
           }
           return {

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -386,6 +386,9 @@ function shouldSurfaceNoDataMessage(params: {
   activeProviderCount: number;
 }): boolean {
   const { provider, result, isAutoMode, activeProviderCount } = params;
+  if (result.notApplicable) {
+    return false;
+  }
   if (result.attempted || result.entries.length > 0 || result.errors.length > 0) {
     return false;
   }

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -376,6 +376,9 @@ function getExplicitNoDataMessage(provider: QuotaProvider): string {
   if (provider.id === "anthropic") {
     return getAnthropicNoDataMessage();
   }
+  if (provider.id === "opencode-go") {
+    return "Not subscribed";
+  }
   return "Not configured";
 }
 
@@ -568,6 +571,12 @@ export async function collectQuotaRenderData(params: {
       if (!selection.isAutoMode) {
         hasExplicitProviderIssues = true;
       }
+    } else if (provider && result?.notApplicable && params.config.showNotApplicableProviders) {
+      errors.push({
+        kind: "intentional-filter",
+        label: getQuotaProviderDisplayLabel(provider.id),
+        message: getExplicitNoDataMessage(provider),
+      });
     }
   }
 

--- a/src/lib/quota-state-codec.ts
+++ b/src/lib/quota-state-codec.ts
@@ -31,6 +31,7 @@ export function cloneQuotaProviderResult(result: QuotaProviderResult): QuotaProv
     attempted: result.attempted,
     entries: result.entries.map(cloneQuotaToastEntry),
     errors: result.errors.map((error) => ({ ...error })),
+    ...(result.notApplicable ? { notApplicable: true } : {}),
     ...(result.diagnostics
       ? {
           diagnostics: result.diagnostics.map((diagnostic) => ({
@@ -420,12 +421,14 @@ function isQuotaProviderResult(value: unknown, safeText: boolean): value is Quot
       "attempted",
       "entries",
       "errors",
+      "notApplicable",
       "diagnostics",
       "statusDetails",
       "rawDetails",
       "presentation",
     ]) &&
     typeof value.attempted === "boolean" &&
+    (value.notApplicable === undefined || value.notApplicable === true) &&
     isDenseArray(value.entries) &&
     value.entries.every((entry) => isQuotaToastEntry(entry, safeText)) &&
     isDenseArray(value.errors) &&

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -912,7 +912,7 @@ export type OpenCodeGoResult =
       weekly: OpenCodeGoWindow;
       monthly: OpenCodeGoWindow;
     }
-  | QuotaError;
+  | (QuotaError & { notSubscribed?: true });
 
 /** Cached toast data */
 export interface CachedToast {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -169,6 +169,8 @@ export interface QuotaToastConfig {
   showOnQuestion: boolean;
   showOnCompact: boolean;
   showOnBothFail: boolean;
+  /** Surface one soft line per deliberately no-data provider instead of hiding it. */
+  showNotApplicableProviders: boolean;
   /** Toast duration in milliseconds */
   toastDurationMs: number;
 
@@ -253,6 +255,7 @@ export const DEFAULT_CONFIG: QuotaToastConfig = {
   showOnQuestion: true,
   showOnCompact: true,
   showOnBothFail: true,
+  showNotApplicableProviders: false,
   toastDurationMs: 9000,
   onlyCurrentModel: false,
   showSessionTokens: true,

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -17,6 +17,7 @@ import type { OpenCodeGoResult, OpenCodeGoWindowKey } from "../lib/types.js";
 import {
   attemptedErrorResult,
   attemptedResult,
+  notApplicableResult,
   notAttemptedResult,
   statusDetailsFromRecord,
   withStatusDetails,
@@ -29,6 +30,12 @@ const OPENCODE_GO_WINDOW_LABELS: Record<OpenCodeGoWindowKey, { name: string; lab
   weekly: { name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`, label: "Weekly:" },
   monthly: { name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`, label: "Monthly:" },
 };
+
+let notSubscribedApiKey: string | null = null;
+
+export function resetOpenCodeGoNotSubscribedForTests(): void {
+  notSubscribedApiKey = null;
+}
 
 function authStatusDetails(diagnostics: OpenCodeGoAuthDiagnostics): QuotaProviderStatusDetail[] {
   return statusDetailsFromRecord({
@@ -109,11 +116,25 @@ export const opencodeGoProvider: QuotaProvider = {
       );
     }
 
+    if (notSubscribedApiKey !== null && notSubscribedApiKey === auth.apiKey) {
+      return withStatusDetails(notApplicableResult(), [
+        ...statusDetails,
+        { key: "opencode_go_state", value: "not_subscribed" },
+      ]);
+    }
+
     const result = await queryOpenCodeGoQuota(auth.apiKey, {
       requestTimeoutMs: ctx.config.requestTimeoutMs,
     });
 
     if (!result.success) {
+      if (result.notSubscribed === true) {
+        notSubscribedApiKey = auth.apiKey;
+        return withStatusDetails(notApplicableResult(), [
+          ...statusDetails,
+          { key: "opencode_go_state", value: "not_subscribed" },
+        ]);
+      }
       return withStatusDetails(
         attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, result.error, {
           retryable: result.retryable,

--- a/src/providers/result-helpers.ts
+++ b/src/providers/result-helpers.ts
@@ -14,6 +14,10 @@ export function notAttemptedResult(): QuotaProviderResult {
   return { attempted: false, entries: [], errors: [] };
 }
 
+export function notApplicableResult(): QuotaProviderResult {
+  return { attempted: false, entries: [], errors: [], notApplicable: true };
+}
+
 export function attemptedResult(
   entries: QuotaToastEntry[],
   errors: QuotaToastError[] = [],

--- a/tests/lib.opencode-go.test.ts
+++ b/tests/lib.opencode-go.test.ts
@@ -252,6 +252,32 @@ describe("queryOpenCodeGoQuota", () => {
     );
   });
 
+  it("flags a 403 EntitlementError body as not subscribed", async () => {
+    mockHttpFailure(
+      403,
+      '{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}',
+    );
+
+    const result = await queryOpenCodeGoQuota("token");
+
+    expect(result).toEqual({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+  });
+
+  it("does not flag unrelated 403 bodies as not subscribed", async () => {
+    mockHttpFailure(403, '{"error":"forbidden"}');
+
+    const result = await queryOpenCodeGoQuota("token");
+
+    expect(result).toMatchObject({ success: false });
+    expect((result as { error: string }).error).toContain("OpenCode Go API error 403");
+    expect((result as { notSubscribed?: true }).notSubscribed).toBeUndefined();
+  });
+
   it("retains the HTTP status when reading a non-success body fails", async () => {
     const token = "distinctive-secret-token";
     mocks.fetchResponse.mockResolvedValueOnce({

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -24,7 +24,10 @@ vi.mock("../src/lib/opencode-go.js", () => ({
   queryOpenCodeGoQuota: mocks.queryOpenCodeGoQuota,
 }));
 
-import { opencodeGoProvider } from "../src/providers/opencode-go.js";
+import {
+  opencodeGoProvider,
+  resetOpenCodeGoNotSubscribedForTests,
+} from "../src/providers/opencode-go.js";
 
 function successfulResult() {
   return {
@@ -76,6 +79,7 @@ async function runFetch(
 describe("opencode-go provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetOpenCodeGoNotSubscribedForTests();
     mocks.getOpenCodeGoAuthDiagnostics.mockResolvedValue(diagnostics());
     mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
       state: "configured",
@@ -221,6 +225,54 @@ describe("opencode-go provider", () => {
     });
   });
 
+  it("skips silently, short-circuits re-polls, and marks results not applicable", async () => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValue({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+
+    const first = await runFetch();
+
+    expectNotAttempted(first);
+    expect(first).toMatchObject({ notApplicable: true });
+    expect(first.statusDetails).toEqual(
+      expect.arrayContaining([{ key: "opencode_go_state", value: "not_subscribed" }]),
+    );
+
+    const second = await runFetch();
+
+    expectNotAttempted(second);
+    expect(second).toMatchObject({ notApplicable: true });
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(1);
+
+    await expect(opencodeGoProvider.isAvailable(createProviderAvailabilityContext())).resolves.toBe(
+      true,
+    );
+  });
+
+  it("queries the API again when the auth key changes after a not-subscribed cache", async () => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+    await runFetch();
+
+    mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
+      state: "configured",
+      apiKey: "new-token-after-subscribing",
+    });
+    await runFetch();
+
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(2);
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenLastCalledWith("new-token-after-subscribing", {
+      requestTimeoutMs: 5_000,
+    });
+  });
+
   it("does not copy the resolved token into provider output", async () => {
     const out = await runFetch();
     expect(JSON.stringify(out)).not.toContain("provider-test-token");
@@ -230,6 +282,7 @@ describe("opencode-go provider", () => {
 describe("opencode-go availability and model matching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetOpenCodeGoNotSubscribedForTests();
   });
 
   it.each([

--- a/tests/quota-render-data.test.ts
+++ b/tests/quota-render-data.test.ts
@@ -78,6 +78,39 @@ describe("collectQuotaRenderData shared quota state", () => {
     await rm(TEST_RUNTIME_ROOT, { recursive: true, force: true });
   });
 
+  it("hides not-applicable provider results by default and can surface a soft line", async () => {
+    const notApplicableProvider = testProvider("opencode-go", {
+      attempted: false,
+      entries: [],
+      errors: [],
+      notApplicable: true,
+      statusDetails: [{ key: "opencode_go_state", value: "not_subscribed" }],
+    });
+
+    const silent = await collectQuotaRenderData({
+      client: TEST_CLIENT,
+      config: renderConfig({
+        enabledProviders: ["opencode-go"],
+        showNotApplicableProviders: false,
+      }),
+      surfaceExplicitProviderIssues: true,
+      formatStyle: "allWindows",
+      providers: [notApplicableProvider],
+    });
+    expect(silent.data).toBeNull();
+
+    const surfaced = await collectQuotaRenderData({
+      client: TEST_CLIENT,
+      config: renderConfig({ enabledProviders: ["opencode-go"], showNotApplicableProviders: true }),
+      surfaceExplicitProviderIssues: true,
+      formatStyle: "allWindows",
+      providers: [notApplicableProvider],
+    });
+    expect(surfaced.data?.errors).toEqual([
+      { kind: "intentional-filter", label: "OpenCode Go", message: "Not subscribed" },
+    ]);
+  });
+
   it("uses explicitly provided providers instead of the global registry", async () => {
     const runtimeProvider = testProvider("custom-runtime", {
       entries: [


### PR DESCRIPTION
Closes #247

## Summary

A 403 `EntitlementError` from the OpenCode Go usage API is a permanent state (the account has no Go subscription), but the plugin kept re-polling it on every refresh and surfaced the raw error in the toast and sidebar indefinitely.

This PR treats that response as a first-class "not subscribed" outcome:

- `lib/opencode-go.ts`: detects `403` + `EntitlementError` (or a "subscription required" body) and returns a `notSubscribed` result with a stable, redaction-safe message.
- `providers/opencode-go.ts`: caches the API key on the first not-subscribed response, short-circuits subsequent fetches (no re-poll until the key changes), and returns a not-attempted result carrying an `opencode_go_state: not_subscribed` status detail.
- `QuotaProviderResult` gains `notApplicable`: a deliberate no-data outcome that is neither an error nor "not configured". The renderer skips the "Not configured" fallback for it, and the result codec, sanitizer, and clone paths propagate the flag so persistence, cache decode, and exports keep it intact.

### Why silent by default

With several configured sources, every unavailable or errored provider adds its own row to the toast: N providers mean N recurring error rows on every idle/interrupt refresh. Deliberate no-data states are permanent (they cannot be resolved from the TUI), so repeating them turns the toast into a wall of recurring errors. Silent-by-default keeps the toast limited to actual data; the state remains observable through `statusDetails` (`/quota status` probes).

Users who want the visibility back can set the new documented option:

```jsonc
{
  // one soft intentional-filter line per deliberately no-data provider
  showNotApplicableProviders: true
}
```

Soft lines use the existing `intentional-filter` kind, so they do not count as compact-status issues.

## Testing

- Full suite green: 182 files / 2179 tests (vitest, node 22 / pnpm 11 per the repo pins)
- New tests: 403 EntitlementError detection (and non-EntitlementError 403s stay generic errors), silent skip + short-circuit + key-change invalidation at the provider level, codec propagation, renderer suppression and the opt-in soft line
- Validated live against a real subscription-less key: no more error toasts on idle/interrupt, other providers unaffected