### PR TITLE
feat(anthropic): show Fable weekly quota

### DIFF
--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -389,6 +389,8 @@ If Claude lives at a custom path, set `anthropicBinaryPath` in `opencode-quota/q
 
 When Claude Code does not expose quota windows itself, quota is read from Anthropic's OAuth usage endpoint using the first usable access token: OpenCode's own `anthropic` OAuth credential from `auth.json`, then Claude Code's credentials. `/quota_status` reports which store answered as `oauth_credential_source`.
 
+If that response includes Anthropic's model-scoped Fable weekly window, OpenCode Quota shows it as a separate `Fable` row. The row is omitted when Anthropic does not return the window; OpenCode Quota does not infer eligibility from the account's plan name. See [Claude Fable models on your plan](https://support.claude.com/en/articles/15424964-claude-fable-models-on-your-plan) for Anthropic's current eligibility rules.
+
 <a id="cursor"></a>
 
 ### Cursor

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -54,12 +54,14 @@ export interface AnthropicQuotaWindow {
 export interface AnthropicUsageResponse {
   five_hour: AnthropicQuotaWindow;
   seven_day: AnthropicQuotaWindow;
+  limits?: unknown[];
 }
 
 export interface AnthropicQuotaResult {
   success: true;
   five_hour: { percentRemaining: number; resetTimeIso?: string };
   seven_day: { percentRemaining: number; resetTimeIso?: string };
+  fable_weekly?: { percentRemaining: number; resetTimeIso?: string };
 }
 
 export interface AnthropicQuotaError {
@@ -357,6 +359,38 @@ function getUsageRoots(data: unknown): Record<string, unknown>[] {
   return roots;
 }
 
+function parseFableWeeklyWindow(
+  limits: unknown,
+): { percentRemaining: number; resetTimeIso?: string } | undefined {
+  if (!Array.isArray(limits)) {
+    return undefined;
+  }
+
+  for (const value of limits) {
+    const limit = asRecord(value);
+    if (!limit || limit["kind"] !== "weekly_scoped") {
+      continue;
+    }
+
+    const scope = asRecord(limit["scope"]);
+    const model = asRecord(scope?.["model"]);
+    const displayName = model?.["display_name"];
+    if (displayName !== "Fable") {
+      continue;
+    }
+
+    const window = parseQuotaWindow({
+      utilization: limit["percent"],
+      resets_at: limit["resets_at"],
+    });
+    if (window) {
+      return window;
+    }
+  }
+
+  return undefined;
+}
+
 function parseUsageResponse(data: unknown): AnthropicQuotaResult | null {
   for (const root of getUsageRoots(data)) {
     const fiveHour = parseQuotaWindow(root["five_hour"] ?? root["fiveHour"]);
@@ -370,6 +404,27 @@ function parseUsageResponse(data: unknown): AnthropicQuotaResult | null {
       success: true,
       five_hour: fiveHour,
       seven_day: sevenDay,
+    };
+  }
+
+  return null;
+}
+
+function parseOAuthUsageResponse(data: unknown): AnthropicQuotaResult | null {
+  for (const root of getUsageRoots(data)) {
+    const fiveHour = parseQuotaWindow(root["five_hour"] ?? root["fiveHour"]);
+    const sevenDay = parseQuotaWindow(root["seven_day"] ?? root["sevenDay"]);
+
+    if (!fiveHour || !sevenDay) {
+      continue;
+    }
+
+    const fableWeekly = parseFableWeeklyWindow(root["limits"]);
+    return {
+      success: true,
+      five_hour: fiveHour,
+      seven_day: sevenDay,
+      ...(fableWeekly ? { fable_weekly: fableWeekly } : {}),
     };
   }
 
@@ -771,7 +826,7 @@ async function performAnthropicOAuthUsageRequest(
           };
         }
 
-        const quota = parseUsageResponse(data);
+        const quota = parseOAuthUsageResponse(data);
         if (!quota) {
           return {
             state: "unavailable",
@@ -1408,4 +1463,4 @@ export async function queryAnthropicQuota(
   }
 }
 
-export { parseUsageResponse };
+export { parseOAuthUsageResponse, parseUsageResponse };

--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -79,6 +79,9 @@ export const anthropicProvider: QuotaProvider = {
         seven_day_remaining: quota
           ? `${quota.seven_day.percentRemaining}% reset_at=${quota.seven_day.resetTimeIso ?? "(none)"}`
           : undefined,
+        fable_weekly_remaining: quota?.fable_weekly
+          ? `${quota.fable_weekly.percentRemaining}% reset_at=${quota.fable_weekly.resetTimeIso ?? "(none)"}`
+          : undefined,
       });
     } catch (error) {
       statusDetails = statusDetailsFromRecord({
@@ -124,6 +127,26 @@ export const anthropicProvider: QuotaProvider = {
         resetTimeIso: result.seven_day.resetTimeIso,
       },
     ];
+
+    if (result.fable_weekly) {
+      entries.push({
+        accounting: {
+          resultType: "quota",
+          acquisitionMethod,
+          ownership: "maintained",
+          authority: "provider_reported",
+        },
+        name: "Claude Fable Weekly",
+        group: "Claude",
+        label: "Fable:",
+        semantic: {
+          metric: { kind: "named", name: "Fable weekly" },
+          prominence: "primary",
+        },
+        percentRemaining: result.fable_weekly.percentRemaining,
+        resetTimeIso: result.fable_weekly.resetTimeIso,
+      });
+    }
 
     return withStatusDetails(attemptedResult(entries), statusDetails);
   },

--- a/tests/fixtures/anthropic/fable-weekly.sanitized.json
+++ b/tests/fixtures/anthropic/fable-weekly.sanitized.json
@@ -1,0 +1,42 @@
+{
+  "five_hour": {
+    "utilization": 42,
+    "resets_at": "2026-07-21T14:10:00.268668+00:00"
+  },
+  "seven_day": {
+    "utilization": 28,
+    "resets_at": "2026-07-27T07:00:00.268694+00:00"
+  },
+  "limits": [
+    {
+      "kind": "session",
+      "group": "session",
+      "percent": 42,
+      "resets_at": "2026-07-21T14:10:00.268668+00:00",
+      "scope": null,
+      "is_active": true
+    },
+    {
+      "kind": "weekly_all",
+      "group": "weekly",
+      "percent": 28,
+      "resets_at": "2026-07-27T07:00:00.268694+00:00",
+      "scope": null,
+      "is_active": false
+    },
+    {
+      "kind": "weekly_scoped",
+      "group": "weekly",
+      "percent": 2,
+      "resets_at": "2026-07-27T07:00:00.268958+00:00",
+      "scope": {
+        "model": {
+          "id": null,
+          "display_name": "Fable"
+        },
+        "surface": null
+      },
+      "is_active": false
+    }
+  ]
+}

--- a/tests/lib.anthropic.test.ts
+++ b/tests/lib.anthropic.test.ts
@@ -26,11 +26,13 @@ import {
   clearAnthropicDiagnosticsCacheForTests,
   getAnthropicDiagnostics,
   hasAnthropicCredentialsConfigured,
+  parseOAuthUsageResponse,
   parseUsageResponse,
   queryAnthropicQuota,
   resolveAnthropicAuthIdentity,
 } from "../src/lib/anthropic.js";
 import { fetchWithTimeout } from "../src/lib/http.js";
+import fableWeeklyUsage from "./fixtures/anthropic/fable-weekly.sanitized.json";
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
@@ -182,6 +184,78 @@ describe("parseUsageResponse", () => {
     expect(result?.five_hour.resetTimeIso).toBe("2026-03-25T18:00:00.000Z");
     expect(result?.seven_day.percentRemaining).toBe(85);
     expect(result?.seven_day.resetTimeIso).toBe("2026-04-01T00:00:00.000Z");
+  });
+
+  it("parses the exact Fable weekly_scoped window from a sanitized response", () => {
+    const result = parseOAuthUsageResponse(fableWeeklyUsage);
+
+    expect(parseUsageResponse(fableWeeklyUsage)).not.toHaveProperty("fable_weekly");
+    expect(result).toEqual({
+      success: true,
+      five_hour: {
+        percentRemaining: 58,
+        resetTimeIso: "2026-07-21T14:10:00.268Z",
+      },
+      seven_day: {
+        percentRemaining: 72,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+      fable_weekly: {
+        percentRemaining: 98,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+    });
+  });
+
+  it("keeps the existing windows when Fable scoped data is absent or malformed", () => {
+    const withoutFable = parseOAuthUsageResponse({
+      five_hour: { utilization: 20 },
+      seven_day: { utilization: 30 },
+      limits: [
+        {
+          kind: "weekly_scoped",
+          percent: 40,
+          scope: { model: { display_name: "Opus" } },
+        },
+        {
+          kind: "weekly_scoped",
+          percent: 40,
+          scope: { model: { display_name: "Claude Fable 5" } },
+        },
+        {
+          kind: "weekly_scoped",
+          percent: "not-a-number",
+          scope: { model: { display_name: "Fable" } },
+        },
+      ],
+    });
+
+    expect(withoutFable).toEqual({
+      success: true,
+      five_hour: { percentRemaining: 80, resetTimeIso: undefined },
+      seven_day: { percentRemaining: 70, resetTimeIso: undefined },
+    });
+  });
+
+  it("accepts a zero-percent Fable window without a reset timestamp", () => {
+    const result = parseOAuthUsageResponse({
+      five_hour: { utilization: 20 },
+      seven_day: { utilization: 30 },
+      limits: [
+        {
+          kind: "weekly_scoped",
+          percent: 0,
+          resets_at: null,
+          scope: { model: { display_name: "Fable" } },
+          is_active: false,
+        },
+      ],
+    });
+
+    expect(result?.fable_weekly).toEqual({
+      percentRemaining: 100,
+      resetTimeIso: undefined,
+    });
   });
 
   it("drops invalid reset timestamps and only caps percent remaining above 100", () => {
@@ -557,30 +631,21 @@ describe("Claude CLI diagnostics", () => {
         },
       }),
     );
-    fetchResponseMock.mockResolvedValue(
-      mockJsonResponse({
-        oauth_usage: {
-          fiveHour: {
-            usedPercent: 35,
-            resetAt: "2026-03-25T18:00:00.000Z",
-          },
-          sevenDay: {
-            percent_used: 15,
-            resetsAt: "2026-04-01T00:00:00.000Z",
-          },
-        },
-      }),
-    );
+    fetchResponseMock.mockResolvedValue(mockJsonResponse(fableWeeklyUsage));
 
     const diagnostics = await getAnthropicDiagnostics();
     expect(diagnostics.installed).toBe(true);
     expect(diagnostics.authStatus).toBe("authenticated");
     expect(diagnostics.quotaSupported).toBe(true);
     expect(diagnostics.quotaSource).toBe("claude-credentials-oauth-api");
-    expect(diagnostics.quota?.five_hour.percentRemaining).toBe(65);
-    expect(diagnostics.quota?.five_hour.resetTimeIso).toBe("2026-03-25T18:00:00.000Z");
-    expect(diagnostics.quota?.seven_day.percentRemaining).toBe(85);
-    expect(diagnostics.quota?.seven_day.resetTimeIso).toBe("2026-04-01T00:00:00.000Z");
+    expect(diagnostics.quota?.five_hour.percentRemaining).toBe(58);
+    expect(diagnostics.quota?.five_hour.resetTimeIso).toBe("2026-07-21T14:10:00.268Z");
+    expect(diagnostics.quota?.seven_day.percentRemaining).toBe(72);
+    expect(diagnostics.quota?.seven_day.resetTimeIso).toBe("2026-07-27T07:00:00.268Z");
+    expect(diagnostics.quota?.fable_weekly).toEqual({
+      percentRemaining: 98,
+      resetTimeIso: "2026-07-27T07:00:00.268Z",
+    });
     expect(fetchWithTimeoutMock).toHaveBeenCalledWith(ANTHROPIC_USAGE_URL, {
       request: {
         headers: {
@@ -595,8 +660,9 @@ describe("Claude CLI diagnostics", () => {
     const quota = await queryAnthropicQuota();
     expect(quota?.success).toBe(true);
     if (quota?.success) {
-      expect(quota.five_hour.percentRemaining).toBe(65);
-      expect(quota.seven_day.percentRemaining).toBe(85);
+      expect(quota.five_hour.percentRemaining).toBe(58);
+      expect(quota.seven_day.percentRemaining).toBe(72);
+      expect(quota.fable_weekly?.percentRemaining).toBe(98);
     }
 
     expect(execFileMock).toHaveBeenCalledTimes(2);

--- a/tests/providers.anthropic.test.ts
+++ b/tests/providers.anthropic.test.ts
@@ -75,6 +75,75 @@ describe("anthropic provider", () => {
     });
   });
 
+  it("adds the Fable weekly row and diagnostic when the OAuth response reports it", async () => {
+    const { getAnthropicDiagnostics, queryAnthropicQuota } = await import(
+      "../src/lib/anthropic.js"
+    );
+    const quota = {
+      success: true,
+      five_hour: { percentRemaining: 58, resetTimeIso: "2026-07-21T14:10:00.268Z" },
+      seven_day: { percentRemaining: 72, resetTimeIso: "2026-07-27T07:00:00.268Z" },
+      fable_weekly: {
+        percentRemaining: 98,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+    };
+    (getAnthropicDiagnostics as any).mockResolvedValueOnce({
+      installed: true,
+      version: "2.1.258",
+      authStatus: "authenticated",
+      quotaSupported: true,
+      quotaSource: "opencode-auth-oauth-api",
+      oauthCredentialSource: "opencode-auth",
+      checkedCommands: ["claude --version"],
+      quota,
+    });
+    (queryAnthropicQuota as any).mockResolvedValueOnce(quota);
+
+    const out = await anthropicProvider.fetch({} as any);
+
+    expectAttemptedWithNoErrors(out);
+    expect(out.statusDetails).toContainEqual({
+      key: "fable_weekly_remaining",
+      value: "98% reset_at=2026-07-27T07:00:00.268Z",
+    });
+    expect(visibleEntries(out.entries, "anthropic")).toEqual([
+      {
+        name: "Claude 5h",
+        group: "Claude",
+        label: "5h:",
+        percentRemaining: 58,
+        resetTimeIso: "2026-07-21T14:10:00.268Z",
+      },
+      {
+        name: "Claude Weekly",
+        group: "Claude",
+        label: "Weekly:",
+        percentRemaining: 72,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+      {
+        name: "Claude Fable Weekly",
+        group: "Claude",
+        label: "Fable:",
+        semantic: {
+          metric: { kind: "named", name: "Fable weekly" },
+          prominence: "primary",
+        },
+        percentRemaining: 98,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+    ]);
+    expect(out.entries.map((entry) => entry.accounting)).toEqual(
+      Array.from({ length: 3 }, () => ({
+        resultType: "quota",
+        acquisitionMethod: "remote_api",
+        ownership: "maintained",
+        authority: "provider_reported",
+      })),
+    );
+  });
+
   it("returns attempted:false when Anthropic quota is unavailable locally", async () => {
     const { queryAnthropicQuota } = await import("../src/lib/anthropic.js");
     (queryAnthropicQuota as any).mockResolvedValueOnce(null);

--- a/tests/v4-phase5-cross-surface.test.ts
+++ b/tests/v4-phase5-cross-surface.test.ts
@@ -51,6 +51,9 @@ const mocks = vi.hoisted(() => ({
   getMiniMaxAuthDiagnostics: vi.fn(),
   resolveMiniMaxChinaAuthCached: vi.fn(),
   getMiniMaxChinaAuthDiagnostics: vi.fn(),
+  getAnthropicDiagnostics: vi.fn(),
+  hasAnthropicCredentialsConfigured: vi.fn(),
+  queryAnthropicQuota: vi.fn(),
   fetchSessionTokensForDisplay: vi.fn(),
 }));
 
@@ -104,6 +107,11 @@ vi.mock("../src/lib/minimax-auth.js", () => ({
   getMiniMaxAuthDiagnostics: mocks.getMiniMaxAuthDiagnostics,
   resolveMiniMaxChinaAuthCached: mocks.resolveMiniMaxChinaAuthCached,
   getMiniMaxChinaAuthDiagnostics: mocks.getMiniMaxChinaAuthDiagnostics,
+}));
+vi.mock("../src/lib/anthropic.js", () => ({
+  getAnthropicDiagnostics: mocks.getAnthropicDiagnostics,
+  hasAnthropicCredentialsConfigured: mocks.hasAnthropicCredentialsConfigured,
+  queryAnthropicQuota: mocks.queryAnthropicQuota,
 }));
 vi.mock("../src/lib/opencode-runtime-paths.js", () =>
   createPluginRuntimePathsMockModule(TEST_RUNTIME_ROOT, { includeCandidates: true }),
@@ -163,7 +171,7 @@ function configFor(formatStyle: "allWindows" | "singleWindow") {
   });
 }
 
-function configForMiniMax(providerId = "minimax-coding-plan") {
+function configForSingleProvider(providerId = "minimax-coding-plan") {
   return makeQuotaToastTestConfig({
     enabled: true,
     enabledProviders: [providerId],
@@ -694,7 +702,7 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
   });
 
   it("keeps over-quota MiniMax results in cache, export, and all four displays", async () => {
-    currentConfig = configForMiniMax();
+    currentConfig = configForSingleProvider();
     mocks.loadConfig.mockImplementation(async () => currentConfig);
     const { minimaxCodingPlanProvider } = await import("../src/providers/minimax-coding-plan.js");
     minimaxCodingPlanProvider.cachePolicy = { kind: "account-neutral" };
@@ -801,8 +809,96 @@ describe("v4 Phase 5 cross-surface release evidence", () => {
     await hooks.dispose?.();
   });
 
+  it("shows the optional Anthropic Fable weekly row on all four displays", async () => {
+    currentConfig = configForSingleProvider("anthropic");
+    mocks.loadConfig.mockImplementation(async () => currentConfig);
+    mocks.hasAnthropicCredentialsConfigured.mockResolvedValue(true);
+    const quota = {
+      success: true,
+      five_hour: { percentRemaining: 58, resetTimeIso: "2026-07-21T14:10:00.268Z" },
+      seven_day: { percentRemaining: 72, resetTimeIso: "2026-07-27T07:00:00.268Z" },
+      fable_weekly: {
+        percentRemaining: 98,
+        resetTimeIso: "2026-07-27T07:00:00.268Z",
+      },
+    };
+    mocks.getAnthropicDiagnostics.mockResolvedValue({
+      installed: true,
+      version: "2.1.258",
+      authStatus: "authenticated",
+      quotaSupported: true,
+      quotaSource: "opencode-auth-oauth-api",
+      oauthCredentialSource: "opencode-auth",
+      checkedCommands: ["claude --version"],
+      quota,
+    });
+    mocks.queryAnthropicQuota.mockResolvedValue(quota);
+
+    const { anthropicProvider } = await import("../src/providers/anthropic.js");
+    anthropicProvider.cachePolicy = { kind: "account-neutral" };
+    mocks.getProviders.mockReturnValue([anthropicProvider]);
+
+    const client = createClient();
+    client.config.providers.mockResolvedValue({
+      data: { providers: [{ id: "anthropic" }] },
+    });
+
+    const { QuotaToastPlugin } = await import("../src/plugin.js");
+    const hooks = (await QuotaToastPlugin({ client } as never)) as PluginHooks;
+
+    await expectHandled(
+      hooks["command.execute.before"]?.({
+        command: "quota",
+        sessionID: "anthropic-fable-session",
+      }),
+    );
+    const serverOutput = getPromptText(client);
+    expect(serverOutput).toContain("Claude");
+    expect(serverOutput).toContain("Fable");
+    expect(serverOutput).toContain("98% left");
+
+    await hooks.event?.({
+      event: {
+        type: "session.idle",
+        properties: { sessionID: "anthropic-fable-session" },
+      },
+    });
+    const toastOutput = getToastMessage(client);
+    expect(toastOutput).toContain("Fable");
+    expect(toastOutput).toContain("98%");
+
+    const tuiApi = {
+      state: {
+        provider: [{ id: "anthropic" }],
+        path: { worktree: process.cwd(), directory: process.cwd() },
+        session: { messages: () => [] },
+      },
+      client,
+    } as never;
+    const { loadTuiSessionQuotaSurfaces } = await import("../src/lib/tui-runtime.js");
+    const surfaces = await loadTuiSessionQuotaSurfaces({
+      api: tuiApi,
+      sessionID: "anthropic-fable-session",
+    });
+
+    expect(surfaces.sidebar.status).toBe("ready");
+    const sidebarOutput = [
+      ...surfaces.sidebar.lines,
+      ...(surfaces.sidebar.linesExpanded ?? []),
+    ].join("\n");
+    expect(sidebarOutput).toContain("Fable");
+    expect(sidebarOutput).toContain("98%");
+
+    expect(surfaces.compact.status).toBe("ready");
+    const compactOutput = surfaces.compact.status === "ready" ? surfaces.compact.text : "";
+    expect(compactOutput).toContain("Fable");
+    expect(compactOutput).toContain("98%");
+
+    await hooks.dispose?.();
+  });
+
   it("renders CN general percentage quota and excludes video on all four surfaces", async () => {
-    currentConfig = configForMiniMax("minimax-china-coding-plan");
+    currentConfig = configForSingleProvider("minimax-china-coding-plan");
     mocks.loadConfig.mockImplementation(async () => currentConfig);
     mocks.resolveMiniMaxChinaAuthCached.mockResolvedValue({
       state: "configured",


### PR DESCRIPTION
Integrates the independently approved local implementation for issue #257.

The original commit and authorship are preserved. The integration keeps the existing Usage Credits behavior and adds the optional Anthropic Fable weekly quota across provider and display surfaces.

Local validation: targeted Anthropic, documentation, and four-surface tests, pnpm verify, and explicit build all passed.