### PR TITLE
fix: settle session lifecycle after inline slash command output

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -64,6 +64,7 @@ interface OpencodeClient {
         parts: Array<{ type: "text"; text: string; ignored?: boolean }>;
       };
     }) => Promise<unknown>;
+    abort: (params: { path: { id: string } }) => Promise<unknown>;
   };
   tui: {
     showToast: (params: {
@@ -228,6 +229,12 @@ export const QuotaToastPlugin: Plugin = async ({ client, directory }) => {
 
     if (result.state === "output") {
       await injectRawOutput(input.sessionID, result.output, { rethrow: true });
+      // Settle the session so lifecycle watchers recover from chat.message.
+      try {
+        await typedClient.session.abort({ path: { id: input.sessionID } });
+      } catch {
+        // Best-effort settle; the injected output is already visible.
+      }
     }
 
     handled();

--- a/src/tui.tsx
+++ b/src/tui.tsx
@@ -860,6 +860,12 @@ async function runQuotaDialogCommandAsync(
         noReply: true,
         parts: [{ type: "text", text: result.output, ignored: true }],
       });
+      // Settle the session so lifecycle watchers recover from chat.message.
+      try {
+        await api.client.session.abort?.({ sessionID: destination.sessionID });
+      } catch {
+        // Best-effort settle; the injected output is already visible.
+      }
       return;
     }
 

--- a/src/types/tui-runtime-shims.d.ts
+++ b/src/types/tui-runtime-shims.d.ts
@@ -178,6 +178,7 @@ declare module "@opencode-ai/plugin/tui" {
       };
       session: {
         prompt: OpencodeClient["session"]["prompt"];
+        abort?: (params: { sessionID: string }) => Promise<unknown>;
         get?: (params: { path: { id: string } }) => Promise<{
           data?: {
             model?: {

--- a/tests/helpers/plugin-test-harness.ts
+++ b/tests/helpers/plugin-test-harness.ts
@@ -342,6 +342,7 @@ export function createPluginTestClient({
     session: {
       get: vi.fn().mockResolvedValue({ data }),
       prompt: vi.fn().mockResolvedValue({}),
+      abort: vi.fn().mockResolvedValue({}),
     },
     tui: {
       showToast: vi.fn().mockResolvedValue({}),

--- a/tests/plugin.command-handled-boundary.test.ts
+++ b/tests/plugin.command-handled-boundary.test.ts
@@ -270,6 +270,7 @@ describe("plugin command handled boundary", () => {
     );
     expect(getPromptText(client)).toContain("Quota unavailable");
     expect(getPromptText(client)).toContain("No provider data available");
+    expect(client.session.abort).toHaveBeenCalledWith({ path: { id: "session-2" } });
   });
 
   it("injects clean plain text with noReply/ignored when /quota has no current model", async () => {
@@ -373,6 +374,7 @@ describe("plugin command handled boundary", () => {
     ).rejects.toBe(injectionError);
 
     expect(isCommandHandledError(injectionError)).toBe(false);
+    expect(client.session.abort).not.toHaveBeenCalled();
     expect(client.app.log).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.objectContaining({

--- a/tests/tui-smoke.test.ts
+++ b/tests/tui-smoke.test.ts
@@ -208,6 +208,7 @@ function createApi() {
       session: {
         prompt: vi.fn(),
         command: vi.fn(),
+        abort: vi.fn().mockResolvedValue(undefined),
       },
     },
   };
@@ -340,6 +341,7 @@ describe("tui plugin smoke", () => {
 
     expect(buildQuotaDialogCommandOutput).toHaveBeenCalledOnce();
     expect(api.client.session.prompt).toHaveBeenCalledOnce();
+    expect(api.client.session.abort).toHaveBeenCalledWith({ sessionID: "session-route" });
     expect(registered[1]!.slots.session_prompt({}, { session_id: "session-1" })).not.toBeNull();
     expect(registered[1]!.slots.home_bottom({}, {})).not.toBeNull();
     expect(loadTuiSessionQuotaSurfaces).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

Inline slash-command output is injected with `session.prompt({ noReply: true })`, which fires `chat.message`, but no end-of-turn event follows, so lifecycle-aware clients (e.g. Herdr) stay stuck on "working" until the next real prompt.

Fix: settle the session with a best-effort `session.abort` right after the injection.

- `src/plugin.ts`: server `handleDeterministicSlashCommand` aborts after a successful injection (v1 shape `{ path: { id } }`). The tool-execute path is unchanged; its LLM turn publishes `session.idle` normally.
- `src/tui.tsx`: inline branch aborts after the injection (flat shape `{ sessionID }`, optional call).
- Abort failures are swallowed: the output is already visible and a settle failure must not turn a successful command into an error.

## Linked Issue

- Fixes #272 

## OpenCode Validation

- Current production released OpenCode version tested: 1.18.30
- Why this version is relevant to the fix: stuck "working" stream and the `session.abort` settle behavior were both reproduced on 1.18.30; `session.abort` presence and shape were probed in-process with a diagnostic plugin.

## Quality Checklist

- [x] I ran `pnpm run typecheck`
- [x] I ran `pnpm run build`
- [x] I ran `pnpm test`
- [x] This change is focused and avoids unrelated behavior changes
- [x] I updated or added tests when behavior changed
- [ ] I updated docs when user-facing workflow, command, or config behavior changed
- [x] For provider changes, I followed [Provider Changes](https://github.com/slkiser/opencode-quota/blob/main/CONTRIBUTING.md#provider-changes), or this does not apply

## Test details

- `tests/helpers/plugin-test-harness.ts`: mock client gains `session.abort`.
- `tests/plugin.command-handled-boundary.test.ts`: server `/quota` aborts after successful injection; no abort when injection fails.
- `tests/tui-smoke.test.ts`: inline branch aborts with the active route's session id.