### PR TITLE
fix(opencode-go): suppress non-entitled quota refreshes

### DIFF
--- a/src/lib/opencode-go.ts
+++ b/src/lib/opencode-go.ts
@@ -133,6 +133,17 @@ function normalizeResponse(payload: unknown, accessToken: string): OpenCodeGoRes
   };
 }
 
+function isNotSubscribedResponse(status: number, text: string): boolean {
+  if (status !== 403) return false;
+  try {
+    const payload = asRecord(JSON.parse(text));
+    const error = asRecord(payload?.error);
+    return payload?.type === "error" && error?.type === "EntitlementError";
+  } catch {
+    return false;
+  }
+}
+
 export async function queryOpenCodeGoQuota(
   accessToken: string,
   options: { requestTimeoutMs?: number } = {},
@@ -157,6 +168,14 @@ export async function queryOpenCodeGoQuota(
               success: false,
               error: `OpenCode Go API error ${response.status}: ${errorMessage(error, accessToken)}`,
               retryable: isRetryableHttpStatus(response.status),
+            };
+          }
+          if (isNotSubscribedResponse(response.status, text)) {
+            return {
+              success: false,
+              error: "OpenCode Go not subscribed (403 EntitlementError)",
+              notSubscribed: true,
+              retryable: false,
             };
           }
           return {

--- a/src/lib/quota-status.ts
+++ b/src/lib/quota-status.ts
@@ -92,6 +92,7 @@ const OPENCODE_GO_STATUS_DETAIL_KEYS = new Set([
   "weekly_usage",
   "monthly_usage",
   "live_fetch_error",
+  "opencode_go_state",
 ]);
 type ProviderLiveProbe = {
   providerId: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -911,7 +911,7 @@ export type OpenCodeGoResult =
       weekly: OpenCodeGoWindow;
       monthly: OpenCodeGoWindow;
     }
-  | QuotaError;
+  | (QuotaError & { notSubscribed?: true });
 
 /** Cached toast data */
 export interface CachedToast {

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type {
   QuotaProvider,
   QuotaProviderContext,
@@ -29,6 +31,12 @@ const OPENCODE_GO_WINDOW_LABELS: Record<OpenCodeGoWindowKey, { name: string; lab
   weekly: { name: `${OPENCODE_GO_PROVIDER_LABEL} Weekly`, label: "Weekly:" },
   monthly: { name: `${OPENCODE_GO_PROVIDER_LABEL} Monthly`, label: "Monthly:" },
 };
+
+let notSubscribedCredentialFingerprint: string | null = null;
+
+export function __resetOpenCodeGoNotSubscribedForTests(): void {
+  notSubscribedCredentialFingerprint = null;
+}
 
 function authStatusDetails(diagnostics: OpenCodeGoAuthDiagnostics): QuotaProviderStatusDetail[] {
   return statusDetailsFromRecord({
@@ -99,14 +107,28 @@ export const opencodeGoProvider: QuotaProvider = {
     });
 
     if (auth.state === "none") {
+      notSubscribedCredentialFingerprint = null;
       return withStatusDetails(notAttemptedResult(), statusDetails);
     }
 
     if (auth.state === "invalid") {
+      notSubscribedCredentialFingerprint = null;
       return withStatusDetails(
         attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, auth.error),
         statusDetails,
       );
+    }
+
+    const credentialFingerprint = createHash("sha256").update(auth.apiKey).digest("hex");
+    if (notSubscribedCredentialFingerprint !== credentialFingerprint) {
+      notSubscribedCredentialFingerprint = null;
+    }
+
+    if (notSubscribedCredentialFingerprint !== null) {
+      return withStatusDetails(attemptedResult([]), [
+        ...statusDetails,
+        { key: "opencode_go_state", value: "not_subscribed" },
+      ]);
     }
 
     const result = await queryOpenCodeGoQuota(auth.apiKey, {
@@ -114,6 +136,13 @@ export const opencodeGoProvider: QuotaProvider = {
     });
 
     if (!result.success) {
+      if (result.notSubscribed === true) {
+        notSubscribedCredentialFingerprint = credentialFingerprint;
+        return withStatusDetails(attemptedResult([]), [
+          ...statusDetails,
+          { key: "opencode_go_state", value: "not_subscribed" },
+        ]);
+      }
       return withStatusDetails(
         attemptedErrorResult(OPENCODE_GO_PROVIDER_LABEL, result.error, {
           retryable: result.retryable,

--- a/src/providers/opencode-go.ts
+++ b/src/providers/opencode-go.ts
@@ -85,7 +85,11 @@ export const opencodeGoProvider: QuotaProvider = {
     const auth = await resolveOpenCodeGoAuthCached({
       maxAgeMs: DEFAULT_OPENCODE_GO_AUTH_CACHE_MAX_AGE_MS,
     });
-    return auth.state === "configured";
+    if (auth.state !== "configured") {
+      notSubscribedCredentialFingerprint = null;
+      return false;
+    }
+    return true;
   },
 
   matchesCurrentModel(model: string): boolean {

--- a/tests/lib.opencode-go.test.ts
+++ b/tests/lib.opencode-go.test.ts
@@ -269,17 +269,19 @@ describe("queryOpenCodeGoQuota", () => {
   });
 
   it.each([
-    '{"error":"forbidden"}',
-    '{"error":{"type":"EntitlementError"}}',
-    '{"error":{"type":"PermissionError","message":"subscription required"}}',
-    "not-json EntitlementError",
-  ])("keeps unrelated 403 body %s as an ordinary error", async (body) => {
-    mockHttpFailure(403, body);
+    [403, '{"error":"forbidden"}'],
+    [403, '{"error":{"type":"EntitlementError"}}'],
+    [403, '{"type":"error","error":{"type":"entitlementerror"}}'],
+    [403, '{"error":{"type":"PermissionError","message":"subscription required"}}'],
+    [403, "not-json EntitlementError"],
+    [401, '{"type":"error","error":{"type":"EntitlementError"}}'],
+  ])("keeps unrelated HTTP %s body %s as an ordinary error", async (status, body) => {
+    mockHttpFailure(status, body);
 
     const result = await queryOpenCodeGoQuota("token");
 
     expect(result).toMatchObject({ success: false, retryable: false });
-    expect((result as { error: string }).error).toContain("OpenCode Go API error 403");
+    expect((result as { error: string }).error).toContain(`OpenCode Go API error ${status}`);
     expect((result as { notSubscribed?: true }).notSubscribed).toBeUndefined();
   });
 

--- a/tests/lib.opencode-go.test.ts
+++ b/tests/lib.opencode-go.test.ts
@@ -252,6 +252,37 @@ describe("queryOpenCodeGoQuota", () => {
     );
   });
 
+  it("flags a 403 EntitlementError body as not subscribed", async () => {
+    mockHttpFailure(
+      403,
+      '{"type":"error","error":{"type":"EntitlementError","message":"OpenCode Go subscription required."}}',
+    );
+
+    const result = await queryOpenCodeGoQuota("token");
+
+    expect(result).toEqual({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+  });
+
+  it.each([
+    '{"error":"forbidden"}',
+    '{"error":{"type":"EntitlementError"}}',
+    '{"error":{"type":"PermissionError","message":"subscription required"}}',
+    "not-json EntitlementError",
+  ])("keeps unrelated 403 body %s as an ordinary error", async (body) => {
+    mockHttpFailure(403, body);
+
+    const result = await queryOpenCodeGoQuota("token");
+
+    expect(result).toMatchObject({ success: false, retryable: false });
+    expect((result as { error: string }).error).toContain("OpenCode Go API error 403");
+    expect((result as { notSubscribed?: true }).notSubscribed).toBeUndefined();
+  });
+
   it("retains the HTTP status when reading a non-success body fails", async () => {
     const token = "distinctive-secret-token";
     mocks.fetchResponse.mockResolvedValueOnce({

--- a/tests/provider-surfaces.opencode-go.test.ts
+++ b/tests/provider-surfaces.opencode-go.test.ts
@@ -155,7 +155,15 @@ describe("OpenCode Go shared projections", () => {
       configOverrides: config,
       resetPluginState: true,
     });
-    provider = (await import("../src/providers/opencode-go.js")).opencodeGoProvider;
+    const providerModule = await import("../src/providers/opencode-go.js");
+    providerModule.__resetOpenCodeGoNotSubscribedForTests();
+    provider = providerModule.opencodeGoProvider;
+    provider.cachePolicy = {
+      kind: "resolved-auth",
+      async resolveIdentity() {
+        return "opencode-go-test-identity" as never;
+      },
+    };
     mocks.loadConfig.mockResolvedValue(config);
     mocks.getProviders.mockReturnValue([provider]);
     mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
@@ -241,6 +249,92 @@ describe("OpenCode Go shared projections", () => {
       percentDisplayMode: "remaining",
     });
     expect(JSON.stringify(surfaces)).not.toContain(TEST_TOKEN);
+
+    await hooks.dispose?.();
+  });
+
+  it("hides a not-subscribed result on every display and keeps it visible in safe diagnostics", async () => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValue({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+    const client = createPluginTestClient({
+      modelID: "opencode-go/model",
+      providerID: "opencode-go",
+    });
+    client.config.providers.mockResolvedValue({
+      data: { providers: [{ id: "opencode-go" }] },
+    });
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = (await QuotaToastPlugin({ client } as never)) as PluginHooks;
+
+    await expectHandled(
+      hooks["command.execute.before"]?.({
+        command: "quota",
+        sessionID: "opencode-go-no-subscription",
+      }),
+    );
+    const command = getPromptText(client);
+
+    await hooks.event?.({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "opencode-go-no-subscription" },
+      },
+    });
+
+    const { loadTuiSessionQuotaSurfaces } = await import("../src/lib/tui-runtime.js");
+    const surfaces = await loadTuiSessionQuotaSurfaces({
+      api: {
+        state: {
+          provider: [{ id: "opencode-go" }],
+          path: { worktree: process.cwd(), directory: process.cwd() },
+          session: { messages: () => [] },
+        },
+        client,
+      } as never,
+      sessionID: "opencode-go-no-subscription",
+    });
+    const sidebar = [...surfaces.sidebar.lines, ...(surfaces.sidebar.linesExpanded ?? [])].join(
+      "\n",
+    );
+    const compact = surfaces.compact.status === "ready" ? surfaces.compact.text : "";
+
+    for (const output of [command, getToastMessage(client), sidebar, compact]) {
+      expect(output).not.toContain("EntitlementError");
+      expect(output).not.toContain("not subscribed");
+      expect(output).not.toContain(TEST_TOKEN);
+    }
+    expect(client.tui.showToast).not.toHaveBeenCalled();
+
+    const { buildQuotaExport } = await import("../src/lib/quota-export.js");
+    const { createRuntimeProviderIdResolver } = await import("../src/lib/runtime-provider-ids.js");
+    const exportData = await buildQuotaExport({
+      providers: [provider],
+      ctx: {
+        client,
+        config: createConfig(),
+        resolveRuntimeProviderIds: createRuntimeProviderIdResolver(client),
+      } as never,
+      ttlMs: 60_000,
+      fromCache: true,
+    });
+    expect(exportData.providers["opencode-go"]).toEqual({ status: "unavailable" });
+
+    await expectHandled(
+      hooks["command.execute.before"]?.({
+        command: "quota_status",
+        sessionID: "opencode-go-no-subscription",
+      }),
+    );
+    const status = getPromptText(client, 1);
+    expect(status).toContain("opencode_go_state");
+    expect(status).toContain("not_subscribed");
+    expect(status).not.toContain(TEST_TOKEN);
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(1);
 
     await hooks.dispose?.();
   });

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -258,6 +258,9 @@ describe("opencode-go provider", () => {
       notSubscribed: true,
       retryable: false,
     });
+    await expect(opencodeGoProvider.isAvailable(createProviderAvailabilityContext())).resolves.toBe(
+      true,
+    );
     await runFetch();
 
     mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
@@ -282,13 +285,9 @@ describe("opencode-go provider", () => {
   });
 
   it.each([
-    ["missing", diagnostics("none"), { state: "none" }],
-    [
-      "invalid",
-      diagnostics("invalid"),
-      { state: "invalid", error: "OpenCode Go auth entry present but key is empty" },
-    ],
-  ])("queries again when the same credential becomes %s and is restored", async (_name, details, auth) => {
+    ["missing", { state: "none" }],
+    ["invalid", { state: "invalid", error: "OpenCode Go auth entry present but key is empty" }],
+  ])("queries again after production availability sees %s auth", async (_name, auth) => {
     mocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
       success: false,
       error: "OpenCode Go not subscribed (403 EntitlementError)",
@@ -297,12 +296,16 @@ describe("opencode-go provider", () => {
     });
     await runFetch();
 
-    mocks.getOpenCodeGoAuthDiagnostics.mockResolvedValueOnce(details);
     mocks.resolveOpenCodeGoAuthCached.mockResolvedValueOnce(auth);
-    await runFetch();
+    await expect(opencodeGoProvider.isAvailable(createProviderAvailabilityContext())).resolves.toBe(
+      false,
+    );
     await runFetch();
 
     expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(2);
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenLastCalledWith("provider-test-token", {
+      requestTimeoutMs: 5_000,
+    });
   });
 
   it("does not copy the resolved token into provider output", async () => {

--- a/tests/providers.opencode-go.test.ts
+++ b/tests/providers.opencode-go.test.ts
@@ -24,7 +24,10 @@ vi.mock("../src/lib/opencode-go.js", () => ({
   queryOpenCodeGoQuota: mocks.queryOpenCodeGoQuota,
 }));
 
-import { opencodeGoProvider } from "../src/providers/opencode-go.js";
+import {
+  __resetOpenCodeGoNotSubscribedForTests,
+  opencodeGoProvider,
+} from "../src/providers/opencode-go.js";
 
 function successfulResult() {
   return {
@@ -76,6 +79,7 @@ async function runFetch(
 describe("opencode-go provider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetOpenCodeGoNotSubscribedForTests();
     mocks.getOpenCodeGoAuthDiagnostics.mockResolvedValue(diagnostics());
     mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
       state: "configured",
@@ -221,6 +225,86 @@ describe("opencode-go provider", () => {
     });
   });
 
+  it("suppresses repeat requests after a not-subscribed response", async () => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValue({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+
+    const first = await runFetch();
+    const second = await runFetch();
+
+    expectAttemptedWithNoErrors(first);
+    expectAttemptedWithNoErrors(second);
+    expect(first.entries).toEqual([]);
+    expect(second.entries).toEqual([]);
+    expect(first.statusDetails).toContainEqual({
+      key: "opencode_go_state",
+      value: "not_subscribed",
+    });
+    expect(second.statusDetails).toContainEqual({
+      key: "opencode_go_state",
+      value: "not_subscribed",
+    });
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(1);
+  });
+
+  it("queries again after the credential changes, including when the original returns", async () => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+    await runFetch();
+
+    mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
+      state: "configured",
+      apiKey: "new-provider-test-token",
+    });
+    await runFetch();
+
+    mocks.resolveOpenCodeGoAuthCached.mockResolvedValue({
+      state: "configured",
+      apiKey: "provider-test-token",
+    });
+    await runFetch();
+
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(3);
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenNthCalledWith(2, "new-provider-test-token", {
+      requestTimeoutMs: 5_000,
+    });
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenLastCalledWith("provider-test-token", {
+      requestTimeoutMs: 5_000,
+    });
+  });
+
+  it.each([
+    ["missing", diagnostics("none"), { state: "none" }],
+    [
+      "invalid",
+      diagnostics("invalid"),
+      { state: "invalid", error: "OpenCode Go auth entry present but key is empty" },
+    ],
+  ])("queries again when the same credential becomes %s and is restored", async (_name, details, auth) => {
+    mocks.queryOpenCodeGoQuota.mockResolvedValueOnce({
+      success: false,
+      error: "OpenCode Go not subscribed (403 EntitlementError)",
+      notSubscribed: true,
+      retryable: false,
+    });
+    await runFetch();
+
+    mocks.getOpenCodeGoAuthDiagnostics.mockResolvedValueOnce(details);
+    mocks.resolveOpenCodeGoAuthCached.mockResolvedValueOnce(auth);
+    await runFetch();
+    await runFetch();
+
+    expect(mocks.queryOpenCodeGoQuota).toHaveBeenCalledTimes(2);
+  });
+
   it("does not copy the resolved token into provider output", async () => {
     const out = await runFetch();
     expect(JSON.stringify(out)).not.toContain("provider-test-token");
@@ -230,6 +314,7 @@ describe("opencode-go provider", () => {
 describe("opencode-go availability and model matching", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetOpenCodeGoNotSubscribedForTests();
   });
 
   it.each([


### PR DESCRIPTION
Integrates the independently approved local implementation for issue #247.

Included commits preserve their original authorship and suppress repeated non-entitled OpenCode Go refreshes while clearing suppression when availability changes.

Local validation: targeted OpenCode Go tests, pnpm verify, and explicit build all passed.