### PR TITLE
fix: prepare MiniMax accounting for v4.9.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -907,8 +907,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.19:
-    resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
+  baseline-browser-mapping@2.10.44:
+    resolution: {integrity: sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -922,11 +922,11 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -938,8 +938,8 @@ packages:
     peerDependencies:
       typescript: ^5
 
-  caniuse-lite@1.0.30001788:
-    resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -990,8 +990,8 @@ packages:
   effect@4.0.0-beta.83:
     resolution: {integrity: sha512-0wsak8RtgGAr9UWSbVDgJHZcUqMSvicHcvaZv1MbMM7MCGgW4Rn/137J1MHQbwYPcwYGxT/IqehFd+UbYuj78w==}
 
-  electron-to-chromium@1.5.336:
-    resolution: {integrity: sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==}
+  electron-to-chromium@1.5.393:
+    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -1276,8 +1276,9 @@ packages:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
 
-  node-releases@2.0.37:
-    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1663,7 +1664,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.0
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -2284,7 +2285,7 @@ snapshots:
   base64-js@1.5.1:
     optional: true
 
-  baseline-browser-mapping@2.10.19: {}
+  baseline-browser-mapping@2.10.44: {}
 
   better-sqlite3@12.10.0:
     dependencies:
@@ -2304,17 +2305,17 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  browserslist@4.28.2:
+  browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.10.19
-      caniuse-lite: 1.0.30001788
-      electron-to-chromium: 1.5.336
-      node-releases: 2.0.37
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.10.44
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.393
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   buffer@5.7.1:
     dependencies:
@@ -2326,7 +2327,7 @@ snapshots:
     dependencies:
       typescript: 7.0.2
 
-  caniuse-lite@1.0.30001788: {}
+  caniuse-lite@1.0.30001806: {}
 
   chai@6.2.2: {}
 
@@ -2378,7 +2379,7 @@ snapshots:
       uuid: 14.0.1
       yaml: 2.9.0
 
-  electron-to-chromium@1.5.336: {}
+  electron-to-chromium@1.5.393: {}
 
   emoji-regex@10.6.0: {}
 
@@ -2592,7 +2593,7 @@ snapshots:
 
   minimatch@8.0.7:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.4
 
   minimist@1.2.8:
     optional: true
@@ -2639,7 +2640,7 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-releases@2.0.37: {}
+  node-releases@2.0.51: {}
 
   obug@2.1.1: {}
 
@@ -2896,9 +2897,9 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ export type {
   GoogleModelQuota,
   GoogleQuotaResult,
   MaintainerAnnouncementsConfig,
+  MiniMaxResult,
+  MiniMaxResultEntry,
   PricingSnapshotSource,
   QuotaToastConfig,
   SessionTokenScope,

--- a/src/lib/quota-state-codec.ts
+++ b/src/lib/quota-state-codec.ts
@@ -209,12 +209,12 @@ function isAccountingQuantity(value: unknown, safeText: boolean): value is Accou
   );
 }
 
