### PR TITLE
fix(openrouter): show limit-window usage instead of lifetime usage in budget row

### DIFF
--- a/src/lib/quota-providers-remote.ts
+++ b/src/lib/quota-providers-remote.ts
@@ -695,6 +695,7 @@ function parseOpenRouterKeyV1(
       };
     }
     const percentRemaining = (remainingValue / limit) * 100;
+    const usedUsd = typeof remaining === "number" ? limit - remainingValue : usage;
     return {
       success: true,
       entries: [
@@ -704,7 +705,7 @@ function parseOpenRouterKeyV1(
           name: `${source.label} budget`,
           group: source.label,
           label: "Budget:",
-          right: `${formatUsd(usage)}/${formatUsd(limit)}`,
+          right: `${formatUsd(usedUsd)}/${formatUsd(limit)}`,
           percentRemaining,
         },
       ],

--- a/tests/lib.quota-providers-remote.test.ts
+++ b/tests/lib.quota-providers-remote.test.ts
@@ -272,6 +272,44 @@ describe("quota provider remote runtime", () => {
     });
   });
 
+  it("shows limit-window usage in the OpenRouter budget row when the key's lifetime usage exceeds it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          data: { usage: 140.7, limit: 100, limit_remaining: 87.459170905 },
+        }),
+      ),
+    );
+
+    await expect(
+      fetchRemoteQuotaProvider(source({ format: "openrouter-key-v1" }), "secret"),
+    ).resolves.toEqual({
+      success: true,
+      entries: [
+        expect.objectContaining({
+          kind: "percent",
+          right: "$12.54/$100.00",
+          percentRemaining: 87.459170905,
+        }),
+      ],
+    });
+  });
+
+  it("falls back to the OpenRouter usage field for the budget row when no limit window is reported", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ data: { usage: 13, limit: 100 } })),
+    );
+
+    await expect(
+      fetchRemoteQuotaProvider(source({ format: "openrouter-key-v1" }), "secret"),
+    ).resolves.toEqual({
+      success: true,
+      entries: [expect.objectContaining({ kind: "percent", right: "$13.00/$100.00" })],
+    });
+  });
+
   it("rejects percent rows for non-remaining accounting result types", async () => {
     vi.stubGlobal(
       "fetch",
@@ -321,7 +359,9 @@ describe("quota provider remote runtime", () => {
     );
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.entries[0]).toEqual(expect.objectContaining({ percentRemaining: -20 }));
+      expect(result.entries[0]).toEqual(
+        expect.objectContaining({ right: "$12.00/$10.00", percentRemaining: -20 }),
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

The built-in OpenRouter source displays the key's **lifetime total usage** as the used amount in the budget row, while the percentage is derived from `limit_remaining` (the current limit window). For keys with a monthly limit these two values diverge, producing inconsistent rows like:

```
Budget  13% used | $140.70/$100.00
```

where `$140.70` is the key's lifetime usage and the correct limit-window usage is `$12.54` (`limit - limit_remaining`).

`parseOpenRouterKeyV1` now computes the displayed used amount as `limit - limit_remaining` whenever OpenRouter reports `limit_remaining`, and falls back to `usage` when it does not (in that case both were already consistent). The `percentRemaining` calculation is unchanged, and the over-budget (negative `limit_remaining`) behavior is preserved.

Before: `Budget: $140.70/$100.00` with `percentRemaining: 87.46` (13% used)
After: `Budget: $12.54/$100.00` with `percentRemaining: 87.46` (13% used)

## Linked Issue

Fixes #262

## OpenCode Validation

- Current production released OpenCode version tested: OpenCode 1.18.29 with @slkiser/opencode-quota 4.9.0
- Why this version is relevant to the fix: the reported inconsistency was observed live against a monthly-limited OpenRouter key via `/quota` and the toast/sidebar with `percentDisplayMode: "used"`.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed (no docs document the numeric composition of the budget row, so none needed)
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply