### PR TITLE
fix(atomic-json): write through symlinked destinations

### DIFF
--- a/src/lib/atomic-json.ts
+++ b/src/lib/atomic-json.ts
@@ -1,11 +1,48 @@
-import { mkdir, rename, rm, writeFile } from "fs/promises";
-import { dirname } from "path";
+import { lstat, mkdir, readlink, rename, rm, writeFile } from "fs/promises";
+import { dirname, resolve } from "path";
 import { stringifyWithComments } from "./jsonc.js";
 
 export interface WriteJsonAtomicOptions {
   trailingNewline?: boolean;
   directoryMode?: number;
   fileMode?: number;
+}
+
+const MAX_SYMLINK_DEPTH = 8;
+
+/**
+ * Resolve the real file a destination points at.
+ *
+ * An atomic write ends in `rename()`, which replaces the path itself rather
+ * than following it. When the destination is a symlink - the usual shape for a
+ * config file linked into a dotfiles repository - renaming over it silently
+ * detaches the link and leaves a plain file behind, so later edits stop
+ * reaching the original target. Resolving first keeps the write atomic while
+ * preserving the link.
+ *
+ * A missing destination, a dangling link, or a cycle longer than
+ * `MAX_SYMLINK_DEPTH` resolves to the last path reached, which the caller then
+ * writes as a regular file.
+ */
+async function resolveWriteTarget(path: string): Promise<string> {
+  let current = path;
+
+  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth += 1) {
+    let stats: Awaited<ReturnType<typeof lstat>>;
+    try {
+      stats = await lstat(current);
+    } catch {
+      return current;
+    }
+
+    if (!stats.isSymbolicLink()) {
+      return current;
+    }
+
+    current = resolve(dirname(current), await readlink(current));
+  }
+
+  return current;
 }
 
 async function safeRm(target: string): Promise<void> {
@@ -31,8 +68,9 @@ export async function writeTextAtomic(
   content: string,
   opts: Omit<WriteJsonAtomicOptions, "trailingNewline"> = {},
 ): Promise<void> {
-  const dir = dirname(path);
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const target = await resolveWriteTarget(path);
+  const dir = dirname(target);
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
   await mkdir(
     dir,
@@ -53,7 +91,7 @@ export async function writeTextAtomic(
   }
 
   try {
-    await rename(tmp, path);
+    await rename(tmp, target);
   } catch (renameError) {
     const code =
       renameError && typeof renameError === "object" && "code" in renameError
@@ -67,9 +105,9 @@ export async function writeTextAtomic(
       throw renameError;
     }
 
-    await safeRm(path);
+    await safeRm(target);
     try {
-      await rename(tmp, path);
+      await rename(tmp, target);
     } catch (replaceError) {
       await safeRm(tmp);
       throw replaceError;

--- a/tests/lib.atomic-json.symlink.test.ts
+++ b/tests/lib.atomic-json.symlink.test.ts
@@ -1,0 +1,66 @@
+import { lstat, mkdtemp, readdir, readFile, rm, symlink, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeJsonAtomic } from "../src/lib/atomic-json.js";
+
+describe("atomic-json symlinked destinations", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "opencode-quota-atomic-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes through a symlinked destination instead of replacing the link", async () => {
+    const real = join(dir, "dotfiles", "opencode.json");
+    const link = join(dir, "opencode.json");
+    await writeJsonAtomic(real, { plugin: [] });
+    await symlink(real, link);
+
+    await writeJsonAtomic(link, { plugin: ["a"] }, { trailingNewline: true });
+
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(await readFile(real, "utf-8"))).toEqual({ plugin: ["a"] });
+    expect(await readdir(dir)).toEqual(["dotfiles", "opencode.json"]);
+  });
+
+  it("resolves a chain of symlinks down to the real file", async () => {
+    const real = join(dir, "real.json");
+    const middle = join(dir, "middle.json");
+    const link = join(dir, "link.json");
+    await writeFile(real, "{}\n", "utf-8");
+    await symlink(real, middle);
+    await symlink(middle, link);
+
+    await writeJsonAtomic(link, { ok: true });
+
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
+    expect((await lstat(middle)).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(await readFile(real, "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("creates the target of a dangling symlink and keeps the link", async () => {
+    const missing = join(dir, "missing.json");
+    const link = join(dir, "link.json");
+    await symlink(missing, link);
+
+    await writeJsonAtomic(link, { ok: true });
+
+    expect((await lstat(link)).isSymbolicLink()).toBe(true);
+    expect(JSON.parse(await readFile(missing, "utf-8"))).toEqual({ ok: true });
+  });
+
+  it("writes a regular file when the destination does not exist", async () => {
+    const path = join(dir, "nested", "state.json");
+
+    await writeJsonAtomic(path, { ok: true });
+
+    expect((await lstat(path)).isFile()).toBe(true);
+    expect(JSON.parse(await readFile(path, "utf-8"))).toEqual({ ok: true });
+  });
+});

--- a/tests/lib.atomic-json.test.ts
+++ b/tests/lib.atomic-json.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("fs/promises", () => ({
+  lstat: vi.fn(async () => ({ isSymbolicLink: () => false })),
   mkdir: vi.fn(),
+  readlink: vi.fn(),
   rename: vi.fn(),
   rm: vi.fn(),
   writeFile: vi.fn(),


### PR DESCRIPTION
## Summary

`writeTextAtomic()` finished with `rename(tmp, path)`. `rename(2)` replaces the path itself rather than following it, so a symlinked destination was destroyed and replaced by a regular file. Since `init-installer.ts` writes `opencode.json` through `writeJsonAtomic`, any config write silently detached an `opencode.json` that was symlinked into a dotfiles repository, and every later edit stopped reaching the original target. The retryable-rename fallback compounded it by calling `safeRm(path)` on the link first.

Temp-file-plus-rename is the right pattern; the defect was only the missing symlink resolution. This change resolves the destination through its symlink chain before choosing the temp path and renaming, so the temp file stays in the real target's directory and the write remains atomic on the same filesystem. A missing destination, a dangling link, or a cycle beyond `MAX_SYMLINK_DEPTH` resolves to the last path reached and is written as a regular file, matching the previous behavior for those cases.

Scope: `src/lib/atomic-json.ts` only, plus tests. No public signature changes, no behavior change for non-symlinked destinations.

### Tests

- `tests/lib.atomic-json.symlink.test.ts` (new) exercises the real filesystem rather than mocks, since the defect is precisely about inode identity: write-through, a symlink chain, a dangling link, and a plain missing destination as a control. Three of the four fail on `main`; the control passes, which is what makes it a regression test rather than a behavior change.
- `tests/lib.atomic-json.test.ts` gains `lstat`/`readlink` in its existing `fs/promises` mock. Its assertions are unchanged.

## Linked Issue

Fixes #265

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.29
- Why this version is relevant to the fix: this is the version whose plugin cache resolved `@slkiser/opencode-quota@latest` to 4.4.1, where I hit the bug on a real symlinked `~/.config/opencode/opencode.json`. I also reproduced it directly against that published 4.4.1 artifact, and confirmed the patched code writes through the link. The fix is in the plugin's own file writer and does not depend on OpenCode internals.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [ ] I updated docs when user-facing workflow, command, or config behavior changed - not applicable, no user-facing command, config, or workflow change
- [ ] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply - not a provider change

`pnpm verify` passes end to end (Biome, pinned TypeScript check, history/privacy, typecheck, build, 2284 tests, four-surface parity, package contents) on Node 24.18.1, macOS.