-function isAccountingBasisFact(value: unknown, safeText: boolean): boolean {
+function isAccountingBasisFact(value: unknown, safeText: boolean, allowNegative = false): boolean {
   return (
     isRecord(value) &&
     hasOnlyKeys(value, ["quantity", "authority"]) &&
     isAccountingQuantity(value.quantity, safeText) &&
-    !value.quantity.decimal.startsWith("-") &&
+    (allowNegative || !value.quantity.decimal.startsWith("-")) &&
     isOneOf(value.authority, ["provider_reported", "locally_derived", "user_configured"])
   );
 }
@@ -227,7 +227,12 @@ function isAccountingPercentageBasis(
   const facts = [value.used, value.limit, value.remaining].filter(
     (fact): fact is Record<string, unknown> => fact !== undefined,
   );
-  if (facts.length === 0 || !facts.every((fact) => isAccountingBasisFact(fact, safeText))) {
+  if (
+    facts.length === 0 ||
+    (value.used !== undefined && !isAccountingBasisFact(value.used, safeText)) ||
+    (value.limit !== undefined && !isAccountingBasisFact(value.limit, safeText)) ||
+    (value.remaining !== undefined && !isAccountingBasisFact(value.remaining, safeText, true))
+  ) {
     return false;
   }
   const firstFact = facts[0];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -817,6 +817,23 @@ export type CopilotResult =
 export type GoogleResult = GoogleQuotaResult | QuotaError | null;
 export type GeminiCliResult = GeminiCliQuotaResult | QuotaError | null;
 export type ZaiResult = ZaiQuotaResult | QuotaError | null;
+/** Single entry in a MiniMax quota result */
+export interface MiniMaxResultEntry {
+  window: "five_hour" | "weekly";
+  name: string;
+  group?: string;
+  label?: string;
+  right?: string;
+  percentRemaining: number;
+  resetTimeIso?: string;
+}
+
+export type MiniMaxResult =
+  | {
+      success: true;
+      entries: MiniMaxResultEntry[];
+    }
+  | QuotaError;
 export type ChutesResult =
   | {
       success: true;

--- a/src/providers/minimax-coding-plan.ts
+++ b/src/providers/minimax-coding-plan.ts
@@ -186,9 +186,15 @@ function computeMiniMaxEntryData(
     const { used, remaining } = normalizeMiniMaxCounts(total, rawCount, countSemantics);
     const percentRemaining = roundPercent((remaining / total) * 100);
     const basis: AccountingPercentageBasis = {
-      used: { quantity: quantity(used, REQUEST_UNIT), authority: "provider_reported" },
+      used: {
+        quantity: quantity(used, REQUEST_UNIT),
+        authority: countSemantics === "used" ? "provider_reported" : "locally_derived",
+      },
       limit: { quantity: quantity(total, REQUEST_UNIT), authority: "provider_reported" },
-      remaining: { quantity: quantity(remaining, REQUEST_UNIT), authority: "locally_derived" },
+      remaining: {
+        quantity: quantity(remaining, REQUEST_UNIT),
+        authority: countSemantics === "remaining" ? "provider_reported" : "locally_derived",
+      },
     };
     return { basis, percentRemaining, resetTimeIso };
   }

--- a/tests/lib.quota-state-codec.test.ts
+++ b/tests/lib.quota-state-codec.test.ts
@@ -174,6 +174,23 @@ describe("quota-state codec", () => {
     expect(normalized?.diagnostics?.[0]?.checkedPaths).toEqual(["env:SYNTHETIC_API_KEY"]);
   });
 
+  it("normalizes and round-trips over-quota remaining basis values", () => {
+    const input = createValidResult();
+    const percentEntry = input.entries[0] as any;
+    percentEntry.percentRemaining = -5;
+    percentEntry.basis.used.quantity.decimal = "105";
+    percentEntry.basis.remaining.quantity.decimal = "-5";
+
+    expect(normalizeQuotaProviderResult(input)).toEqual(input);
+
+    const encoded = createEnvelope(input);
+    const decoded = decodePersistedQuotaProviderCacheEntry(
+      JSON.parse(JSON.stringify(encoded)) as unknown,
+      EXPECTED_IDENTITY,
+    );
+    expect(decoded?.result).toEqual(input);
+  });
+
   it("sanitizes text before strict safe-text revalidation", () => {
     const input = createValidResult();
     const quantity = input.entries[2] as any;
@@ -307,8 +324,12 @@ describe("quota-state codec", () => {
       (value: any) => (value.entries[0].basis.used.quantity.decimal = "01"),
     ],
     [
-      "basis quantities are nonnegative",
+      "basis used quantities are nonnegative",
       (value: any) => (value.entries[0].basis.used.quantity.decimal = "-1"),
+    ],
+    [
+      "basis limits are nonnegative",
+      (value: any) => (value.entries[0].basis.limit.quantity.decimal = "-1"),
     ],
     [
       "basis units match",

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -299,6 +299,19 @@ describe("package manifest compatibility", () => {
     });
   });
 
+  it("keeps the legacy MiniMax result types in generated public declarations", async () => {
+    const [indexDeclarations, typesDeclarations] = await Promise.all([
+      readFile(new URL("../dist/index.d.ts", import.meta.url), "utf8"),
+      readFile(new URL("../dist/lib/types.d.ts", import.meta.url), "utf8"),
+    ]);
+
+    expect(indexDeclarations).toMatch(/MiniMaxResult[\s\S]*MiniMaxResultEntry/u);
+    expect(typesDeclarations).toContain("export interface MiniMaxResultEntry {");
+    expect(typesDeclarations).toContain('window: "five_hour" | "weekly";');
+    expect(typesDeclarations).toContain("export type MiniMaxResult = {");
+    expect(typesDeclarations).toContain("entries: MiniMaxResultEntry[];");
+  });
+
   it("does not leave stale Crof generated artifacts in active dist", async () => {
     const staleCrofDistPaths = [
       "../dist/lib/crof-config.d.ts",

--- a/tests/providers.minimax-coding-plan.test.ts
+++ b/tests/providers.minimax-coding-plan.test.ts
@@ -174,10 +174,17 @@ describe("minimax-coding-plan provider", () => {
       percentRemaining: 98,
       semantic: { metric: { kind: "window", window: "five_hour" } },
       basis: {
-        used: { quantity: { decimal: "70", unit: { kind: "count", unit: "request" } } },
-        limit: { quantity: { decimal: "4500", unit: { kind: "count", unit: "request" } } },
+        used: {
+          quantity: { decimal: "70", unit: { kind: "count", unit: "request" } },
+          authority: "locally_derived",
+        },
+        limit: {
+          quantity: { decimal: "4500", unit: { kind: "count", unit: "request" } },
+          authority: "provider_reported",
+        },
         remaining: {
           quantity: { decimal: "4430", unit: { kind: "count", unit: "request" } },
+          authority: "provider_reported",
         },
       },
     });
@@ -262,9 +269,9 @@ describe("minimax-coding-plan provider", () => {
       percentRemaining: 20,
       semantic: { metric: { kind: "window", window: "five_hour" } },
       basis: {
-        used: { quantity: { decimal: "1200" } },
-        limit: { quantity: { decimal: "1500" } },
-        remaining: { quantity: { decimal: "300" } },
+        used: { quantity: { decimal: "1200" }, authority: "provider_reported" },
+        limit: { quantity: { decimal: "1500" }, authority: "provider_reported" },
+        remaining: { quantity: { decimal: "300" }, authority: "locally_derived" },
       },
     });
     expect(out.entries[0]).not.toHaveProperty("window");
@@ -671,9 +678,9 @@ describe("minimax-coding-plan provider", () => {
     expect(out.entries[0]).toMatchObject({
       percentRemaining: -1,
       basis: {
-        used: { quantity: { decimal: "4550" } },
-        limit: { quantity: { decimal: "4500" } },
-        remaining: { quantity: { decimal: "-50" } },
+        used: { quantity: { decimal: "4550" }, authority: "locally_derived" },
+        limit: { quantity: { decimal: "4500" }, authority: "provider_reported" },
+        remaining: { quantity: { decimal: "-50" }, authority: "provider_reported" },
       },
     });
     expect(out.entries[1]).toMatchObject({

--- a/tests/v4-phase5-cross-surface.test.ts
+++ b/tests/v4-phase5-cross-surface.test.ts
@@ -324,10 +324,10 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
             {
               model_name: "MiniMax-M*",
               current_interval_total_count: 100,
-              current_interval_usage_count: 35,
+              current_interval_usage_count: -5,
               remains_time: 3_600_000,
               current_weekly_total_count: 200,
-              current_weekly_usage_count: 160,
+              current_weekly_usage_count: -20,
               weekly_remains_time: 86_400_000,
             },
           ],
@@ -693,7 +693,7 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     await hooks.dispose?.();
   });
 
-  it("renders non-empty MiniMax five-hour and weekly quota on all four surfaces", async () => {
+  it("keeps over-quota MiniMax results in cache, export, and all four displays", async () => {
     currentConfig = configForMiniMax();
     mocks.loadConfig.mockImplementation(async () => currentConfig);
     const { minimaxCodingPlanProvider } = await import("../src/providers/minimax-coding-plan.js");
@@ -718,9 +718,40 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     expect(serverOutput).toContain("MiniMax Token Plan");
     expect(serverOutput).toContain("Five-hour quota");
     expect(serverOutput).toContain("Weekly quota");
-    expect(serverOutput).toContain("35%");
-    expect(serverOutput).toContain("80%");
+    expect(serverOutput).toContain("0% left");
+    expect(serverOutput).toContain("Remaining: -5 requests");
+    expect(serverOutput).toContain("Remaining: -20 requests");
     expect(serverOutput).not.toContain("Invalid normalized provider result");
+
+    const { resolveQuotaRuntimeContext } = await import("../src/lib/quota-runtime-context.js");
+    const runtime = await resolveQuotaRuntimeContext({
+      client: client as never,
+      roots: { workspaceRoot: process.cwd() },
+      config: currentConfig,
+      providers: [minimaxCodingPlanProvider],
+      configureTelemetry: false,
+    });
+    const { buildQuotaExport, createExportProviderContext } = await import(
+      "../src/lib/quota-export.js"
+    );
+    const fetchCallsBeforeExport = vi.mocked(globalThis.fetch).mock.calls.length;
+    const exportData = await buildQuotaExport({
+      providers: [minimaxCodingPlanProvider],
+      ctx: createExportProviderContext(runtime),
+      ttlMs: currentConfig.minIntervalMs,
+      fromCache: true,
+    });
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(fetchCallsBeforeExport);
+    const exportedProvider = exportData.providers["minimax-coding-plan"];
+    expect(exportedProvider?.status).toBe("ok");
+    if (!exportedProvider || !("entries" in exportedProvider)) {
+      throw new Error("Expected cached MiniMax export entries");
+    }
+    expect(
+      exportedProvider.entries.map((entry) =>
+        entry.renderType === "percent" ? entry.percentRemaining : entry.value,
+      ),
+    ).toEqual([-5, -10]);
 
     await hooks.event?.({
       event: {
@@ -732,8 +763,9 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     expect(toastOutput).toContain("MiniMax Token Plan");
     expect(toastOutput).toContain("Five-hour");
     expect(toastOutput).toContain("Weekly");
-    expect(toastOutput).toContain("35%");
-    expect(toastOutput).toContain("80%");
+    expect(toastOutput).toContain("0% left");
+    expect(toastOutput).toContain("Remaining: -5 requests");
+    expect(toastOutput).toContain("Remaining: -20 requests");
 
     const tuiApi = {
       state: {
@@ -757,13 +789,13 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     expect(sidebarOutput).toContain("MiniMax Token Plan");
     expect(sidebarOutput).toContain("Five-hour");
     expect(sidebarOutput).toContain("Weekly");
-    expect(sidebarOutput).toContain("35%");
-    expect(sidebarOutput).toContain("80%");
+    expect(sidebarOutput).toContain("0% left");
+    expect(sidebarOutput).toContain("Remaining: -5 requests");
+    expect(sidebarOutput).toContain("Remaining: -20 requests");
 
     expect(surfaces.compact.status).toBe("ready");
     const compactOutput = surfaces.compact.status === "ready" ? surfaces.compact.text : "";
-    expect(compactOutput).toContain("35%");
-    expect(compactOutput).toContain("80%");
+    expect(compactOutput.match(/0%/gu)).toHaveLength(2);
     expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(1);
 
     await hooks.dispose?.();


### PR DESCRIPTION
## Summary

- Preserve MiniMax overage through cache, export, and all four displays.
- Correct endpoint authority.
- Restore public MiniMax types.
- Update audited transitive dependencies.

## Validation

- `pnpm verify`: 185 files, 2,216 passed, 1 skipped.
- Package verification passed.
- High-level audit clear.
- Independent review approved.