### PR TITLE
feat: add Claude Usage Credits

### DIFF
--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -389,6 +389,8 @@ If Claude lives at a custom path, set `anthropicBinaryPath` in `opencode-quota/q
 
 When Claude Code does not expose quota windows itself, quota is read from Anthropic's OAuth usage endpoint using the first usable access token: OpenCode's own `anthropic` OAuth credential from `auth.json`, then Claude Code's credentials. `/quota_status` reports which store answered as `oauth_credential_source`.
 
+When that OAuth response includes enabled Usage Credits with numeric utilization, quota displays show a separate monthly **Claude Usage Credits** group; missing or invalid credit data leaves the regular 5-hour and weekly rows unchanged.
+
 <a id="cursor"></a>
 
 ### Cursor

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -46,15 +46,26 @@ export interface AnthropicQuotaWindow {
   resetAt?: string;
 }
 
+export interface AnthropicExtraUsage {
+  is_enabled?: boolean;
+  utilization?: number;
+}
+
 export interface AnthropicUsageResponse {
   five_hour: AnthropicQuotaWindow;
   seven_day: AnthropicQuotaWindow;
+  extra_usage?: AnthropicExtraUsage;
 }
 
 export interface AnthropicQuotaResult {
   success: true;
   five_hour: { percentRemaining: number; resetTimeIso?: string };
   seven_day: { percentRemaining: number; resetTimeIso?: string };
+  extra_usage?: { percentRemaining: number };
+}
+
+export interface AnthropicUsageParseOptions {
+  includeExtraUsage?: boolean;
 }
 
 export interface AnthropicQuotaError {
@@ -322,6 +333,20 @@ function parseQuotaWindow(
   };
 }
 
+function parseExtraUsageQuota(extraUsage: unknown): { percentRemaining: number } | undefined {
+  const record = asRecord(extraUsage);
+  if (!record || record["is_enabled"] !== true) {
+    return undefined;
+  }
+
+  const used = record["utilization"];
+  if (typeof used !== "number" || !Number.isFinite(used) || used < 0 || used > 100) {
+    return undefined;
+  }
+
+  return { percentRemaining: Math.round(100 - used) };
+}
+
 function getUsageRoots(data: unknown): Record<string, unknown>[] {
   const root = asRecord(data);
   if (!root) {
@@ -352,7 +377,10 @@ function getUsageRoots(data: unknown): Record<string, unknown>[] {
   return roots;
 }
 
-function parseUsageResponse(data: unknown): AnthropicQuotaResult | null {
+function parseUsageResponse(
+  data: unknown,
+  options: AnthropicUsageParseOptions = {},
+): AnthropicQuotaResult | null {
   for (const root of getUsageRoots(data)) {
     const fiveHour = parseQuotaWindow(root["five_hour"] ?? root["fiveHour"]);
     const sevenDay = parseQuotaWindow(root["seven_day"] ?? root["sevenDay"]);
@@ -361,10 +389,15 @@ function parseUsageResponse(data: unknown): AnthropicQuotaResult | null {
       continue;
     }
 
+    const extraUsage = options.includeExtraUsage
+      ? parseExtraUsageQuota(root["extra_usage"])
+      : undefined;
+
     return {
       success: true,
       five_hour: fiveHour,
       seven_day: sevenDay,
+      ...(extraUsage ? { extra_usage: extraUsage } : {}),
     };
   }
 
@@ -766,7 +799,7 @@ async function performAnthropicOAuthUsageRequest(
           };
         }
 
-        const quota = parseUsageResponse(data);
+        const quota = parseUsageResponse(data, { includeExtraUsage: true });
         if (!quota) {
           return {
             state: "unavailable",

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -125,6 +125,21 @@ export const anthropicProvider: QuotaProvider = {
       },
     ];
 
+    if (result.extra_usage) {
+      entries.push({
+        accounting: {
+          resultType: "quota",
+          acquisitionMethod,
+          ownership: "maintained",
+          authority: "provider_reported",
+        },
+        name: "Claude Usage Credits",
+        group: "Claude",
+        label: "Monthly:",
+        percentRemaining: result.extra_usage.percentRemaining,
+      });
+    }
+
     return withStatusDetails(attemptedResult(entries), statusDetails);
   },
 };

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -134,7 +134,7 @@ export const anthropicProvider: QuotaProvider = {
           authority: "provider_reported",
         },
         name: "Claude Usage Credits",
-        group: "Claude",
+        group: "Claude Usage Credits",
         label: "Monthly:",
         percentRemaining: result.extra_usage.percentRemaining,
       });

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -171,6 +171,74 @@ describe("parseUsageResponse", () => {
     expect(result?.seven_day.resetTimeIso).toBe("2026-04-01T00:00:00.000Z");
   });
 
+  it("parses enabled extra usage as remaining quota", () => {
+    const result = parseUsageResponse(
+      {
+        five_hour: { utilization: 57 },
+        seven_day: { utilization: 12 },
+        extra_usage: { is_enabled: true, utilization: 37.8 },
+      },
+      { includeExtraUsage: true },
+    );
+
+    expect(result?.extra_usage).toEqual({ percentRemaining: 62 });
+  });
+
+  it("ignores disabled or invalid extra usage without dropping quota windows", () => {
+    for (const extraUsage of [
+      undefined,
+      { is_enabled: false, utilization: 37 },
+      { is_enabled: true, utilization: "not-a-number" },
+      { is_enabled: true, utilization: 101 },
+      { is_enabled: true, utilization: -1 },
+    ]) {
+      const result = parseUsageResponse(
+        {
+          five_hour: { utilization: 57 },
+          seven_day: { utilization: 12 },
+          extra_usage: extraUsage,
+        },
+        { includeExtraUsage: true },
+      );
+
+      expect(result?.five_hour.percentRemaining).toBe(43);
+      expect(result?.seven_day.percentRemaining).toBe(88);
+      expect(result?.extra_usage).toBeUndefined();
+    }
+  });
+
+  it("ignores extra usage aliases and string utilization values", () => {
+    for (const extraUsage of [
+      { is_enabled: true, used_percentage: 37 },
+      { is_enabled: true, usedPercent: 37 },
+      { is_enabled: true, utilization: "37" },
+    ]) {
+      const result = parseUsageResponse(
+        {
+          five_hour: { utilization: 57 },
+          seven_day: { utilization: 12 },
+          extra_usage: extraUsage,
+        },
+        { includeExtraUsage: true },
+      );
+
+      expect(result?.extra_usage).toBeUndefined();
+    }
+  });
+
+  it("ignores camelCase extraUsage in OAuth payloads", () => {
+    const result = parseUsageResponse(
+      {
+        five_hour: { utilization: 57 },
+        seven_day: { utilization: 12 },
+        extraUsage: { is_enabled: true, utilization: 37 },
+      },
+      { includeExtraUsage: true },
+    );
+
+    expect(result?.extra_usage).toBeUndefined();
+  });
+
   it("drops invalid reset timestamps and only caps percent remaining above 100", () => {
     const result = parseUsageResponse({
       usage: {
@@ -434,6 +502,7 @@ describe("Claude CLI diagnostics", () => {
               usedPercentage: 12,
               resetsAt: "2026-04-01T00:00:00.000Z",
             },
+            extra_usage: { is_enabled: true, utilization: 37.8 },
           },
         }),
       },
@@ -446,6 +515,7 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.quotaSource).toBe("claude-auth-status-json");
     expect(diagnostics.quota?.five_hour.percentRemaining).toBe(43);
     expect(diagnostics.quota?.seven_day.percentRemaining).toBe(88);
+    expect(diagnostics.quota?.extra_usage).toBeUndefined();
 
     const quota = await queryAnthropicQuota();
     expect(quota?.success).toBe(true);
@@ -499,6 +569,7 @@ describe("Claude CLI diagnostics", () => {
             percent_used: 15,
             resetsAt: "2026-04-01T00:00:00.000Z",
           },
+          extra_usage: { is_enabled: true, utilization: 37.8 },
         },
       }),
     );
@@ -512,6 +583,7 @@ describe("Claude CLI diagnostics", () => {
     expect(diagnostics.quota?.five_hour.resetTimeIso).toBe("2026-03-25T18:00:00.000Z");
     expect(diagnostics.quota?.seven_day.percentRemaining).toBe(85);
     expect(diagnostics.quota?.seven_day.resetTimeIso).toBe("2026-04-01T00:00:00.000Z");
+    expect(diagnostics.quota?.extra_usage).toEqual({ percentRemaining: 62 });
     expect(fetchWithTimeoutMock).toHaveBeenCalledWith(ANTHROPIC_USAGE_URL, {
       request: {
         headers: {

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -184,6 +184,25 @@ describe("parseUsageResponse", () => {
     expect(result?.extra_usage).toEqual({ percentRemaining: 62 });
   });
 
+  it.each([
+    { utilization: 0, percentRemaining: 100 },
+    { utilization: 100, percentRemaining: 0 },
+  ])("preserves extra usage boundary utilization $utilization", ({
+    utilization,
+    percentRemaining,
+  }) => {
+    const result = parseUsageResponse(
+      {
+        five_hour: { utilization: 57 },
+        seven_day: { utilization: 12 },
+        extra_usage: { is_enabled: true, utilization },
+      },
+      { includeExtraUsage: true },
+    );
+
+    expect(result?.extra_usage).toEqual({ percentRemaining });
+  });
+
   it("ignores disabled or invalid extra usage without dropping quota windows", () => {
     for (const extraUsage of [
       undefined,

--- a/tests/providers.anthropic.surfaces.test.ts
+++ b/tests/providers.anthropic.surfaces.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuotaToastEntry } from "../src/lib/entries.js";
+import { renderAccountingFourSurfaces } from "./helpers/accounting-four-surface.js";
+
+const accounting = {
+  resultType: "quota" as const,
+  acquisitionMethod: "remote_api" as const,
+  ownership: "maintained" as const,
+  authority: "provider_reported" as const,
+};
+
+const entries: QuotaToastEntry[] = [
+  {
+    accounting,
+    name: "Claude 5h",
+    group: "Claude",
+    label: "5h:",
+    percentRemaining: 43,
+  },
+  {
+    accounting,
+    name: "Claude Weekly",
+    group: "Claude",
+    label: "Weekly:",
+    percentRemaining: 88,
+  },
+  {
+    accounting,
+    name: "Claude Usage Credits",
+    group: "Claude Usage Credits",
+    label: "Monthly:",
+    percentRemaining: 62,
+  },
+];
+
+describe("Anthropic four-surface formatting", () => {
+  it("identifies Usage Credits without changing the existing Claude quota rows", () => {
+    const outputs = renderAccountingFourSurfaces({
+      data: { entries, errors: [] },
+      accountingDetail: "summary",
+      toastMaxWidth: 64,
+      toastNarrowAt: 44,
+      compactMaxWidth: 160,
+    });
+
+    for (const output of Object.values(outputs)) {
+      expect(output).toContain("Claude Usage Credits");
+      expect(output).toContain("43%");
+      expect(output).toContain("88%");
+      expect(output).toContain("62%");
+    }
+
+    for (const output of [outputs.command, outputs.toast, outputs.sidebar]) {
+      expect(output).toMatch(/Month(?:ly| quota)/u);
+    }
+
+    expect(outputs.compact).toBe("Claude 5h 43%, 7d 88% | Claude Usage Credits 62%");
+  });
+});

--- a/tests/providers.anthropic.test.ts
+++ b/tests/providers.anthropic.test.ts
@@ -130,6 +130,61 @@ describe("anthropic provider", () => {
     expect(out.presentation).toBeUndefined();
   });
 
+  it("reports enabled Usage Credits as a third remote API quota row", async () => {
+    const { getAnthropicDiagnostics, queryAnthropicQuota } = await import(
+      "../src/lib/anthropic.js"
+    );
+    (getAnthropicDiagnostics as any).mockResolvedValueOnce({
+      installed: true,
+      version: "1.2.3",
+      authStatus: "authenticated",
+      quotaSupported: true,
+      quotaSource: "opencode-auth-oauth-api",
+      oauthCredentialSource: "opencode-auth",
+      checkedCommands: ["claude --version"],
+      quota: {
+        success: true,
+        five_hour: { percentRemaining: 43 },
+        seven_day: { percentRemaining: 88 },
+        extra_usage: { percentRemaining: 62 },
+      },
+    });
+    (queryAnthropicQuota as any).mockResolvedValueOnce({
+      success: true,
+      five_hour: { percentRemaining: 43, resetTimeIso: "2026-03-25T18:00:00.000Z" },
+      seven_day: { percentRemaining: 88, resetTimeIso: "2026-04-01T00:00:00.000Z" },
+      extra_usage: { percentRemaining: 62 },
+    });
+
+    const out = await anthropicProvider.fetch({} as any);
+
+    expect(visibleEntries(out.entries, "anthropic")).toEqual([
+      {
+        name: "Claude 5h",
+        group: "Claude",
+        label: "5h:",
+        percentRemaining: 43,
+        resetTimeIso: "2026-03-25T18:00:00.000Z",
+      },
+      {
+        name: "Claude Weekly",
+        group: "Claude",
+        label: "Weekly:",
+        percentRemaining: 88,
+        resetTimeIso: "2026-04-01T00:00:00.000Z",
+      },
+      {
+        name: "Claude Usage Credits",
+        group: "Claude",
+        label: "Monthly:",
+        percentRemaining: 62,
+      },
+    ]);
+    expect(out.entries.every((entry) => entry.accounting.acquisitionMethod === "remote_api")).toBe(
+      true,
+    );
+  });
+
   it("defaults to canonical grouped-capable rows when no style is specified", async () => {
     const { queryAnthropicQuota } = await import("../src/lib/anthropic.js");
     (queryAnthropicQuota as any).mockResolvedValueOnce({
@@ -140,6 +195,7 @@ describe("anthropic provider", () => {
 
     const out = await anthropicProvider.fetch({} as any);
     expectAttemptedWithNoErrors(out);
+    expect(out.entries).toHaveLength(2);
     expect(visibleEntries(out.entries, "anthropic")).toEqual([
       {
         name: "Claude 5h",

--- a/tests/providers.anthropic.test.ts
+++ b/tests/providers.anthropic.test.ts
@@ -175,7 +175,7 @@ describe("anthropic provider", () => {
       },
       {
         name: "Claude Usage Credits",
-        group: "Claude",
+        group: "Claude Usage Credits",
         label: "Monthly:",
         percentRemaining: 62,
       },


### PR DESCRIPTION
## Summary

Add Claude Usage Credits from the OAuth subscription usage response as a third quota row.

The row shows remaining credits for the monthly period using the `Monthly:` label.

## Linked Issue

No issue exists. This is a focused enhancement that exposes the existing Claude OAuth `extra_usage` field.

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.25
- Why this version is relevant to the fix: it is the OpenCode version against which the Claude OAuth quota path and TUI/server rendering were tested.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed — not applicable; no setup, configuration, command, or workflow changed
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply — this modifies the existing Anthropic provider rather than adding a built-in provider