### PR TITLE
feat(quota): add fixed-window runway projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ More ways to use it:
 - Check quota anywhere: use `opencode-quota show` in a terminal or the same slash commands in the TUI, Web, and Desktop.
 - Automate quota checks with JSON output for scripts, status bars, and CI. Optional OpenTelemetry metrics support monitoring tools.
 - Customize the display with [`tuiPromptBar.enabled`](docs/readme/configuration.md#tui-settings), OpenCode Go's preferred collapsed-sidebar window, reset precision or spacing, bare percent labels, and [`accountingDetail`](docs/readme/configuration.md#show-accounting-detail).
+- Optionally estimate **Runs out ≈ 1h 50m** for supported fixed windows with [`quotaProjection: "runway"`](docs/readme/configuration.md#estimate-when-fixed-quota-runs-out). It is off by default and leaves JSON output unchanged.
 - Choose current-session or descendant-tree token totals. Get reset popups for selected windows with [`resetNotifications`](docs/readme/configuration.md#notify-when-quota-becomes-available-again).
 - Troubleshoot authentication, quota sources, pricing, and maintainer notices.
 

--- a/docs/readme/configuration.md
+++ b/docs/readme/configuration.md
@@ -24,6 +24,7 @@ Strict `.json` files also work. Run `/quota_status` if you are unsure which file
 | Show every reset period                    | `formatStyle: "allWindows"`   |
 | Show one quota window per provider         | `formatStyle: "singleWindow"` |
 | Show quota used instead of left            | `percentDisplayMode: "used"`  |
+| Estimate when eligible fixed quota runs out | `quotaProjection: "runway"`   |
 | Show percentages without `left` or `used`   | `percentLabelStyle: "bare"`   |
 | Add spaces between reset countdown units    | `resetTimeSpaced: true`         |
 | Show supplementary accounting facts        | `accountingDetail: "detailed"` |
@@ -50,6 +51,8 @@ The installer chooses `allWindows` by default. If the setting is absent, the bui
   // Show every quota reset period as percentage remaining.
   "formatStyle": "allWindows",
   "percentDisplayMode": "remaining",
+  // Optional linear estimate for supported fixed windows. Off when omitted.
+  "quotaProjection": "runway",
   "percentLabelStyle": "bare",
   "resetTimeSpaced": true,
   "accountingDetail": "summary",
@@ -82,6 +85,24 @@ Restart OpenCode after changing the file.
 It applies to human output from `/quota`, terminal `show`, popup toasts, the TUI sidebar, Compact status, and the prompt bar below the input. Narrow, tiny, 36-column sidebar, and compact layouts can omit basis or supplementary detail rather than truncate a financial value. The prompt bar always keeps one primary row and omits supplementary rows and basis details.
 
 This setting is independent of `formatStyle`, which selects quota windows, and `percentDisplayMode`, which selects used or remaining percentage direction. Those display settings do not change provider input or cache identity. Changing only `accountingDetail` reprojects an available snapshot immediately; later collection still follows normal cache expiry, disabled-cache, and refresh rules. The words `Used`, `Limit`, and `Remaining` always keep their literal meanings in either percentage mode.
+
+### Estimate when fixed quota runs out
+
+`quotaProjection: "runway"` is optional and off by default. It adds a **Runs out** estimate to eligible percentage rows on shared Web/Desktop and TUI `/quota`, terminal `show`, popup toasts, the expanded Sidebar, Compact status, and the prompt bar.
+
+```jsonc
+{
+  "quotaProjection": "runway",
+}
+```
+
+The estimate is a straight-line average since the confirmed fixed window began: used percentage divided by elapsed time, then remaining percentage divided by that average rate. It is not a recent-rate forecast, trend, alert, budget, or prediction model. Changing `percentDisplayMode` between `remaining` and `used` does not change the calculation.
+
+The provider's exact reset countdown stays separate from the estimate. If the calculated exhaustion is before reset, full displays use **Runs out ≈ 1h 50m**; Compact status and the prompt bar use **r/o ≈ 1h 50m**, where `r/o` means “runs out.” The approximation marker always has one following space, duration units are spaced, and partial minutes round up. If current use would last through the reset, displays say **lasts past reset**.
+
+Availability is deliberately narrow. A row needs a finite percentage, its original observation time, a nonzero elapsed interval, and explicit fixed-window start, end/reset, and full-reset evidence. OpenAI's known API rate-limit windows, xAI periods with explicit `currentPeriod.start` and `currentPeriod.end`, Cursor cycles with `cursorBillingCycleStartDay`, Qwen's maintained UTC-day window, and configured `local-estimate` `utc-day` windows can qualify. Rolling windows, RPM rows, balance/status/unlimited rows, Cursor's calendar-month fallback, and windows inferred only from labels do not. Unsupported rows are simply unchanged.
+
+This option changes human presentation only. It reuses cached provider snapshots without another provider request, preserves the provider observation time, and does not add fields to JSON export v2.
 
 ### Notify when quota becomes available again
 
@@ -373,6 +394,7 @@ Existing `experimental.quotaToast` settings remain supported. Quota settings do 
 | `requestTimeoutMs`            | `5000`         | Remote provider request timeout in milliseconds.                                                                                                                                                                                                                                                                    |
 | `formatStyle`                 | `singleWindow` | Shared quota reset-period display for TUI popup toasts, the Sidebar panel, and Compact status line unless a TUI surface override is set: `singleWindow` shows one reset period per provider; `allWindows` shows all reset periods per provider. Legacy `classic`/`grouped` aliases are still accepted.              |
 | `percentDisplayMode`          | `remaining`    | Percentage/bar direction across human surfaces: `remaining` shows the percentage left; `used` shows the percentage consumed. It does not rename literal basis facts.                                                                                                                                               |
+| `quotaProjection`             | unset          | Set to `"runway"` for a linear **Runs out** estimate on explicitly supported fixed, full-reset percentage windows. Off when unset; unsupported rows remain unchanged; JSON export v2 is unchanged.                                                                                                                |
 | `percentLabelStyle`           | unset          | Set to `bare` to remove `left` or `used` from full-report percentage labels. Full reports and the Sidebar name the direction in a `Quota [Remaining]` or `Quota [Used]` heading. `full` is also accepted. Unset keeps full labels.                                                                                  |
 | `accountingDetail`            | `summary`      | Provider-neutral accounting detail across human surfaces: `summary` keeps primary rows; `detailed` also admits supplementary rows and fuller basis detail when width allows. Independent of `formatStyle` and `percentDisplayMode`.                                                                                |
 | `resetTimeDecimals`           | unset          | Decimal places for a largest-unit reset countdown override in popup toasts, the Sidebar panel, terminal `show`, and the prompt bar. Accepts integers `0`–`4`; when unset, the default shows exact remaining days, hours, and minutes as `DdHhMm`. |

--- a/docs/readme/providers.md
+++ b/docs/readme/providers.md
@@ -107,6 +107,18 @@ Structured currency rows use explicit uppercase codes such as `USD 12.50` or `CN
 
 xAI reads OpenCode's existing xAI OAuth login and reports its single Weekly quota window. The credits endpoint remains authoritative for quota; a best-effort subscriptions lookup labels recognized plans as xAI Lite, xAI SuperGrok, or xAI Heavy. If subscription metadata is unavailable or unrecognized, the quota remains visible under the xAI SuperGrok label.
 
+### Runs out projection evidence
+
+The optional `quotaProjection: "runway"` estimate is intentionally limited to fixed windows with trustworthy start, observation, end/reset, and full-reset evidence. Labels such as Five-hour, Weekly, Monthly, or RPM never make a row eligible by themselves.
+
+- **OpenAI:** recognized 5-hour, weekly, or monthly rate-limit API windows with `limit_window_seconds` and an exact reset. Individual spend-control rows, code-review rows, and unknown durations are excluded.
+- **xAI:** credits responses with both explicit `currentPeriod.start` and `currentPeriod.end` around the observation. A billing-end fallback without a period start is excluded.
+- **Cursor:** included API budget when `cursorBillingCycleStartDay` defines the cycle. The unconfigured calendar-month fallback, partial/unknown model spend, and spend-only rows are excluded.
+- **Qwen Code:** the maintained UTC-day request window. Its RPM window is excluded.
+- **Configured local estimates:** `utc-day` request percentages and priced budget percentages. Every `rolling` window and unpriced value row is excluded.
+
+Other providers and window shapes remain unchanged. The estimate uses the average use since the fixed window began, not a recent-rate trend. Exact reset remains separate; **lasts past reset** means the linear exhaustion instant is at or beyond that reset.
+
 OpenRouter reads the existing OpenCode API key and calls OpenRouter's current-key endpoint. Limited keys show used budget and the remaining percentage; unlimited keys show spend. It does not invent a reset time.
 
 ## Custom providers
@@ -405,11 +417,15 @@ opencode auth login --provider cursor
 
 Cursor estimates the current local billing cycle from OpenCode history. With complete model coverage and a positive configured/preset allowance, it shows an **API budget** percentage with used, limit, and remaining USD facts. If any Cursor model is unknown, it shows only **Known API spend** plus a partial-data issue; it never presents that partial spend as total account spend or a percentage. Without an allowance it shows **API spend**. **Auto+Composer spend** is supplementary and appears in detailed output when space allows.
 
+Runs-out projection is available only when `cursorBillingCycleStartDay` explicitly anchors that fixed cycle. The ordinary local calendar-month fallback is not projection evidence.
+
 <a id="qwen-code"></a>
 
 ### Qwen Code
 
 Use companion plugin [`opencode-qwencode-auth`](https://github.com/gustavodiasdev/opencode-qwencode-auth#readme). Add it before `@slkiser/opencode-quota` in `opencode.json`.
+
+Qwen's maintained UTC-day request window can show the optional runs-out projection. Its RPM window is rolling and never qualifies.
 
 OpenCode Quota's Google integrations use independent community companion plugins. They are not endorsed by Google.
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,6 +46,7 @@ export const QUOTA_TOAST_SETTING_SOURCE_KEYS = [
   "tuiCommandDisplay",
   "formatStyle",
   "percentDisplayMode",
+  "quotaProjection",
   "percentLabelStyle",
   "accountingDetail",
   "resetTimeDecimals",
@@ -160,6 +161,7 @@ type ValidatedQuotaToastPatch = {
   tuiCommandDisplay?: TuiCommandDisplay;
   formatStyle?: QuotaToastConfig["formatStyle"];
   percentDisplayMode?: PercentDisplayMode;
+  quotaProjection?: "runway";
   percentLabelStyle?: PercentLabelStyle;
   accountingDetail?: QuotaToastConfig["accountingDetail"];
   resetTimeDecimals?: number;
@@ -686,6 +688,14 @@ function extractValidatedQuotaToastPatch(
     patch.percentDisplayMode = quotaToastConfig.percentDisplayMode;
   }
 
+  if (hasOwnKey(quotaToastConfig, "quotaProjection")) {
+    if (quotaToastConfig.quotaProjection === "runway") {
+      patch.quotaProjection = "runway";
+    } else {
+      reportIssue?.("quotaProjection", 'expected "runway"');
+    }
+  }
+
   if (
     hasOwnKey(quotaToastConfig, "percentLabelStyle") &&
     isValidPercentLabelStyle(quotaToastConfig.percentLabelStyle)
@@ -968,6 +978,11 @@ function applyValidatedQuotaToastPatch(
   if (hasOwnKey(patch, "percentDisplayMode")) {
     config.percentDisplayMode = patch.percentDisplayMode!;
     applySettingSource(settingSources, "percentDisplayMode", sourcePath);
+  }
+
+  if (hasOwnKey(patch, "quotaProjection")) {
+    config.quotaProjection = patch.quotaProjection;
+    applySettingSource(settingSources, "quotaProjection", sourcePath);
   }
 
   if (hasOwnKey(patch, "percentLabelStyle")) {

--- a/src/lib/cursor-usage.ts
+++ b/src/lib/cursor-usage.ts
@@ -27,6 +27,7 @@ export interface CursorUsageBucket {
 
 export interface CursorUsageSummary {
   window: CursorCycleWindow;
+  observedAtMs: number;
   api: CursorUsageBucket;
   autoComposer: CursorUsageBucket;
   total: CursorUsageBucket;
@@ -163,6 +164,7 @@ export async function getCurrentCursorUsageSummary(params?: {
 
   return {
     window,
+    observedAtMs: nowMs,
     api,
     autoComposer,
     total,

--- a/src/lib/entries.ts
+++ b/src/lib/entries.ts
@@ -113,6 +113,18 @@ export interface AccountingMetadata {
   observedAtIso?: string;
 }
 
+export interface FixedWindowProjectionEvidence {
+  kind: "fixed_window";
+  startedAtIso: string;
+  observedAtIso: string;
+  endsAtIso: string;
+  fullReset: true;
+}
+
+export type QuotaRunwayProjection =
+  | { kind: "before_reset"; projectedAtIso: string }
+  | { kind: "lasts_past_reset" };
+
 export interface GroupedQuotaEntryMeta {
   /** Required provider-neutral accounting semantics for this row. */
   accounting: AccountingMetadata;
@@ -143,6 +155,10 @@ export type QuotaPercentEntry = GroupedQuotaEntryMeta & {
   /** Optional typed operands. Renderers never derive a percentage from these facts. */
   basis?: AccountingPercentageBasis;
   resetTimeIso?: string;
+  /** Internal provider evidence for fixed-window exhaustion projection. */
+  fixedWindow?: FixedWindowProjectionEvidence;
+  /** Presentation-only projection. Provider caches must never persist this field. */
+  runway?: QuotaRunwayProjection;
 };
 
 export type QuotaValueEntry = GroupedQuotaEntryMeta & {
@@ -223,6 +239,10 @@ export function cloneQuotaToastEntry(entry: QuotaToastEntry): QuotaToastEntry {
     ...(isPercentEntry(entry) && entry.basis
       ? { basis: cloneAccountingPercentageBasis(entry.basis) }
       : {}),
+    ...(isPercentEntry(entry) && entry.fixedWindow
+      ? { fixedWindow: { ...entry.fixedWindow } }
+      : {}),
+    ...(isPercentEntry(entry) && entry.runway ? { runway: { ...entry.runway } } : {}),
     ...(isQuantityEntry(entry) ? { quantity: cloneAccountingQuantity(entry.quantity) } : {}),
   };
 }

--- a/src/lib/format-utils.ts
+++ b/src/lib/format-utils.ts
@@ -41,6 +41,35 @@ export function padLeft(str: string, width: number): string {
   return " ".repeat(width - str.length) + str;
 }
 
+export function wrapDisplayText(text: string, maxWidth: number): string[] {
+  if (maxWidth <= 0) return [];
+  const words = text.trim().split(/\s+/u).filter(Boolean);
+  const lines: string[] = [];
+  let line = "";
+
+  for (const word of words) {
+    if (word.length > maxWidth) {
+      if (line) {
+        lines.push(line);
+        line = "";
+      }
+      for (let offset = 0; offset < word.length; offset += maxWidth) {
+        lines.push(word.slice(offset, offset + maxWidth));
+      }
+      continue;
+    }
+    const next = line ? `${line} ${word}` : word;
+    if (next.length <= maxWidth) {
+      line = next;
+    } else {
+      lines.push(line);
+      line = word;
+    }
+  }
+  if (line) lines.push(line);
+  return lines;
+}
+
 /**
  * Render a progress bar of filled/empty blocks.
  */

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -14,8 +14,10 @@ import {
   padLeft,
   padRight,
   resolveDisplayedPercent,
+  wrapDisplayText,
 } from "./format-utils.js";
 import { buildSingleWindowPercentEntryDisplayName } from "./quota-entry-display.js";
+import { formatQuotaRunway } from "./quota-exhaustion-projection.js";
 import type { QuotaFormatStyle } from "./quota-format-style.js";
 import { getQuotaFormatStyleDefinition } from "./quota-format-style.js";
 import {
@@ -104,6 +106,7 @@ export function formatQuotaRows(params: {
   accountingDetail?: QuotaToastConfig["accountingDetail"];
   resetTimeDecimals?: number;
   resetTimeSpaced?: boolean;
+  wrapLabels?: boolean;
   sessionTokens?: SessionTokensData;
 }): string {
   const styleDefinition = getQuotaFormatStyleDefinition(params.style);
@@ -118,6 +121,7 @@ export function formatQuotaRows(params: {
       accountingDetail: params.accountingDetail,
       resetTimeDecimals: params.resetTimeDecimals,
       resetTimeSpaced: params.resetTimeSpaced,
+      wrapLabels: params.wrapLabels,
       sessionTokens: params.sessionTokens,
     });
   }
@@ -163,6 +167,7 @@ export function formatQuotaRows(params: {
     resetIso: string | undefined,
     remaining: number,
     rightSummary?: string,
+    runway?: string,
   ) => {
     const displayedPercent = resolveDisplayedPercent(remaining, params.percentDisplayMode);
     const percentLabel = formatDisplayedPercentLabel(
@@ -203,12 +208,16 @@ export function formatQuotaRows(params: {
         padLeft(visibleBarSuffix, percentValueCol),
       ].join(separator);
       lines.push(line.slice(0, maxWidth));
+      if (runway) lines.push(`Runs out  ${runway}`.slice(0, maxWidth));
       return;
     }
 
     // Line 1: label + time can use the full available width. Prefer keeping the
     // reset text aligned, but shrink padding before truncating labels that fit.
-    if (
+    if (params.wrapLabels && leftText.length > maxWidth) {
+      lines.push(...wrapDisplayText(leftText, maxWidth));
+      if (timeStr) lines.push(padLeft(timeStr, maxWidth));
+    } else if (
       timeStr &&
       leftText.length <= maxWidth &&
       leftText.length + separator.length + timeStr.length > maxWidth
@@ -232,6 +241,7 @@ export function formatQuotaRows(params: {
     const suffixCell = padLeft(visibleBarSuffix, percentValueCol);
     const barLine = [barCell, suffixCell].join(separator);
     lines.push(barLine);
+    if (runway) lines.push(`Runs out  ${runway}`.slice(0, maxWidth));
   };
 
   const addValueEntry = (
@@ -379,6 +389,7 @@ export function formatQuotaRows(params: {
         entry.resetTimeIso,
         interpretation.display.percentRemaining,
         entry.right,
+        isPercentEntry(entry) ? formatQuotaRunway(entry.runway) : "",
       );
       addBasisLine(interpretation.basis);
     }

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -6,6 +6,7 @@
  */
 
 import { sanitizeDisplayText } from "./display-sanitize.js";
+import type { FixedWindowProjectionEvidence } from "./entries.js";
 import { clampPercent } from "./format-utils.js";
 import { fetchWithTimeout } from "./http.js";
 import { readAuthFileCached } from "./opencode-auth.js";
@@ -71,6 +72,7 @@ type OpenAIWindowKind = "hourly" | "weekly" | "monthly";
 type OpenAIWindowValue = {
   percentRemaining: number;
   resetTimeIso?: string;
+  fixedWindow?: FixedWindowProjectionEvidence;
 };
 
 const WINDOW_KIND_BY_DURATION: Readonly<Record<number, OpenAIWindowKind>> = {
@@ -86,11 +88,11 @@ function isoFromMilliseconds(milliseconds: number): string | undefined {
   return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
 }
 
-function resetIsoFromNowSeconds(seconds: unknown): string | undefined {
+function resetIsoFromNowSeconds(seconds: unknown, observedAtMs: number): string | undefined {
   if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds <= 0) {
     return undefined;
   }
-  return isoFromMilliseconds(Date.now() + Math.round(seconds * 1000));
+  return isoFromMilliseconds(observedAtMs + Math.round(seconds * 1000));
 }
 
 function resetIsoFromResetAt(resetAt: unknown): string | undefined {
@@ -100,7 +102,7 @@ function resetIsoFromResetAt(resetAt: unknown): string | undefined {
   return isoFromMilliseconds(Math.round(resetAt * 1000));
 }
 
-function parseWindowValue(window: unknown): OpenAIWindowValue | null {
+function parseWindowValue(window: unknown, observedAtMs: number): OpenAIWindowValue | null {
   if (!window || typeof window !== "object") return null;
 
   const value = window as Record<string, unknown>;
@@ -111,11 +113,15 @@ function parseWindowValue(window: unknown): OpenAIWindowValue | null {
   return {
     percentRemaining: clampPercent(100 - value.used_percent),
     resetTimeIso:
-      resetIsoFromResetAt(value.reset_at) ?? resetIsoFromNowSeconds(value.reset_after_seconds),
+      resetIsoFromResetAt(value.reset_at) ??
+      resetIsoFromNowSeconds(value.reset_after_seconds, observedAtMs),
   };
 }
 
-function parseRemainingWindowValue(window: unknown): OpenAIWindowValue | null {
+function parseRemainingWindowValue(
+  window: unknown,
+  observedAtMs: number,
+): OpenAIWindowValue | null {
   if (!window || typeof window !== "object") return null;
 
   const value = window as Record<string, unknown>;
@@ -126,12 +132,14 @@ function parseRemainingWindowValue(window: unknown): OpenAIWindowValue | null {
   return {
     percentRemaining: clampPercent(value.remaining_percent),
     resetTimeIso:
-      resetIsoFromResetAt(value.reset_at) ?? resetIsoFromNowSeconds(value.reset_after_seconds),
+      resetIsoFromResetAt(value.reset_at) ??
+      resetIsoFromNowSeconds(value.reset_after_seconds, observedAtMs),
   };
 }
 
 function parseRateLimitWindow(
   window: unknown,
+  observedAtMs: number,
 ): { kind: OpenAIWindowKind; value: OpenAIWindowValue } | null {
   if (!window || typeof window !== "object") return null;
 
@@ -143,8 +151,21 @@ function parseRateLimitWindow(
   const kind = WINDOW_KIND_BY_DURATION[raw.limit_window_seconds];
   if (!kind) return null;
 
-  const value = parseWindowValue(window);
-  return value ? { kind, value } : null;
+  const value = parseWindowValue(window, observedAtMs);
+  if (!value) return null;
+
+  const endsAtMs = value.resetTimeIso ? Date.parse(value.resetTimeIso) : Number.NaN;
+  const startedAtMs = endsAtMs - raw.limit_window_seconds * 1000;
+  if (Number.isFinite(startedAtMs) && startedAtMs < observedAtMs && observedAtMs < endsAtMs) {
+    value.fixedWindow = {
+      kind: "fixed_window",
+      startedAtIso: new Date(startedAtMs).toISOString(),
+      observedAtIso: new Date(observedAtMs).toISOString(),
+      endsAtIso: new Date(endsAtMs).toISOString(),
+      fullReset: true,
+    };
+  }
+  return { kind, value };
 }
 
 function derivePlanLabel(planType: string | undefined): string {
@@ -305,10 +326,17 @@ export async function queryOpenAIQuota(
         }
 
         const data = (await resp.json()) as OpenAIUsageResponse;
-        const primary = parseRateLimitWindow(data.rate_limit?.primary_window);
-        const secondary = parseRateLimitWindow(data.rate_limit?.secondary_window);
-        const individualLimit = parseRemainingWindowValue(data.spend_control?.individual_limit);
-        const codeReview = parseWindowValue(data.code_review_rate_limit?.primary_window);
+        const observedAtMs = Date.now();
+        const primary = parseRateLimitWindow(data.rate_limit?.primary_window, observedAtMs);
+        const secondary = parseRateLimitWindow(data.rate_limit?.secondary_window, observedAtMs);
+        const individualLimit = parseRemainingWindowValue(
+          data.spend_control?.individual_limit,
+          observedAtMs,
+        );
+        const codeReview = parseWindowValue(
+          data.code_review_rate_limit?.primary_window,
+          observedAtMs,
+        );
         const credits = data.credits ?? null;
         const windows: {
           hourly?: OpenAIWindowValue;

--- a/src/lib/quota-accounting-projection.ts
+++ b/src/lib/quota-accounting-projection.ts
@@ -9,6 +9,7 @@ import type {
 import { cloneQuotaToastEntry, isPercentEntry } from "./entries.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
+import { projectQuotaRunway } from "./quota-exhaustion-projection.js";
 import type { QuotaFormatStyle } from "./quota-format-style.js";
 import { getQuotaFormatStyleDefinition } from "./quota-format-style.js";
 import type { QuotaToastConfig } from "./types.js";
@@ -369,9 +370,11 @@ export function projectQuotaProviderResults(
   accountingDetail: QuotaToastConfig["accountingDetail"],
   options?: {
     preferredWindowsByResultIndex?: ReadonlyMap<number, AccountingWindow>;
+    quotaProjection?: QuotaToastConfig["quotaProjection"];
+    nowMs?: number;
   },
 ): QuotaToastEntry[] {
-  return results.flatMap((result, index) =>
+  const entries = results.flatMap((result, index) =>
     projectProviderResultToStyle(
       result,
       style,
@@ -379,4 +382,17 @@ export function projectQuotaProviderResults(
       options?.preferredWindowsByResultIndex?.get(index),
     ),
   );
+  if (options?.quotaProjection !== "runway") return entries;
+
+  const nowMs = options.nowMs ?? Date.now();
+  return entries.map((entry) => {
+    if (!isPercentEntry(entry)) return entry;
+    const runway = projectQuotaRunway({
+      percentRemaining: entry.percentRemaining,
+      fixedWindow: entry.fixedWindow,
+      resetTimeIso: entry.resetTimeIso,
+      nowMs,
+    });
+    return runway ? { ...entry, runway } : entry;
+  });
 }

--- a/src/lib/quota-command-format.ts
+++ b/src/lib/quota-command-format.ts
@@ -9,7 +9,7 @@
 
 import { type AccountingRowInterpretation, interpretAccountingRow } from "./accounting-format.js";
 import type { QuotaToastEntry, QuotaToastError, SessionTokensData } from "./entries.js";
-import { isValueEntry } from "./entries.js";
+import { isPercentEntry, isValueEntry } from "./entries.js";
 import {
   bar,
   formatDisplayedPercentLabel,
@@ -24,6 +24,7 @@ import {
 import { groupQuotaEntries } from "./grouped-entry-normalization.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
+import { formatQuotaRunway } from "./quota-exhaustion-projection.js";
 import {
   type ReportDocument,
   type ReportSection,
@@ -97,10 +98,20 @@ function formatCommandDetails(
 ): string {
   const right = entry.right?.trim();
   const reset = formatCommandReset(entry.resetTimeIso, resetTimeSpaced);
-  if (right && reset) return ` | ${padRight(right, rightWidth)} | ${reset}`;
-  if (right) return ` | ${right}`;
-  if (reset) return ` | ${reset}`;
-  return "";
+  const runway = isPercentEntry(entry) ? formatQuotaRunway(entry.runway) : "";
+  if (!runway) {
+    if (right && reset) return ` | ${padRight(right, rightWidth)} | ${reset}`;
+    if (right) return ` | ${right}`;
+    if (reset) return ` | ${reset}`;
+    return "";
+  }
+
+  const details = [
+    ...(right ? [padRight(right, rightWidth)] : []),
+    ...(reset ? [reset] : []),
+    `Runs out ${runway}`,
+  ];
+  return ` | ${details.join(" | ")}`;
 }
 
 function getCommandBasisLines(basis: AccountingRowInterpretation["basis"]): string[] {

--- a/src/lib/quota-exhaustion-projection.ts
+++ b/src/lib/quota-exhaustion-projection.ts
@@ -1,0 +1,117 @@
+import type { FixedWindowProjectionEvidence, QuotaRunwayProjection } from "./entries.js";
+
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const MINUTE_MS = 60_000;
+
+function parseIsoTimestamp(value: unknown): number | null {
+  if (typeof value !== "string" || !ISO_TIMESTAMP_RE.test(value)) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function isFixedWindowProjectionEvidence(
+  value: unknown,
+  resetTimeIso?: string,
+): value is FixedWindowProjectionEvidence {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const evidence = value as Record<string, unknown>;
+  if (
+    Object.keys(evidence).some(
+      (key) => !["kind", "startedAtIso", "observedAtIso", "endsAtIso", "fullReset"].includes(key),
+    ) ||
+    evidence.kind !== "fixed_window" ||
+    evidence.fullReset !== true
+  ) {
+    return false;
+  }
+
+  const startedAt = parseIsoTimestamp(evidence.startedAtIso);
+  const observedAt = parseIsoTimestamp(evidence.observedAtIso);
+  const endsAt = parseIsoTimestamp(evidence.endsAtIso);
+  if (startedAt === null || observedAt === null || endsAt === null) return false;
+  if (!(startedAt < observedAt && observedAt < endsAt)) return false;
+
+  const resetAt = parseIsoTimestamp(resetTimeIso);
+  if (resetAt === null || resetAt !== endsAt) return false;
+  return true;
+}
+
+export function projectQuotaRunway(params: {
+  percentRemaining: number;
+  fixedWindow?: FixedWindowProjectionEvidence;
+  resetTimeIso?: string;
+  nowMs?: number;
+}): QuotaRunwayProjection | null {
+  const nowMs = params.nowMs ?? Date.now();
+  if (!Number.isFinite(params.percentRemaining) || !Number.isFinite(nowMs)) return null;
+  if (!isFixedWindowProjectionEvidence(params.fixedWindow, params.resetTimeIso)) return null;
+
+  const startedAt = Date.parse(params.fixedWindow.startedAtIso);
+  const observedAt = Date.parse(params.fixedWindow.observedAtIso);
+  const endsAt = Date.parse(params.fixedWindow.endsAtIso);
+  if (nowMs < observedAt || nowMs >= endsAt) return null;
+
+  const remaining = params.percentRemaining;
+  const used = 100 - remaining;
+  if (used < 0) return null;
+  if (used === 0) return { kind: "lasts_past_reset" };
+
+  const elapsed = observedAt - startedAt;
+  if (!(elapsed > 0)) return null;
+  const rate = used / elapsed;
+  if (!(rate > 0) || !Number.isFinite(rate)) return null;
+
+  const runwayMs = remaining / rate;
+  const projectedAt = observedAt + runwayMs;
+  if (!Number.isFinite(projectedAt)) return null;
+  if (projectedAt >= endsAt) return { kind: "lasts_past_reset" };
+
+  return {
+    kind: "before_reset",
+    projectedAtIso: new Date(projectedAt).toISOString(),
+  };
+}
+
+function formatRunwayDuration(milliseconds: number): string {
+  const totalMinutes = Math.max(0, Math.ceil(milliseconds / MINUTE_MS));
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+
+  const parts: string[] = [];
+  if (days > 0) parts.push(`${days}d`);
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0 || parts.length === 0) parts.push(`${minutes}m`);
+  return parts.join(" ");
+}
+
+export function formatQuotaRunway(
+  projection: QuotaRunwayProjection | undefined,
+  nowMs: number = Date.now(),
+): string {
+  if (!projection) return "";
+  if (projection.kind === "lasts_past_reset") return "lasts past reset";
+
+  const projectedAt = parseIsoTimestamp(projection.projectedAtIso);
+  if (projectedAt === null || !Number.isFinite(nowMs)) return "";
+  return `≈ ${formatRunwayDuration(projectedAt - nowMs)}`;
+}
+
+export function compareQuotaRunwayUrgency(
+  left: QuotaRunwayProjection | undefined,
+  right: QuotaRunwayProjection | undefined,
+  nowMs: number = Date.now(),
+): number {
+  const urgency = (projection: QuotaRunwayProjection | undefined): [number, number] => {
+    if (!projection) return [3, Number.POSITIVE_INFINITY];
+    if (projection.kind === "lasts_past_reset") return [2, Number.POSITIVE_INFINITY];
+    const projectedAt = parseIsoTimestamp(projection.projectedAtIso);
+    if (projectedAt === null) return [3, Number.POSITIVE_INFINITY];
+    if (projectedAt <= nowMs) return [0, projectedAt];
+    return [1, projectedAt];
+  };
+
+  const [leftRank, leftAt] = urgency(left);
+  const [rightRank, rightAt] = urgency(right);
+  return leftRank - rightRank || leftAt - rightAt;
+}

--- a/src/lib/quota-providers-local.ts
+++ b/src/lib/quota-providers-local.ts
@@ -323,6 +323,19 @@ export function computeLocalQuotaProviderEstimate(params: {
     );
     const resetTimeIso =
       window.type === "utc-day" ? nextUtcMidnight(nowMs) : rollingReset(messages, window);
+    const fixedWindow =
+      window.type === "utc-day" &&
+      resetTimeIso !== undefined &&
+      sinceMs < params.state.updatedAt &&
+      params.state.updatedAt < Date.parse(resetTimeIso)
+        ? ({
+            kind: "fixed_window",
+            startedAtIso: new Date(sinceMs).toISOString(),
+            observedAtIso: new Date(params.state.updatedAt).toISOString(),
+            endsAtIso: resetTimeIso,
+            fullReset: true,
+          } as const)
+        : undefined;
 
     entries.push({
       accounting: {
@@ -340,6 +353,7 @@ export function computeLocalQuotaProviderEstimate(params: {
       right: `${messages.length}/${window.requestLimit}`,
       percentRemaining: percentRemaining(messages.length, window.requestLimit),
       ...(resetTimeIso ? { resetTimeIso } : {}),
+      ...(fixedWindow ? { fixedWindow } : {}),
     });
 
     if (window.usdBudget === undefined) continue;
@@ -379,6 +393,7 @@ export function computeLocalQuotaProviderEstimate(params: {
         kind: "percent",
         right: `${formatUsd(costUsd)}/${formatUsd(window.usdBudget)}`,
         percentRemaining: percentRemaining(costUsd, window.usdBudget),
+        ...(fixedWindow ? { fixedWindow } : {}),
       });
     }
   }

--- a/src/lib/quota-render-data.ts
+++ b/src/lib/quota-render-data.ts
@@ -539,7 +539,16 @@ export async function collectQuotaRenderData(params: {
   });
 
   const style = params.formatStyle ?? params.config.formatStyle;
-  const entries = projectQuotaProviderResults(results, style, params.config.accountingDetail);
+  const projectionOptions = {
+    quotaProjection: params.config.quotaProjection,
+    nowMs: Date.now(),
+  } as const;
+  const entries = projectQuotaProviderResults(
+    results,
+    style,
+    params.config.accountingDetail,
+    projectionOptions,
+  );
   const errors = results.flatMap((result) => result.errors);
   const attemptedAny = results.some((result) => result.attempted);
 
@@ -591,7 +600,12 @@ export async function collectQuotaRenderData(params: {
     const allWindowsEntries =
       style === "allWindows"
         ? entries
-        : projectQuotaProviderResults(results, "allWindows", params.config.accountingDetail);
+        : projectQuotaProviderResults(
+            results,
+            "allWindows",
+            params.config.accountingDetail,
+            projectionOptions,
+          );
     allWindowsData = packageQuotaRenderData({
       entries: allWindowsEntries,
       errors: [...errors],
@@ -604,6 +618,7 @@ export async function collectQuotaRenderData(params: {
           results,
           "singleWindow",
           params.config.accountingDetail,
+          projectionOptions,
         ),
         errors: [...errors],
         sessionTokens,

--- a/src/lib/quota-state-codec.ts
+++ b/src/lib/quota-state-codec.ts
@@ -9,8 +9,9 @@ import type {
   QuotaToastEntry,
 } from "./entries.js";
 import { cloneQuotaToastEntry } from "./entries.js";
+import { isFixedWindowProjectionEvidence } from "./quota-exhaustion-projection.js";
 
-export const QUOTA_PROVIDER_CACHE_VERSION = 2 as const;
+export const QUOTA_PROVIDER_CACHE_VERSION = 3 as const;
 
 export type PersistedQuotaProviderCacheEntry = {
   version: typeof QUOTA_PROVIDER_CACHE_VERSION;
@@ -292,10 +293,12 @@ function isQuotaToastEntry(value: unknown, safeText: boolean): value is QuotaToa
   }
   return (
     (value.kind === undefined || value.kind === "percent") &&
-    hasOnlyKeys(value, [...COMMON_ENTRY_KEYS, "percentRemaining", "basis"]) &&
+    hasOnlyKeys(value, [...COMMON_ENTRY_KEYS, "percentRemaining", "basis", "fixedWindow"]) &&
     typeof value.percentRemaining === "number" &&
     Number.isFinite(value.percentRemaining) &&
-    (value.basis === undefined || isAccountingPercentageBasis(value.basis, safeText))
+    (value.basis === undefined || isAccountingPercentageBasis(value.basis, safeText)) &&
+    (value.fixedWindow === undefined ||
+      isFixedWindowProjectionEvidence(value.fixedWindow, value.resetTimeIso as string | undefined))
   );
 }
 

--- a/src/lib/quota-toast-runtime.ts
+++ b/src/lib/quota-toast-runtime.ts
@@ -250,6 +250,7 @@ export function createQuotaToastRuntime(
       config.onlyCurrentModel && params.sessionID ? (params.sessionMeta?.providerID ?? "") : "";
     const renderIdentity = JSON.stringify({
       accountingDetail: config.accountingDetail,
+      quotaProjection: config.quotaProjection,
       percentLabelStyle: config.percentLabelStyle,
       resetTimeDecimals: config.resetTimeDecimals,
       resetTimeSpaced: config.resetTimeSpaced,

--- a/src/lib/qwen-local-quota.ts
+++ b/src/lib/qwen-local-quota.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 
 import { writeJsonAtomic } from "./atomic-json.js";
+import type { FixedWindowProjectionEvidence } from "./entries.js";
 import { clampPercent } from "./format-utils.js";
 import { getOpencodeRuntimeDirs } from "./opencode-runtime-paths.js";
 import type { OpenCodeMessage } from "./opencode-storage.js";
@@ -56,6 +57,7 @@ export interface QwenComputedQuota {
     limit: number;
     percentRemaining: number;
     resetTimeIso: string;
+    fixedWindow?: FixedWindowProjectionEvidence;
   };
   rpm: {
     used: number;
@@ -81,6 +83,11 @@ export interface AlibabaCodingPlanComputedQuota {
 
 function utcDayKey(tsMs: number): string {
   return new Date(tsMs).toISOString().slice(0, 10);
+}
+
+function utcDayStart(tsMs: number): number {
+  const now = new Date(tsMs);
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
 }
 
 function nextUtcMidnightIso(tsMs: number): string {
@@ -330,13 +337,26 @@ export function computeQwenQuota(params: {
   const dayUsed = Math.max(0, Math.trunc(state.dayCount));
   const rpmUsed = state.recent.length;
   const oldestRecent = oldestTimestamp(state.recent);
+  const dayStartedAtMs = utcDayStart(nowMs);
+  const dayEndsAtIso = nextUtcMidnightIso(nowMs);
+  const fixedWindow =
+    dayStartedAtMs < state.updatedAt && state.updatedAt < Date.parse(dayEndsAtIso)
+      ? ({
+          kind: "fixed_window",
+          startedAtIso: new Date(dayStartedAtMs).toISOString(),
+          observedAtIso: new Date(state.updatedAt).toISOString(),
+          endsAtIso: dayEndsAtIso,
+          fullReset: true,
+        } as const)
+      : undefined;
 
   return {
     day: {
       used: dayUsed,
       limit: dayLimit,
       percentRemaining: toPercentRemaining(dayUsed, dayLimit),
-      resetTimeIso: nextUtcMidnightIso(nowMs),
+      resetTimeIso: dayEndsAtIso,
+      ...(fixedWindow ? { fixedWindow } : {}),
     },
     rpm: {
       used: rpmUsed,

--- a/src/lib/toast-format-grouped.ts
+++ b/src/lib/toast-format-grouped.ts
@@ -17,10 +17,12 @@ import {
   padLeft,
   padRight,
   resolveDisplayedPercent,
+  wrapDisplayText,
 } from "./format-utils.js";
 import { normalizeGroupedQuotaEntries } from "./grouped-entry-normalization.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { classifyQuotaWindowText, type QuotaWindowKind } from "./quota-entry-display.js";
+import { formatQuotaRunway } from "./quota-exhaustion-projection.js";
 import { renderSessionTokensLines } from "./session-tokens-format.js";
 import type { QuotaToastConfig } from "./types.js";
 
@@ -77,6 +79,7 @@ export function formatQuotaRowsGrouped(params: {
   accountingDetail?: QuotaToastConfig["accountingDetail"];
   resetTimeDecimals?: number;
   resetTimeSpaced?: boolean;
+  wrapLabels?: boolean;
   sessionTokens?: SessionTokensData;
 }): string {
   const layout = params.layout ?? { maxWidth: 50, narrowAt: 42, tinyAt: 32 };
@@ -121,7 +124,12 @@ export function formatQuotaRowsGrouped(params: {
     const list = groups.get(g) ?? [];
     if (gi > 0) lines.push("");
 
-    lines.push(formatGroupedHeader(g).slice(0, maxWidth));
+    const groupHeader = formatGroupedHeader(g);
+    lines.push(
+      ...(params.wrapLabels
+        ? wrapDisplayText(groupHeader, maxWidth)
+        : [groupHeader.slice(0, maxWidth)]),
+    );
 
     for (const entry of list) {
       const interpretation = interpretAccountingRow(entry, {
@@ -250,6 +258,10 @@ export function formatQuotaRowsGrouped(params: {
                 : { spaced: params.resetTimeSpaced },
             )
           : "";
+      const runway = isPercentEntry(entry) ? formatQuotaRunway(entry.runway) : "";
+      const addRunwayLine = () => {
+        if (runway) lines.push(`Runs out  ${runway}`.slice(0, maxWidth));
+      };
 
       if (isTiny) {
         // Tiny: single line with name/time/percent (or just the right summary)
@@ -266,6 +278,7 @@ export function formatQuotaRowsGrouped(params: {
             padLeft(visibleBarSuffix, percentValueCol),
           ].join(separator);
           lines.push(line.slice(0, maxWidth));
+          addRunwayLine();
           continue;
         }
         const tinyNameCol = Math.max(
@@ -278,6 +291,7 @@ export function formatQuotaRowsGrouped(params: {
           padLeft(visibleBarSuffix, percentValueCol),
         ].join(separator);
         lines.push(line.slice(0, maxWidth));
+        addRunwayLine();
         continue;
       }
 
@@ -308,6 +322,7 @@ export function formatQuotaRowsGrouped(params: {
       const barCell = bar(displayedPercent, barWidth);
       const suffixCell = padLeft(percentLabel.slice(0, percentValueCol), percentValueCol);
       lines.push([barCell, suffixCell].join(separator));
+      addRunwayLine();
 
       if (interpretation.basis) {
         const candidates =

--- a/src/lib/tui-compact-format.ts
+++ b/src/lib/tui-compact-format.ts
@@ -1,10 +1,11 @@
 import { interpretAccountingRow } from "./accounting-format.js";
 import { sanitizeQuotaRenderData, sanitizeSingleLineDisplayText } from "./display-sanitize.js";
-import type { QuotaToastEntry, QuotaToastError } from "./entries.js";
+import type { QuotaRunwayProjection, QuotaToastEntry, QuotaToastError } from "./entries.js";
 import { isPercentEntry, isValueEntry } from "./entries.js";
 import { formatDisplayedPercentLabel, formatResetCountdown } from "./format-utils.js";
 import { formatGroupedHeader } from "./grouped-header-format.js";
 import { extractSingleWindowWindowLabel } from "./quota-entry-display.js";
+import { compareQuotaRunwayUrgency, formatQuotaRunway } from "./quota-exhaustion-projection.js";
 import type { QuotaRenderData } from "./quota-render-data.js";
 import type { QuotaToastConfig } from "./types.js";
 
@@ -103,7 +104,12 @@ function formatCompactValueEntrySegment(
 
 type CompactPercentGroup = {
   provider: string;
-  windows: Array<{ label: string | null; value: string; isWindow: boolean }>;
+  windows: Array<{
+    label: string | null;
+    value: string;
+    isWindow: boolean;
+    runway?: QuotaRunwayProjection;
+  }>;
 };
 
 type CompactCandidate = {
@@ -111,12 +117,17 @@ type CompactCandidate = {
   prominence: 0 | 1;
   detail?: string;
   atomic?: { prefix: string; value: string };
+  fallbackSegment?: string;
+  fallbackAtomic?: { prefix: string; value: string };
+  runway?: QuotaRunwayProjection;
 };
 
 type PendingLegacySegment = { kind: "percent"; key: string } | { kind: "value"; segment: string };
 
-function formatCompactPercentGroupSegment(group: CompactPercentGroup): string | null {
-  const windows = group.windows;
+function formatCompactPercentGroupSegment(
+  group: CompactPercentGroup,
+  windows: CompactPercentGroup["windows"] = group.windows,
+): string | null {
   if (windows.length === 0) return null;
 
   const summary =
@@ -160,8 +171,13 @@ function buildSemanticCandidate(
   const provider = getProviderName(entry);
   const label = compactText(interpretation.label);
   const prefix = compactText([provider, label].filter(Boolean).join(": "));
+  const runway = isPercentEntry(entry) ? formatQuotaRunway(entry.runway) : "";
   const displayValue = compactText(
-    [value, formatResetCountdown(entry.resetTimeIso, { spaced: resetTimeSpaced })]
+    [
+      value,
+      formatResetCountdown(entry.resetTimeIso, { spaced: resetTimeSpaced }),
+      runway ? `r/o ${runway}` : "",
+    ]
       .filter(Boolean)
       .join(" "),
   );
@@ -176,6 +192,7 @@ function buildSemanticCandidate(
   return {
     segment,
     prominence: entry.semantic.prominence === "supplementary" ? 1 : 0,
+    ...(isPercentEntry(entry) && entry.runway ? { runway: entry.runway } : {}),
     ...(detail ? { detail } : {}),
     ...(interpretation.display.kind === "value" && interpretation.display.entryKind !== "value"
       ? { atomic: { prefix, value: displayValue } }
@@ -213,10 +230,12 @@ function formatCompactEntryCandidates(params: {
     if (!isPercentEntry(entry)) continue;
 
     const provider = getProviderName(entry);
+    const runway = formatQuotaRunway(entry.runway);
     const value = compactText(
       [
         formatCompactPercentLabel(entry.percentRemaining, params.percentDisplayMode),
         formatResetCountdown(entry.resetTimeIso, { spaced: params.resetTimeSpaced }),
+        runway ? `r/o ${runway}` : "",
       ]
         .filter(Boolean)
         .join(" "),
@@ -235,17 +254,44 @@ function formatCompactEntryCandidates(params: {
       label: label?.text ?? null,
       value,
       isWindow: label?.isWindow ?? false,
+      ...(entry.runway ? { runway: entry.runway } : {}),
     });
   }
 
   const legacy = pendingLegacy
-    .map((pending) =>
-      pending.kind === "value"
-        ? pending.segment
-        : formatCompactPercentGroupSegment(groups.get(pending.key)!),
-    )
-    .filter((segment): segment is string => Boolean(segment))
-    .map((segment): CompactCandidate => ({ segment, prominence: 0 }));
+    .map((pending): CompactCandidate | null => {
+      if (pending.kind === "value") return { segment: pending.segment, prominence: 0 };
+      const group = groups.get(pending.key)!;
+      const segment = formatCompactPercentGroupSegment(group);
+      if (!segment) return null;
+      const eligible = group.windows
+        .map((window, index) => ({ window, index }))
+        .filter(({ window }) => window.runway)
+        .sort(
+          (left, right) =>
+            compareQuotaRunwayUrgency(left.window.runway, right.window.runway) ||
+            left.index - right.index,
+        );
+      const urgent = eligible[0]?.window;
+      const fallbackValue = urgent
+        ? compactText([urgent.label, urgent.value].filter(Boolean).join(" ")) || undefined
+        : undefined;
+      const fallbackSegment = fallbackValue
+        ? compactText(`${group.provider} ${fallbackValue}`) || undefined
+        : undefined;
+      return {
+        segment,
+        prominence: 0,
+        ...(fallbackSegment && fallbackSegment !== segment && fallbackValue
+          ? {
+              fallbackSegment,
+              fallbackAtomic: { prefix: group.provider, value: fallbackValue },
+            }
+          : {}),
+        ...(urgent?.runway ? { runway: urgent.runway } : {}),
+      };
+    })
+    .filter((candidate): candidate is CompactCandidate => Boolean(candidate));
 
   return [...legacy, ...semantic]
     .map((candidate, index) => ({ candidate, index }))
@@ -275,8 +321,26 @@ function admitCompactCandidates(
   maxWidth: number,
 ): CompactCandidate[] {
   const admitted: CompactCandidate[] = [];
+  const fullLine = candidates.map((candidate) => candidate.segment).join(COMPACT_SEGMENT_SEPARATOR);
+  const ordered =
+    fullLine.length <= maxWidth
+      ? candidates
+      : candidates
+          .map((candidate, index) => ({ candidate, index }))
+          .sort((left, right) => {
+            if (left.candidate.runway && right.candidate.runway) {
+              return (
+                compareQuotaRunwayUrgency(left.candidate.runway, right.candidate.runway) ||
+                left.index - right.index
+              );
+            }
+            if (left.candidate.runway) return -1;
+            if (right.candidate.runway) return 1;
+            return left.index - right.index;
+          })
+          .map(({ candidate }) => candidate);
 
-  for (const candidate of candidates) {
+  for (const candidate of ordered) {
     const separatorWidth = admitted.length > 0 ? COMPACT_SEGMENT_SEPARATOR.length : 0;
     const usedWidth = admitted.reduce(
       (total, item, index) =>
@@ -288,6 +352,26 @@ function admitCompactCandidates(
 
     if (candidate.segment.length <= available) {
       admitted.push({ ...candidate });
+      continue;
+    }
+
+    if (candidate.fallbackSegment) {
+      if (candidate.fallbackSegment.length <= available) {
+        admitted.push({ ...candidate, segment: candidate.fallbackSegment });
+        continue;
+      }
+      if (admitted.length > 0) continue;
+
+      if (candidate.fallbackAtomic) {
+        const fitted = fitAtomicCandidate(candidate.fallbackAtomic, available);
+        if (fitted) {
+          admitted.push({ ...candidate, segment: fitted });
+          continue;
+        }
+      }
+
+      const truncated = truncateSingleLine(candidate.fallbackSegment, available);
+      if (truncated) admitted.push({ ...candidate, segment: truncated });
       continue;
     }
 

--- a/src/lib/tui-panel-state.ts
+++ b/src/lib/tui-panel-state.ts
@@ -1,4 +1,5 @@
 import { sanitizeSingleLineDisplayText } from "./display-sanitize.js";
+import type { QuotaRunwayProjection } from "./entries.js";
 import type { PercentDisplayMode } from "./types.js";
 
 const SIDEBAR_LOADING_LINE = "Loading…";
@@ -32,6 +33,7 @@ export type PromptBarEntry = {
   name?: string;
   percentRemaining?: number;
   resetTimeIso?: string;
+  runway?: QuotaRunwayProjection;
 };
 
 export type PromptBarState =

--- a/src/lib/tui-runtime.ts
+++ b/src/lib/tui-runtime.ts
@@ -25,6 +25,7 @@ import {
 import { getQuotaProviderShape, normalizeQuotaProviderId } from "./provider-metadata.js";
 import { projectQuotaProviderResults } from "./quota-accounting-projection.js";
 import { classifyQuotaWindowText } from "./quota-entry-display.js";
+import { compareQuotaRunwayUrgency } from "./quota-exhaustion-projection.js";
 import {
   buildQuotaExport,
   createExportProviderContext,
@@ -365,6 +366,7 @@ function buildSidebarPanelFromData(params: {
               preferredWindowsByResultIndex: new Map([
                 [openCodeGoResultIndex, OPENCODE_GO_ACCOUNTING_WINDOWS[preferredWindowKey]],
               ]),
+              quotaProjection: params.runtime.config.quotaProjection,
             },
           ),
         }
@@ -468,6 +470,7 @@ function buildSemanticPromptBarEntry(
     semanticSegment,
     ...(isPercentEntry(entry) ? { percentRemaining: entry.percentRemaining } : {}),
     ...(entry.resetTimeIso ? { resetTimeIso: entry.resetTimeIso } : {}),
+    ...(isPercentEntry(entry) && entry.runway ? { runway: entry.runway } : {}),
   };
 }
 
@@ -478,6 +481,25 @@ function pickPromptBarEntry(
   if (!data || !Array.isArray(data.entries)) {
     return undefined;
   }
+
+  const projected = data.entries
+    .map((entry, index) => ({
+      entry,
+      index,
+      promptEntry: buildSemanticPromptBarEntry(entry, percentDisplayMode) ?? entry,
+    }))
+    .filter(
+      ({ entry }) =>
+        isPercentEntry(entry) && Number.isFinite(entry.percentRemaining) && Boolean(entry.runway),
+    )
+    .sort(
+      (left, right) =>
+        compareQuotaRunwayUrgency(
+          isPercentEntry(left.entry) ? left.entry.runway : undefined,
+          isPercentEntry(right.entry) ? right.entry.runway : undefined,
+        ) || left.index - right.index,
+    );
+  if (projected[0]) return projected[0].promptEntry;
 
   for (const entry of data.entries) {
     const semantic = buildSemanticPromptBarEntry(entry, percentDisplayMode);

--- a/src/lib/tui-sidebar-format.ts
+++ b/src/lib/tui-sidebar-format.ts
@@ -13,7 +13,12 @@ export const TUI_SIDEBAR_LAYOUT = {
 export function buildSidebarQuotaPanelLines(params: {
   data: QuotaRenderData;
   config: Pick<QuotaToastConfig, "formatStyle" | "percentDisplayMode" | "resetTimeDecimals"> &
-    Partial<Pick<QuotaToastConfig, "accountingDetail" | "percentLabelStyle" | "resetTimeSpaced">>;
+    Partial<
+      Pick<
+        QuotaToastConfig,
+        "accountingDetail" | "percentLabelStyle" | "quotaProjection" | "resetTimeSpaced"
+      >
+    >;
 }): string[] {
   const data = sanitizeQuotaRenderData(params.data);
 
@@ -28,6 +33,7 @@ export function buildSidebarQuotaPanelLines(params: {
     accountingDetail: params.config.accountingDetail,
     resetTimeDecimals: params.config.resetTimeDecimals,
     resetTimeSpaced: params.config.resetTimeSpaced,
+    wrapLabels: params.config.quotaProjection === "runway",
     sessionTokens: data.sessionTokens,
   });
   return quotaBody ? quotaBody.split("\n") : [];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -113,6 +113,8 @@ export interface QuotaToastConfig {
   formatStyle: QuotaFormatStyle;
   /** Shared percent meaning for popup toasts and the TUI sidebar. */
   percentDisplayMode: PercentDisplayMode;
+  /** Optional fixed-window quota exhaustion projection. Unset keeps it disabled. */
+  quotaProjection?: "runway";
   /** Optional suffix style for percentage labels. Unset preserves full labels. */
   percentLabelStyle?: PercentLabelStyle;
   /** Whether human surfaces include supplementary semantic accounting rows. */

--- a/src/lib/xai.ts
+++ b/src/lib/xai.ts
@@ -12,6 +12,7 @@
  */
 
 import { sanitizeSingleLineDisplaySnippet } from "./display-sanitize.js";
+import type { FixedWindowProjectionEvidence } from "./entries.js";
 import { clampPercent } from "./format-utils.js";
 import { fetchWithTimeout } from "./http.js";
 import { readAuthFile, readAuthFileCached } from "./opencode-auth.js";
@@ -33,6 +34,7 @@ export type XaiLabel = "xAI Lite" | "xAI SuperGrok" | "xAI Heavy";
 export interface XaiWindowValue {
   percentRemaining: number;
   resetTimeIso?: string;
+  fixedWindow?: FixedWindowProjectionEvidence;
   kind: XaiPeriodKind;
 }
 
@@ -127,7 +129,7 @@ export async function resolveXaiAuthIdentity(): Promise<ResolvedAuthIdentity | n
   });
 }
 
-function parseCreditsWindow(payload: unknown): XaiWindowValue | null {
+function parseCreditsWindow(payload: unknown, observedAtMs: number): XaiWindowValue | null {
   if (!isRecord(payload) || !isRecord(payload.config)) {
     throw new Error("xAI credits response returned an unexpected response shape");
   }
@@ -153,9 +155,26 @@ function parseCreditsWindow(payload: unknown): XaiWindowValue | null {
   // current period means 0% used rather than missing quota.
   const usedPercent = hasUsage ? (config.creditUsagePercent as number) : 0;
 
+  const startedAtIso = isoOrUndefined(period?.start);
+  const periodEndsAtIso = isoOrUndefined(period?.end);
+  const resetTimeIso = periodEndsAtIso ?? isoOrUndefined(config.billingPeriodEnd);
+  const startedAtMs = startedAtIso ? Date.parse(startedAtIso) : Number.NaN;
+  const endsAtMs = periodEndsAtIso ? Date.parse(periodEndsAtIso) : Number.NaN;
+  const fixedWindow =
+    Number.isFinite(startedAtMs) && startedAtMs < observedAtMs && observedAtMs < endsAtMs
+      ? ({
+          kind: "fixed_window",
+          startedAtIso: new Date(startedAtMs).toISOString(),
+          observedAtIso: new Date(observedAtMs).toISOString(),
+          endsAtIso: new Date(endsAtMs).toISOString(),
+          fullReset: true,
+        } as const)
+      : undefined;
+
   return {
     percentRemaining: clampPercent(100 - usedPercent),
-    resetTimeIso: isoOrUndefined(period?.end) ?? isoOrUndefined(config.billingPeriodEnd),
+    resetTimeIso,
+    ...(fixedWindow ? { fixedWindow } : {}),
     kind: periodKindFromType(period?.type),
   };
 }
@@ -269,7 +288,8 @@ export async function queryXaiQuota(
           };
         }
 
-        const window = parseCreditsWindow(await response.json());
+        const payload = await response.json();
+        const window = parseCreditsWindow(payload, Date.now());
         if (!window) return { success: false, error: "No weekly quota data" };
 
         return { success: true, window };

--- a/src/providers/cursor.ts
+++ b/src/providers/cursor.ts
@@ -122,6 +122,18 @@ export const cursorProvider: QuotaProvider = {
       : [];
     const entries: QuotaToastEntry[] = [];
     const resetTimeIso = usage.window.resetTimeIso;
+    const fixedWindow =
+      usage.window.source === "configured_day" &&
+      usage.window.sinceMs < usage.observedAtMs &&
+      usage.observedAtMs < usage.window.untilMs
+        ? ({
+            kind: "fixed_window",
+            startedAtIso: new Date(usage.window.sinceMs).toISOString(),
+            observedAtIso: new Date(usage.observedAtMs).toISOString(),
+            endsAtIso: new Date(usage.window.untilMs).toISOString(),
+            fullReset: true,
+          } as const)
+        : undefined;
 
     if (hasPositiveAllowance && !hasPartialApiCoverage) {
       const remainingUsd = Math.max(0, includedApiUsd - usage.api.costUsd);
@@ -131,6 +143,7 @@ export const cursorProvider: QuotaProvider = {
         group,
         percentRemaining: 100 - (usage.api.costUsd / includedApiUsd) * 100,
         resetTimeIso,
+        ...(fixedWindow ? { fixedWindow } : {}),
         semantic: {
           metric: { kind: "named", name: "API" },
           prominence: "primary",

--- a/src/providers/qwen-code.ts
+++ b/src/providers/qwen-code.ts
@@ -93,6 +93,7 @@ export const qwenCodeProvider: QuotaProvider = {
           right: `${quota.day.used}/${quota.day.limit}`,
           percentRemaining: quota.day.percentRemaining,
           resetTimeIso: quota.day.resetTimeIso,
+          ...(quota.day.fixedWindow ? { fixedWindow: { ...quota.day.fixedWindow } } : {}),
         },
         {
           accounting: {

--- a/src/providers/result-helpers.ts
+++ b/src/providers/result-helpers.ts
@@ -3,6 +3,7 @@ import { readFile } from "fs/promises";
 import { sanitizeDisplayText } from "../lib/display-sanitize.js";
 import type {
   AccountingMetadata,
+  FixedWindowProjectionEvidence,
   QuotaProviderPresentation,
   QuotaProviderResult,
   QuotaProviderStatusDetail,
@@ -174,6 +175,7 @@ export function groupedPercentWindowEntries(params: {
     window?: {
       percentRemaining: number;
       resetTimeIso?: string;
+      fixedWindow?: FixedWindowProjectionEvidence;
     };
     suffix: string;
     label: string;
@@ -192,6 +194,7 @@ export function groupedPercentWindowEntries(params: {
       label,
       percentRemaining: window.percentRemaining,
       resetTimeIso: window.resetTimeIso,
+      ...(window.fixedWindow ? { fixedWindow: { ...window.fixedWindow } } : {}),
     });
   }
 

--- a/src/providers/xai.ts
+++ b/src/providers/xai.ts
@@ -60,6 +60,9 @@ export const xaiProvider: QuotaProvider = {
               label: `${period}:`,
               percentRemaining: result.window.percentRemaining,
               resetTimeIso: result.window.resetTimeIso,
+              ...(result.window.fixedWindow
+                ? { fixedWindow: { ...result.window.fixedWindow } }
+                : {}),
             },
           ],
           [],

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -22,6 +22,7 @@ import {
   type QuotaDialogCommandSpec,
 } from "./lib/quota-dialog-commands.js";
 import { extractSingleWindowWindowLabel } from "./lib/quota-entry-display.js";
+import { formatQuotaRunway } from "./lib/quota-exhaustion-projection.js";
 import type { SessionTokenError } from "./lib/quota-status.js";
 import { disposeQuotaTelemetryOwner } from "./lib/quota-telemetry.js";
 import { getSidebarBodyLineColor } from "./lib/tui-line-style.js";
@@ -535,6 +536,7 @@ function buildPromptBarParts(params: {
           : { spaced: bar.resetTimeSpaced },
       )
     : "";
+  const runway = formatQuotaRunway(entry.runway);
 
   const hasPercent = Number.isFinite(entry.percentRemaining);
   if (entry.semanticSegment && !hasPercent) {
@@ -571,7 +573,9 @@ function buildPromptBarParts(params: {
   return {
     label: windowLabel,
     barText,
-    meta: entry.semanticSegment ? reset : [percent, reset].filter(Boolean).join(" | "),
+    meta: entry.semanticSegment
+      ? [reset, runway ? `r/o ${runway}` : ""].filter(Boolean).join(" | ")
+      : [percent, reset, runway ? `r/o ${runway}` : ""].filter(Boolean).join(" | "),
   };
 }
 

--- a/tests/lib.cli-show.test.ts
+++ b/tests/lib.cli-show.test.ts
@@ -213,6 +213,69 @@ describe("runCliShowCommand", () => {
     expect(stderr.output).toBe("");
   });
 
+  it("renders default-off runway in human-readable CLI output only when configured", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-09T10:00:00.000Z"));
+    const provider = {
+      id: "synthetic",
+      cachePolicy: { kind: "account-neutral" as const },
+      isAvailable: vi.fn().mockResolvedValue(true),
+      fetch: vi.fn().mockResolvedValue({
+        attempted: true,
+        entries: [
+          {
+            accounting: {
+              ...TEST_ACCOUNTING,
+              observedAtIso: "2026-09-09T10:00:00.000Z",
+            },
+            name: "Synthetic Fixed Window",
+            percentRemaining: 55,
+            resetTimeIso: "2026-09-09T14:00:00.000Z",
+            fixedWindow: {
+              kind: "fixed_window",
+              startedAtIso: "2026-09-09T09:20:00.000Z",
+              observedAtIso: "2026-09-09T10:00:00.000Z",
+              endsAtIso: "2026-09-09T14:00:00.000Z",
+              fullReset: true,
+            },
+          },
+        ],
+        errors: [],
+      }),
+    };
+    mockProviders.push(provider);
+
+    const run = async (quotaProjection?: "runway") => {
+      writeFileSync(
+        join(workspaceDir, "opencode.json"),
+        JSON.stringify({
+          experimental: {
+            quotaToast: {
+              enabledProviders: ["synthetic"],
+              ...(quotaProjection ? { quotaProjection } : {}),
+            },
+          },
+        }),
+        "utf8",
+      );
+      __resetQuotaStateForTests();
+      const stdout = createCaptureStream();
+      const stderr = createCaptureStream();
+      const code = await runCliShowCommand({
+        argv: [],
+        cwd: workspaceDir,
+        stdout: stdout.stream as any,
+        stderr: stderr.stream as any,
+      });
+      expect(code).toBe(0);
+      expect(stderr.output).toBe("");
+      return stdout.output;
+    };
+
+    expect(await run()).not.toContain("Runs out");
+    expect(await run("runway")).toContain("Runs out  ≈ 49m");
+  });
+
   it("renders two Antigravity account labels in human-readable CLI output", async () => {
     const provider = {
       id: "google-antigravity",

--- a/tests/lib.config.test.ts
+++ b/tests/lib.config.test.ts
@@ -860,6 +860,26 @@ describe("loadConfig", () => {
     expect(invalid.config.percentDisplayMode).toBe("remaining");
   });
 
+  it("defaults quotaProjection to off and accepts only runway", async () => {
+    const defaults = await loadSdkConfig({});
+    expect(defaults.config.quotaProjection).toBeUndefined();
+
+    const configured = await loadSdkConfig({ quotaProjection: "runway" });
+    expect(configured.config.quotaProjection).toBe("runway");
+    expect(configured.meta.settingSources).toEqual({
+      quotaProjection: "client.config.get",
+    });
+
+    for (const invalid of ["trend", true, 1, null]) {
+      const rejected = await loadSdkConfig({ quotaProjection: invalid });
+      expect(rejected.config.quotaProjection).toBeUndefined();
+      expect(rejected.meta.settingSources).not.toHaveProperty("quotaProjection");
+      expect(rejected.meta.configIssues).toEqual([
+        expect.objectContaining({ key: "quotaProjection", message: 'expected "runway"' }),
+      ]);
+    }
+  });
+
   it("defaults percentLabelStyle to unset and accepts full or bare overrides", async () => {
     const defaults = await loadSdkConfig({});
     expect(defaults.config.percentLabelStyle).toBeUndefined();

--- a/tests/lib.display-sanitize.test.ts
+++ b/tests/lib.display-sanitize.test.ts
@@ -18,6 +18,15 @@ describe("sanitizeQuotaProviderResult", () => {
           group: "Example\u001b[0m",
           metricLabel: "Monthly\u001b[31m",
           percentRemaining: 75,
+          resetTimeIso: "2026-09-01T00:00:00.000Z",
+          fixedWindow: {
+            kind: "fixed_window",
+            startedAtIso: "2026-08-01T00:00:00.000Z",
+            observedAtIso: "2026-08-21T12:34:56.000Z",
+            endsAtIso: "2026-09-01T00:00:00.000Z",
+            fullReset: true,
+          },
+          runway: { kind: "before_reset", projectedAtIso: "2026-08-25T00:00:00.000Z" },
           semantic: {
             metric: { kind: "named", name: "Known\u001b[31m API" },
             prominence: "primary",
@@ -77,6 +86,11 @@ describe("sanitizeQuotaProviderResult", () => {
       metricLabel: "Monthly",
       semantic: { metric: { kind: "named", name: "Known API" } },
       basis: { used: { quantity: { unit: { kind: "custom", symbol: "NANO" } } } },
+      fixedWindow: {
+        observedAtIso: "2026-08-21T12:34:56.000Z",
+        endsAtIso: "2026-09-01T00:00:00.000Z",
+      },
+      runway: { kind: "before_reset", projectedAtIso: "2026-08-25T00:00:00.000Z" },
     });
     expect(sanitized.entries[1]).toMatchObject({
       quantity: { decimal: "42.500", unit: { kind: "currency", code: "USD" } },
@@ -103,6 +117,8 @@ describe("sanitizeQuotaProviderResult", () => {
     expect(sanitizedPercent.basis.used.quantity.unit).not.toBe(
       inputPercent.basis.used.quantity.unit,
     );
+    expect(sanitizedPercent.fixedWindow).not.toBe(inputPercent.fixedWindow);
+    expect(sanitizedPercent.runway).not.toBe(inputPercent.runway);
     expect(sanitized.presentation).not.toBe(input.presentation);
     expect(sanitized.statusDetails).not.toBe(input.statusDetails);
     expect(sanitized.rawDetails).not.toBe(input.rawDetails);

--- a/tests/lib.openai.test.ts
+++ b/tests/lib.openai.test.ts
@@ -347,6 +347,13 @@ describe("openai auth resolution", () => {
       hourly: {
         percentRemaining: 80,
         resetTimeIso: "2026-01-01T01:00:00.000Z",
+        fixedWindow: {
+          kind: "fixed_window",
+          startedAtIso: "2025-12-31T20:00:00.000Z",
+          observedAtIso: "2026-01-01T00:00:00.000Z",
+          endsAtIso: "2026-01-01T01:00:00.000Z",
+          fullReset: true,
+        },
       },
       codeReview: {
         percentRemaining: 95,
@@ -659,6 +666,13 @@ describe("openai auth resolution", () => {
       hourly: {
         percentRemaining: 80,
         resetTimeIso: "2026-01-01T01:00:00.000Z",
+        fixedWindow: {
+          kind: "fixed_window",
+          startedAtIso: "2025-12-31T20:00:00.000Z",
+          observedAtIso: "2026-01-01T00:00:00.000Z",
+          endsAtIso: "2026-01-01T01:00:00.000Z",
+          fullReset: true,
+        },
       },
       weekly: {
         percentRemaining: 30,

--- a/tests/lib.quota-accounting-projection.test.ts
+++ b/tests/lib.quota-accounting-projection.test.ts
@@ -497,6 +497,54 @@ describe("projectQuotaProviderResults", () => {
     expect(second[0]?.accounting).not.toBe(first[0]?.accounting);
   });
 
+  it("adds runway only after window selection and leaves default-off output unchanged", () => {
+    const fixed = {
+      accounting: TEST_ACCOUNTING,
+      name: "Fixed Daily",
+      label: "Daily:",
+      percentRemaining: 55,
+      resetTimeIso: "2026-09-09T05:00:00.000Z",
+      fixedWindow: {
+        kind: "fixed_window",
+        startedAtIso: "2026-09-09T00:00:00.000Z",
+        observedAtIso: "2026-09-09T01:30:00.000Z",
+        endsAtIso: "2026-09-09T05:00:00.000Z",
+        fullReset: true,
+      },
+    } as const satisfies QuotaToastEntry;
+    const rolling = {
+      accounting: TEST_ACCOUNTING,
+      name: "Rolling Weekly",
+      label: "Weekly:",
+      percentRemaining: 80,
+      resetTimeIso: "2026-09-10T00:00:00.000Z",
+    } as const satisfies QuotaToastEntry;
+    const source = result([fixed, rolling]);
+
+    const disabled = projectQuotaProviderResults([source], "allWindows", "summary", {
+      nowMs: Date.parse("2026-09-09T01:30:00.000Z"),
+    });
+    expect(disabled).toEqual([fixed, rolling]);
+    expect(disabled.every((entry) => !("runway" in entry))).toBe(true);
+
+    const allWindows = projectQuotaProviderResults([source], "allWindows", "summary", {
+      quotaProjection: "runway",
+      nowMs: Date.parse("2026-09-09T01:30:00.000Z"),
+    });
+    expect(allWindows[0]).toMatchObject({
+      runway: { kind: "before_reset", projectedAtIso: "2026-09-09T03:20:00.000Z" },
+    });
+    expect(allWindows[1]).not.toHaveProperty("runway");
+
+    const single = projectQuotaProviderResults([source], "singleWindow", "summary", {
+      quotaProjection: "runway",
+      nowMs: Date.parse("2026-09-09T01:30:00.000Z"),
+    });
+    expect(single).toHaveLength(1);
+    expect(single[0]).toHaveProperty("runway.kind", "before_reset");
+    expect(source.entries.every((entry) => !("runway" in entry))).toBe(true);
+  });
+
   it("returns no entries for empty results and empty provider entry arrays", () => {
     expect(projectQuotaProviderResults([], "singleWindow", "summary")).toEqual([]);
     expect(projectQuotaProviderResults([result([])], "allWindows", "detailed")).toEqual([]);

--- a/tests/lib.quota-exhaustion-projection.test.ts
+++ b/tests/lib.quota-exhaustion-projection.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import type { FixedWindowProjectionEvidence } from "../src/lib/entries.js";
+import {
+  compareQuotaRunwayUrgency,
+  formatQuotaRunway,
+  isFixedWindowProjectionEvidence,
+  projectQuotaRunway,
+} from "../src/lib/quota-exhaustion-projection.js";
+
+const START = Date.parse("2026-09-09T00:00:00.000Z");
+const OBSERVED = Date.parse("2026-09-09T01:30:00.000Z");
+const RESET = Date.parse("2026-09-09T05:00:00.000Z");
+
+function evidence(
+  overrides: Partial<FixedWindowProjectionEvidence> = {},
+): FixedWindowProjectionEvidence {
+  return {
+    kind: "fixed_window",
+    startedAtIso: new Date(START).toISOString(),
+    observedAtIso: new Date(OBSERVED).toISOString(),
+    endsAtIso: new Date(RESET).toISOString(),
+    fullReset: true,
+    ...overrides,
+  };
+}
+
+describe("fixed-window quota runway projection", () => {
+  it("uses average usage since the fixed window began and formats exact typography", () => {
+    const projection = projectQuotaRunway({
+      percentRemaining: 55,
+      fixedWindow: evidence(),
+      resetTimeIso: new Date(RESET).toISOString(),
+      nowMs: OBSERVED,
+    });
+
+    expect(projection).toEqual({
+      kind: "before_reset",
+      projectedAtIso: "2026-09-09T03:20:00.000Z",
+    });
+    expect(formatQuotaRunway(projection ?? undefined, OBSERVED)).toBe("≈ 1h 50m");
+  });
+
+  it("rounds a partial minute up and emits only useful spaced duration units", () => {
+    expect(
+      formatQuotaRunway(
+        { kind: "before_reset", projectedAtIso: new Date(OBSERVED + 60_001).toISOString() },
+        OBSERVED,
+      ),
+    ).toBe("≈ 2m");
+    expect(
+      formatQuotaRunway(
+        { kind: "before_reset", projectedAtIso: new Date(OBSERVED + 60 * 60_000).toISOString() },
+        OBSERVED,
+      ),
+    ).toBe("≈ 1h");
+    expect(
+      formatQuotaRunway(
+        {
+          kind: "before_reset",
+          projectedAtIso: new Date(OBSERVED + (24 * 60 + 2) * 60_000).toISOString(),
+        },
+        OBSERVED,
+      ),
+    ).toBe("≈ 1d 2m");
+  });
+
+  it("reports zero usage and projections at or after reset as lasting past reset", () => {
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 100,
+        fixedWindow: evidence(),
+        resetTimeIso: new Date(RESET).toISOString(),
+        nowMs: OBSERVED,
+      }),
+    ).toEqual({ kind: "lasts_past_reset" });
+
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 80,
+        fixedWindow: evidence(),
+        resetTimeIso: new Date(RESET).toISOString(),
+        nowMs: OBSERVED,
+      }),
+    ).toEqual({ kind: "lasts_past_reset" });
+    expect(formatQuotaRunway({ kind: "lasts_past_reset" }, OBSERVED)).toBe("lasts past reset");
+  });
+
+  it("treats exhausted and over-quota rows as already exhausted", () => {
+    for (const percentRemaining of [0, -10]) {
+      const projection = projectQuotaRunway({
+        percentRemaining,
+        fixedWindow: evidence(),
+        resetTimeIso: new Date(RESET).toISOString(),
+        nowMs: OBSERVED,
+      });
+      expect(projection?.kind).toBe("before_reset");
+      expect(formatQuotaRunway(projection ?? undefined, OBSERVED)).toBe("≈ 0m");
+    }
+  });
+
+  it("omits non-finite, over-100, missing, malformed, zero-elapsed, and stale inputs", () => {
+    const resetTimeIso = new Date(RESET).toISOString();
+    expect(
+      projectQuotaRunway({
+        percentRemaining: Number.NaN,
+        fixedWindow: evidence(),
+        resetTimeIso,
+        nowMs: OBSERVED,
+      }),
+    ).toBeNull();
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 101,
+        fixedWindow: evidence(),
+        resetTimeIso,
+        nowMs: OBSERVED,
+      }),
+    ).toBeNull();
+    expect(projectQuotaRunway({ percentRemaining: 50, resetTimeIso, nowMs: OBSERVED })).toBeNull();
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 50,
+        fixedWindow: evidence({ startedAtIso: "bad" }),
+        resetTimeIso,
+        nowMs: OBSERVED,
+      }),
+    ).toBeNull();
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 50,
+        fixedWindow: evidence({ startedAtIso: new Date(OBSERVED).toISOString() }),
+        resetTimeIso,
+        nowMs: OBSERVED,
+      }),
+    ).toBeNull();
+    expect(
+      projectQuotaRunway({
+        percentRemaining: 50,
+        fixedWindow: evidence(),
+        resetTimeIso,
+        nowMs: RESET,
+      }),
+    ).toBeNull();
+  });
+
+  it("requires exact keys, a full reset, chronological timestamps, and reset agreement", () => {
+    const resetTimeIso = new Date(RESET).toISOString();
+    expect(isFixedWindowProjectionEvidence(evidence(), resetTimeIso)).toBe(true);
+    expect(isFixedWindowProjectionEvidence({ ...evidence(), extra: true }, resetTimeIso)).toBe(
+      false,
+    );
+    expect(isFixedWindowProjectionEvidence({ ...evidence(), fullReset: false }, resetTimeIso)).toBe(
+      false,
+    );
+    expect(
+      isFixedWindowProjectionEvidence(
+        evidence({ observedAtIso: new Date(START).toISOString() }),
+        resetTimeIso,
+      ),
+    ).toBe(false);
+    expect(isFixedWindowProjectionEvidence(evidence(), "2026-09-09T06:00:00.000Z")).toBe(false);
+  });
+
+  it("orders exhausted, before-reset, shortest runway, past-reset, then unsupported", () => {
+    const exhausted = {
+      kind: "before_reset",
+      projectedAtIso: new Date(OBSERVED - 1).toISOString(),
+    } as const;
+    const soon = {
+      kind: "before_reset",
+      projectedAtIso: new Date(OBSERVED + 60_000).toISOString(),
+    } as const;
+    const later = {
+      kind: "before_reset",
+      projectedAtIso: new Date(OBSERVED + 120_000).toISOString(),
+    } as const;
+    const pastReset = { kind: "lasts_past_reset" } as const;
+    const values = [undefined, later, pastReset, soon, exhausted];
+    values.sort((left, right) => compareQuotaRunwayUrgency(left, right, OBSERVED));
+    expect(values).toEqual([exhausted, soon, later, pastReset, undefined]);
+  });
+});

--- a/tests/lib.quota-export.test.ts
+++ b/tests/lib.quota-export.test.ts
@@ -150,6 +150,17 @@ describe("buildQuotaExport", () => {
             percentRemaining: 75,
             resetTimeIso: "2026-07-01T00:00:00.000Z",
             label: "Monthly:",
+            fixedWindow: {
+              kind: "fixed_window",
+              startedAtIso: "2026-06-01T00:00:00.000Z",
+              observedAtIso: "2026-06-01T11:00:00.000Z",
+              endsAtIso: "2026-07-01T00:00:00.000Z",
+              fullReset: true,
+            },
+            runway: {
+              kind: "before_reset",
+              projectedAtIso: "2026-06-15T00:00:00.000Z",
+            },
           },
           {
             accounting: QUOTA_ACCOUNTING,

--- a/tests/lib.quota-providers-local.test.ts
+++ b/tests/lib.quota-providers-local.test.ts
@@ -179,6 +179,18 @@ describe("local quota provider state", () => {
         expect.objectContaining({ label: "Rolling:", right: "1/5" }),
       ]),
     );
+    const dailyEntry = result.entries.find((entry) => entry.label === "Daily:");
+    const rollingEntry = result.entries.find((entry) => entry.label === "Rolling:");
+    expect(dailyEntry).toMatchObject({
+      fixedWindow: {
+        kind: "fixed_window",
+        startedAtIso: "2026-07-16T00:00:00.000Z",
+        observedAtIso: "2026-07-16T12:00:00.000Z",
+        endsAtIso: "2026-07-17T00:00:00.000Z",
+        fullReset: true,
+      },
+    });
+    expect(rollingEntry).not.toHaveProperty("fixedWindow");
   });
 
   it("derives concurrent-session completions from the authoritative storage snapshot", async () => {

--- a/tests/lib.quota-state-codec.test.ts
+++ b/tests/lib.quota-state-codec.test.ts
@@ -174,6 +174,61 @@ describe("quota-state codec", () => {
     expect(normalized?.diagnostics?.[0]?.checkedPaths).toEqual(["env:SYNTHETIC_API_KEY"]);
   });
 
+  it("clones and round-trips fixed-window evidence but rejects presentation projections", () => {
+    const input = createValidResult();
+    const percentEntry = input.entries[0] as any;
+    percentEntry.fixedWindow = {
+      kind: "fixed_window",
+      startedAtIso: "2026-08-01T00:00:00.000Z",
+      observedAtIso: "2026-08-21T12:34:56.000Z",
+      endsAtIso: "2026-09-01T00:00:00.000Z",
+      fullReset: true,
+    };
+
+    const normalized = normalizeQuotaProviderResult(input);
+    expect((normalized?.entries[0] as any).fixedWindow).toEqual(percentEntry.fixedWindow);
+    expect((normalized?.entries[0] as any).fixedWindow).not.toBe(percentEntry.fixedWindow);
+
+    const decoded = decodePersistedQuotaProviderCacheEntry(
+      cloneJson(createEnvelope(input)),
+      EXPECTED_IDENTITY,
+    );
+    expect((decoded?.result.entries[0] as any).fixedWindow).toEqual(percentEntry.fixedWindow);
+
+    percentEntry.runway = {
+      kind: "before_reset",
+      projectedAtIso: "2026-08-25T00:00:00.000Z",
+    };
+    expectInvalidResult(input);
+  });
+
+  it.each([
+    ["missing reset", (entry: any) => delete entry.resetTimeIso],
+    [
+      "end/reset mismatch",
+      (entry: any) => (entry.fixedWindow.endsAtIso = "2026-09-02T00:00:00.000Z"),
+    ],
+    [
+      "zero elapsed",
+      (entry: any) => (entry.fixedWindow.startedAtIso = entry.fixedWindow.observedAtIso),
+    ],
+    ["wrong discriminant", (entry: any) => (entry.fixedWindow.kind = "rolling")],
+    ["no full reset", (entry: any) => (entry.fixedWindow.fullReset = false)],
+    ["extra evidence key", (entry: any) => (entry.fixedWindow.extra = true)],
+  ])("rejects malformed fixed-window evidence: %s", (_label, mutate) => {
+    const input = createValidResult();
+    const entry = input.entries[0] as any;
+    entry.fixedWindow = {
+      kind: "fixed_window",
+      startedAtIso: "2026-08-01T00:00:00.000Z",
+      observedAtIso: "2026-08-21T12:34:56.000Z",
+      endsAtIso: "2026-09-01T00:00:00.000Z",
+      fullReset: true,
+    };
+    mutate(entry);
+    expectInvalidResult(input);
+  });
+
   it("normalizes and round-trips over-quota remaining basis values", () => {
     const input = createValidResult();
     const percentEntry = input.entries[0] as any;
@@ -457,7 +512,8 @@ describe("quota-state codec", () => {
 
   it.each([
     ["V1", { version: 1 }],
-    ["future versions", { version: 3 }],
+    ["V2", { version: 2 }],
+    ["future versions", { version: 4 }],
     ["package identity", { packageVersion: "4.2.1" }],
     ["cache key identity", { key: "other" }],
     ["provider identity", { providerId: "other" }],

--- a/tests/lib.quota-toast-runtime.test.ts
+++ b/tests/lib.quota-toast-runtime.test.ts
@@ -851,10 +851,20 @@ describe("quota toast runtime state machine", () => {
         attempted: true,
         entries: [
           {
-            accounting: TEST_ACCOUNTING,
+            accounting: {
+              ...TEST_ACCOUNTING,
+              observedAtIso: "2026-01-15T10:00:00.000Z",
+            },
             name: "OpenAI Weekly",
             percentRemaining: 81,
             resetTimeIso: "2026-01-17T15:14:00.000Z",
+            fixedWindow: {
+              kind: "fixed_window",
+              startedAtIso: "2026-01-15T09:00:00.000Z",
+              observedAtIso: "2026-01-15T10:00:00.000Z",
+              endsAtIso: "2026-01-17T15:14:00.000Z",
+              fullReset: true,
+            },
           },
         ],
         errors: [],
@@ -897,7 +907,17 @@ describe("quota toast runtime state machine", () => {
       body: expect.objectContaining({ title: "Quota [Used]" }),
     });
 
-    expect(provider.fetch).toHaveBeenCalledTimes(3);
+    mocks.loadConfig.mockResolvedValueOnce(makeToastConfig({ quotaProjection: "runway" }));
+    const runwayClient = createClient();
+    const { runtime: runwayRuntime } = await createRuntime(runwayClient);
+    await runwayRuntime.handleTrigger({
+      sessionID: "session-display-cache",
+      trigger: "session.idle",
+    });
+    expect(getToastMessage(runwayClient)).toContain("Runs out");
+    expect(getToastMessage(defaultClient)).not.toContain("Runs out");
+
+    expect(provider.fetch).toHaveBeenCalledTimes(4);
   });
 
   it("emits reset text only from a fresh collection", async () => {

--- a/tests/lib.qwen-local-quota.test.ts
+++ b/tests/lib.qwen-local-quota.test.ts
@@ -62,7 +62,16 @@ describe("maintained local quota storage derivation", () => {
       recent: [NOW - 1_000],
       updatedAt: NOW,
     });
-    expect(computeQwenQuota({ state, nowMs: NOW }).day.used).toBe(1);
+    const quota = computeQwenQuota({ state, nowMs: NOW });
+    expect(quota.day.used).toBe(1);
+    expect(quota.day.fixedWindow).toEqual({
+      kind: "fixed_window",
+      startedAtIso: "2026-02-24T00:00:00.000Z",
+      observedAtIso: new Date(NOW).toISOString(),
+      endsAtIso: "2026-02-25T00:00:00.000Z",
+      fullReset: true,
+    });
+    expect(quota.rpm).not.toHaveProperty("fixedWindow");
     expect(writes).toEqual([state]);
   });
 

--- a/tests/lib.xai.test.ts
+++ b/tests/lib.xai.test.ts
@@ -413,6 +413,45 @@ describe("queryXaiQuota", () => {
     });
   });
 
+  it("preserves explicit current-period start, observation, and end evidence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
+    await mockConfiguredAuth();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse({
+            config: {
+              currentPeriod: {
+                type: "USAGE_PERIOD_TYPE_WEEKLY",
+                start: "2026-07-13T00:00:00Z",
+                end: "2026-07-20T00:00:00Z",
+              },
+              creditUsagePercent: 25,
+            },
+          }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ subscriptions: [] })) as any,
+    );
+
+    await expect(queryXaiQuota()).resolves.toMatchObject({
+      success: true,
+      window: {
+        percentRemaining: 75,
+        resetTimeIso: "2026-07-20T00:00:00.000Z",
+        fixedWindow: {
+          kind: "fixed_window",
+          startedAtIso: "2026-07-13T00:00:00.000Z",
+          observedAtIso: "2026-07-15T12:00:00.000Z",
+          endsAtIso: "2026-07-20T00:00:00.000Z",
+          fullReset: true,
+        },
+      },
+    });
+  });
+
   it("uses the exact billingPeriodEnd reset fallback from the PR", async () => {
     await mockConfiguredAuth();
     vi.stubGlobal(

--- a/tests/providers.cursor.test.ts
+++ b/tests/providers.cursor.test.ts
@@ -37,7 +37,7 @@ function usageSummary(params: {
   autoCost?: number;
   autoMessages?: number;
   unknownModels?: Array<Record<string, unknown>>;
-}) {
+}): any {
   const autoCost = params.autoCost ?? 0;
   const autoMessages = params.autoMessages ?? 0;
   return {
@@ -120,6 +120,45 @@ describe("cursor provider", () => {
     expect(out.entries.every((entry) => !("barValue" in entry))).toBe(true);
     expect(out.entries.every((entry) => entry.kind !== "value")).toBe(true);
     expect(out.presentation).toBeUndefined();
+  });
+
+  it("attaches fixed-window evidence only to explicitly configured billing cycles", async () => {
+    const { getCurrentCursorUsageSummary } = await import("../src/lib/cursor-usage.js");
+    const observedAtMs = Date.parse("2026-02-15T12:00:00.000Z");
+    const configured = usageSummary({ apiCost: 5, apiMessages: 2 });
+    configured.window = {
+      source: "configured_day",
+      sinceMs: Date.parse("2026-02-01T00:00:00.000Z"),
+      untilMs: Date.parse(resetTimeIso),
+      resetTimeIso,
+    };
+    configured.observedAtMs = observedAtMs;
+    (getCurrentCursorUsageSummary as any).mockResolvedValueOnce(configured);
+
+    const supported = await cursorProvider.fetch({
+      config: { cursorPlan: "pro", cursorBillingCycleStartDay: 1 },
+    } as any);
+    expect(supported.entries[0]).toMatchObject({
+      fixedWindow: {
+        kind: "fixed_window",
+        startedAtIso: "2026-02-01T00:00:00.000Z",
+        observedAtIso: "2026-02-15T12:00:00.000Z",
+        endsAtIso: resetTimeIso,
+        fullReset: true,
+      },
+    });
+
+    const inferred = usageSummary({ apiCost: 5, apiMessages: 2 });
+    inferred.window = {
+      source: "calendar_month",
+      sinceMs: Date.parse("2026-02-01T00:00:00.000Z"),
+      untilMs: Date.parse(resetTimeIso),
+      resetTimeIso,
+    };
+    inferred.observedAtMs = observedAtMs;
+    (getCurrentCursorUsageSummary as any).mockResolvedValueOnce(inferred);
+    const unsupported = await cursorProvider.fetch({ config: { cursorPlan: "pro" } } as any);
+    expect(unsupported.entries[0]).not.toHaveProperty("fixedWindow");
   });
 
   it("marks an explicit included-API override as user configured", async () => {

--- a/tests/quota-runway-surfaces.test.ts
+++ b/tests/quota-runway-surfaces.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { QuotaPercentEntry } from "../src/lib/entries.js";
+import { formatQuotaRows } from "../src/lib/format.js";
+import { formatQuotaCommand } from "../src/lib/quota-command-format.js";
+import type { QuotaRenderData } from "../src/lib/quota-render-data.js";
+import { buildCompactQuotaStatusLine } from "../src/lib/tui-compact-format.js";
+import {
+  buildSidebarQuotaPanelLines,
+  TUI_SIDEBAR_MAX_WIDTH,
+} from "../src/lib/tui-sidebar-format.js";
+
+const NOW_ISO = "2026-09-09T10:00:00.000Z";
+const RESET_ISO = "2026-09-09T12:00:00.000Z";
+
+function percentEntry(overrides: Partial<QuotaPercentEntry> = {}): QuotaPercentEntry {
+  return {
+    accounting: {
+      resultType: "quota",
+      acquisitionMethod: "remote_api",
+      ownership: "maintained",
+      authority: "provider_reported",
+      observedAtIso: NOW_ISO,
+    },
+    name: "OpenAI Five-hour",
+    group: "OpenAI Account With A Very Long Provider Label",
+    label: "Five-hour:",
+    percentRemaining: 50,
+    resetTimeIso: RESET_ISO,
+    runway: { kind: "before_reset", projectedAtIso: "2026-09-09T11:50:00.000Z" },
+    ...overrides,
+  };
+}
+
+function data(entries: QuotaPercentEntry[]): QuotaRenderData {
+  return { entries, errors: [] };
+}
+
+function renderToast(entries: QuotaPercentEntry[], percentDisplayMode: "remaining" | "used") {
+  return formatQuotaRows({
+    version: "test",
+    style: "allWindows",
+    layout: { maxWidth: 52, narrowAt: 42, tinyAt: 32 },
+    entries,
+    errors: [],
+    percentDisplayMode,
+  });
+}
+
+describe("quota runway production surfaces", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shows exact full-label typography and keeps reset separate on /quota and toast", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    const entries = [percentEntry()];
+
+    const command = formatQuotaCommand({
+      ...data(entries),
+      generatedAtMs: Date.parse(NOW_ISO),
+      percentDisplayMode: "remaining",
+    });
+    const toast = renderToast(entries, "remaining");
+
+    for (const output of [command, toast]) {
+      expect(output).toContain("Runs out");
+      expect(output).toContain("≈ 1h 50m");
+      expect(output).toContain("2h");
+      expect(output).not.toContain("≈1h");
+      expect(output).not.toContain("1h50m");
+    }
+    expect(command).toMatch(/reset 2h0m \| Runs out ≈ 1h 50m/u);
+  });
+
+  it("keeps the same runway in used and remaining modes", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    const entries = [percentEntry({ percentRemaining: 75 })];
+
+    const remaining = renderToast(entries, "remaining");
+    const used = renderToast(entries, "used");
+
+    expect(remaining).toContain("75% left");
+    expect(used).toContain("25% used");
+    expect(remaining).toContain("Runs out  ≈ 1h 50m");
+    expect(used).toContain("Runs out  ≈ 1h 50m");
+  });
+
+  it("keeps runway readable and bounded in the tiny toast layout", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+
+    const tiny = formatQuotaRows({
+      version: "test",
+      style: "allWindows",
+      layout: { maxWidth: 30, narrowAt: 42, tinyAt: 32 },
+      entries: [percentEntry({ name: "OpenAI Five-hour", group: "OpenAI" })],
+      errors: [],
+      percentDisplayMode: "remaining",
+    });
+
+    expect(tiny).toContain("Runs out");
+    expect(tiny).toContain("≈ 1h 50m");
+    for (const line of tiny.split("\n")) expect([...line].length).toBeLessThanOrEqual(30);
+  });
+
+  it("wraps long provider/account labels without exceeding the 36-column sidebar", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+
+    const lines = buildSidebarQuotaPanelLines({
+      data: data([percentEntry()]),
+      config: {
+        formatStyle: "allWindows",
+        percentDisplayMode: "remaining",
+        quotaProjection: "runway",
+      },
+    });
+
+    expect(lines.join("\n")).toContain("Runs out");
+    expect(lines.join("\n")).toContain("≈ 1h 50m");
+    expect(lines.length).toBeGreaterThan(3);
+    for (const line of lines) expect([...line].length).toBeLessThanOrEqual(TUI_SIDEBAR_MAX_WIDTH);
+  });
+
+  it("keeps the urgent window when a long provider identity exceeds compact widths", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    const longProvider = "OpenAI Enterprise Account With A Very Long Identity";
+    const entries = [
+      percentEntry({
+        name: "OpenAI Five-hour",
+        group: longProvider,
+        label: "5h:",
+        runway: { kind: "before_reset", projectedAtIso: "2026-09-09T11:50:00.000Z" },
+      }),
+      percentEntry({
+        name: "OpenAI Weekly",
+        group: longProvider,
+        label: "Weekly:",
+        percentRemaining: 20,
+        resetTimeIso: "2026-09-12T10:00:00.000Z",
+        runway: { kind: "before_reset", projectedAtIso: "2026-09-09T10:30:00.000Z" },
+      }),
+    ];
+
+    const wide = buildCompactQuotaStatusLine({
+      data: data(entries),
+      percentDisplayMode: "remaining",
+      maxWidth: 200,
+    });
+
+    expect(wide).toContain("5h");
+    expect(wide).toContain("7d");
+    expect(wide).toContain("r/o ≈ 1h 50m");
+    expect(wide).toContain("r/o ≈ 30m");
+
+    for (const maxWidth of [50, 40, 36]) {
+      const narrow = buildCompactQuotaStatusLine({
+        data: data(entries),
+        percentDisplayMode: "remaining",
+        maxWidth,
+      });
+
+      expect(narrow.length).toBeLessThanOrEqual(maxWidth);
+      expect(narrow).toContain("7d");
+      expect(narrow).toContain("20%");
+      expect(narrow).toContain("r/o ≈ 30m");
+      expect(narrow).not.toContain("50%");
+      expect(narrow).not.toContain("1h 50m");
+    }
+  });
+
+  it("orders already exhausted ahead of future runway and supports lasts-past-reset compact text", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    const exhausted = percentEntry({
+      name: "OpenAI Weekly",
+      group: "OpenAI",
+      label: "Weekly:",
+      runway: { kind: "before_reset", projectedAtIso: "2026-09-09T09:59:00.000Z" },
+    });
+    const future = percentEntry({
+      name: "OpenAI Five-hour",
+      group: "OpenAI",
+      label: "5h:",
+      runway: { kind: "before_reset", projectedAtIso: "2026-09-09T10:30:00.000Z" },
+    });
+    const pastReset = percentEntry({
+      name: "Qwen UTC day",
+      group: "Qwen",
+      label: "UTC day:",
+      runway: { kind: "lasts_past_reset" },
+    });
+
+    const narrow = buildCompactQuotaStatusLine({
+      data: data([future, exhausted]),
+      percentDisplayMode: "remaining",
+      maxWidth: 40,
+    });
+    const crossProvider = buildCompactQuotaStatusLine({
+      data: data([
+        future,
+        { ...exhausted, name: "Qwen UTC day", group: "Qwen", label: "UTC day:" },
+      ]),
+      percentDisplayMode: "remaining",
+      maxWidth: 40,
+    });
+    const lasts = buildCompactQuotaStatusLine({
+      data: data([pastReset]),
+      percentDisplayMode: "remaining",
+      maxWidth: 100,
+    });
+
+    expect(narrow).toContain("7d");
+    expect(narrow).toContain("r/o ≈ 0m");
+    expect(crossProvider.startsWith("Qwen")).toBe(true);
+    expect(crossProvider).toContain("r/o ≈ 0m");
+    expect(lasts).toContain("r/o lasts past reset");
+  });
+
+  it("matches independent default-off outputs when entries have no projection", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_ISO));
+    const entries = [percentEntry({ runway: undefined })];
+    const command = formatQuotaCommand({ ...data(entries), generatedAtMs: Date.parse(NOW_ISO) });
+
+    expect({
+      command: command.slice(command.indexOf("\n\n") + 2),
+      toast: renderToast(entries, "remaining"),
+      sidebar: buildSidebarQuotaPanelLines({
+        data: data(entries),
+        config: { formatStyle: "allWindows", percentDisplayMode: "remaining" },
+      }),
+      compact: buildCompactQuotaStatusLine({
+        data: data(entries),
+        percentDisplayMode: "remaining",
+        maxWidth: 100,
+      }),
+    }).toEqual({
+      command:
+        "→ [OpenAI Account With A Very Long Provider Label]\n  5h quota      █████░░░░░   50% left | reset 2h0m",
+      toast:
+        "[OpenAI Account With A Very Long Provider Label]\nFive-hour                                       2h0m\n█████████████████████░░░░░░░░░░░░░░░░░░░░   50% left",
+      sidebar: [
+        "[OpenAI Account With A Very Long Pro",
+        "Five-hour                       2h0m",
+        "█████████████░░░░░░░░░░░░   50% left",
+      ],
+      compact: "OpenAI Account With A Very Long Provider Label 50% 2h0m",
+    });
+  });
+});

--- a/tests/quota-state.test.ts
+++ b/tests/quota-state.test.ts
@@ -1098,7 +1098,7 @@ describe("quota-state shared cache", () => {
     const key = quotaState.buildQuotaProviderStateCacheKey(provider.id, ctx);
     const path = quotaState.getQuotaProviderStateCacheFilePath(provider.id, key);
     const persisted = JSON.parse(await (await import("fs/promises")).readFile(path, "utf8"));
-    expect(persisted.version).toBe(2);
+    expect(persisted.version).toBe(3);
     expect(persisted.timestamp).toBe(1_000);
     expect(JSON.stringify(persisted)).not.toContain("telemetry");
 
@@ -1243,7 +1243,7 @@ describe("quota-state shared cache", () => {
     telemetry.__resetQuotaTelemetryForTests();
   });
 
-  it("reuses cache v2 with accounting metadata across module resets", async () => {
+  it("reuses cache v3 with accounting metadata across module resets", async () => {
     const quotaStateA = await import("../src/lib/quota-state.js");
     quotaStateA.__resetQuotaStateForTests();
 
@@ -1445,7 +1445,7 @@ describe("quota-state shared cache", () => {
     const path = quotaStateA.getQuotaProviderStateCacheFilePath(provider.id, key);
 
     await quotaStateA.fetchQuotaProviderResult({ provider, ctx, ttlMs: 60_000 });
-    await writeFile(path, JSON.stringify({ version: 2, key }), "utf-8");
+    await writeFile(path, JSON.stringify({ version: 3, key }), "utf-8");
 
     vi.resetModules();
     const quotaStateB = await import("../src/lib/quota-state.js");
@@ -1550,7 +1550,7 @@ describe("quota-state shared cache", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion: "0.0.0-stale-cache",
         key,
         providerId: provider.id,
@@ -1782,7 +1782,7 @@ describe("quota-state shared cache", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion,
         key,
         providerId: provider.id,
@@ -1851,7 +1851,7 @@ describe("quota-state shared cache", () => {
     expect(provider.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects the whole cache v2 result when one entry is malformed", async () => {
+  it("rejects the whole cache v3 result when one entry is malformed", async () => {
     const quotaStateA = await import("../src/lib/quota-state.js");
     quotaStateA.__resetQuotaStateForTests();
 
@@ -1875,7 +1875,7 @@ describe("quota-state shared cache", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion,
         key,
         providerId: provider.id,
@@ -1899,7 +1899,7 @@ describe("quota-state shared cache", () => {
     expect(provider.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects and replaces a cache v2 row containing barValue", async () => {
+  it("rejects and replaces a cache v3 row containing barValue", async () => {
     const quotaState = await import("../src/lib/quota-state.js");
     quotaState.__resetQuotaStateForTests();
     const provider = {
@@ -1922,7 +1922,7 @@ describe("quota-state shared cache", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion,
         key,
         providerId: provider.id,
@@ -1947,7 +1947,7 @@ describe("quota-state shared cache", () => {
     expect(result.entries[0]?.name).toBe("Fresh");
     expect(provider.fetch).toHaveBeenCalledTimes(1);
     const replacement = JSON.parse(await (await import("fs/promises")).readFile(path, "utf8"));
-    expect(replacement.version).toBe(2);
+    expect(replacement.version).toBe(3);
     expect(JSON.stringify(replacement)).not.toContain("barValue");
   });
 
@@ -2158,7 +2158,7 @@ describe("quota-state shared cache", () => {
     });
   });
 
-  it("rejects cache v2 timestamps that are parseable but not ISO", async () => {
+  it("rejects cache v3 timestamps that are parseable but not ISO", async () => {
     const quotaState = await import("../src/lib/quota-state.js");
     quotaState.__resetQuotaStateForTests();
     const provider = {
@@ -2181,7 +2181,7 @@ describe("quota-state shared cache", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion,
         key,
         providerId: provider.id,
@@ -2305,7 +2305,7 @@ describe("readCachedProviderResult", () => {
     await writeFile(
       path,
       JSON.stringify({
-        version: 2,
+        version: 3,
         packageVersion,
         key: createHash("sha256").update(key).digest("hex"),
         providerId: provider.id,

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -1834,7 +1834,7 @@ describe("tui plugin smoke", () => {
     expect(JSON.stringify(hint)).not.toMatch(/[█░▓▒]/u);
   });
 
-  it("renders exact-minute reset text in the prompt bar", async () => {
+  it("renders exact reset and runway text with the 12-cell prompt bar", async () => {
     vi.setSystemTime(new Date("2026-01-15T10:00:00.000Z"));
     const plugin = await loadTuiModule();
     const { api, registered } = createApi();
@@ -1862,6 +1862,10 @@ describe("tui plugin smoke", () => {
           name: "OpenAI Weekly",
           percentRemaining: 50,
           resetTimeIso: "2026-01-17T15:14:00.000Z",
+          runway: {
+            kind: "before_reset",
+            projectedAtIso: "2026-01-15T11:50:00.000Z",
+          },
         },
         percentDisplayMode: "remaining",
       },
@@ -1874,7 +1878,8 @@ describe("tui plugin smoke", () => {
     const rendered = registration.slots.session_prompt({}, { session_id: "session-reset" }) as any;
     const hint = rendered.props.children[1];
 
-    expect(hint.props.children[2].props.children).toBe("50% | 2d5h14m");
+    expect(hint.props.children[1].props.children).toHaveLength(12);
+    expect(hint.props.children[2].props.children).toBe("50% | 2d5h14m | r/o ≈ 1h 50m");
   });
 
   it("keeps the prompt percentage bare while spacing reset units", async () => {


### PR DESCRIPTION
## Summary

Adds the default-off `quotaProjection: "runway"` setting for eligible fixed quota windows.

When enabled, human-readable quota displays estimate when remaining quota will run out using average consumption since a provider-confirmed fixed window began. Estimates appear as `Runs out ≈ 1h 50m` in full displays and `r/o ≈ 1h 50m` in compact displays. The provider's exact reset countdown remains separate.

Compact output keeps the most urgent eligible window under width pressure. Long provider or account identities yield space before the urgent window label, percentage, and runway.

## Supported evidence

Projection evidence is emitted only where the implementation proves the fixed start, observation time, fixed end/reset, and full-reset behavior:

- OpenAI explicit fixed 5-hour, weekly, and monthly API windows
- xAI explicit current-period start and end
- Cursor complete API budget with a configured billing-cycle start
- Qwen Code fixed UTC-day request quota
- Configured local UTC-day request and priced-budget percentages

## Exclusions and compatibility

Rolling or irregular windows, label-only guesses, incomplete timing data, balances, status rows, unlimited rows, and unsupported spend-only rows omit the estimate without warning. This excludes OpenAI spend controls and code-review rows without fixed-window evidence, xAI end-only fallback data, Cursor calendar fallback or partial budget data, Qwen RPM, and other rolling windows.

The public JSON export remains version 2 and unchanged. Fixed-window evidence and rendered runway data stay internal. With the setting disabled, existing output remains unchanged.

Documentation was added to the README configuration and provider guides.

## Linked Issue

Closes #252

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.11
- Why this version is relevant to the fix: it is the repository's pinned OpenCode plugin version used by the automated plugin and TUI validation.

## Validation

- Independent final review passed exact head `08dd8eadb0d29c48174e3971af2df51277e0ba0e`
- Focused Phase 3 matrix: 596 passed, 1 skipped
- Exact-head compact regression slice: 30 passed
- Full suite: 2,307 passed, 1 skipped
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm verify`
- `pnpm run release:check`
- Release-package verification: 656 files
- Same packed artifact passed Node 22.23.2 and Node 24.12.0 smoke tests
- Credential-free command, toast, 36-column Sidebar, and compact display bundle
- `git diff --check`

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [x] I updated docs when user-facing workflow, command, or config behavior changed
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply
